### PR TITLE
Release 2.4.0 — multi-user, corpus intelligence, agent tools & citation graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
         run: ruff check .
       - name: Unit tests (no network / no live server)
         # Heavy model downloads and API keys aren't available in CI, so restrict
-        # to the unit markers. The eval-harness gate (roadmap 1.2) is added once
-        # the real eval set exists.
+        # to the unit markers.
         run: pytest -q -m "not integration and not network"
+      - name: Eval gate
+        # --grounding-judge jaccard (the default) is CI-safe: it scores the
+        # already-committed answers_and_citations.json, no LLM/API key needed.
+        # Threshold set below the current measured overall (0.94) so it fails
+        # on a real regression without being toothless.
+        working-directory: docs/Eval
+        run: python evaluate.py --ci --threshold 0.85

--- a/.gitignore
+++ b/.gitignore
@@ -88,5 +88,6 @@ graphify-out/
 # Local test scratch output
 test_output.txt
 
-# Generated eval artifact — timestamped, noisy diffs; regenerate via docs/Eval/evaluate.py
+# Generated eval artifacts — timestamped, noisy diffs; regenerate via docs/Eval/evaluate.py
 docs/Eval/eval_report.json
+docs/Eval/eval_history/

--- a/agent/nodes/answer_generator.py
+++ b/agent/nodes/answer_generator.py
@@ -46,6 +46,14 @@ def answer_generator_node(state: AgentState) -> dict:
             if cons:
                 prompt += contradiction.contradiction_instruction(cons)
                 logger.info(f"[AnswerGenerator] {len(cons)} contradiction(s) flagged")
+                # Persist to the knowledge graph (Task 3.3). Best-effort.
+                try:
+                    import persistence
+                    persistence.save_graph_edges([
+                        (c["a_title"], c["b_title"], "contradiction", c["score"],
+                         {"context": "auto-detected"}) for c in cons])
+                except Exception as e:
+                    logger.warning(f"[Graph] contradiction persist failed: {e}")
         except Exception as e:
             logger.warning(f"[AnswerGenerator] contradiction check failed: {e}")
 

--- a/agent/nodes/tool_executor_node.py
+++ b/agent/nodes/tool_executor_node.py
@@ -114,6 +114,14 @@ def tool_executor_node(state: AgentState) -> dict:
         )
         tool_calls = tool_calls[:_MAX_PARALLEL_TOOLS]
 
+    # Stamp the run's owner onto state-changing tools so an agent-created watch
+    # belongs to the requesting user, not a generic "agent" label.
+    owner = state.get("user_id")
+    if owner:
+        for call in tool_calls:
+            if call.get("name") == "create_watch":
+                call.setdefault("args", {}).setdefault("user_id", owner)
+
     if len(tool_calls) <= 1:
         for call in tool_calls:
             name, args, result, latency_ms = _run_tool(call["name"], call.get("args", {}))

--- a/agent/nodes/tool_selector.py
+++ b/agent/nodes/tool_selector.py
@@ -49,6 +49,12 @@ Use for citation counts, peer-reviewed papers, or wide literature surveys.
 non-academic queries. Do NOT use for scientific literature.
   "calculate"  Evaluate a mathematical expression.
   "execute_python"  Run sandboxed Python for data manipulation.
+  "create_watch"  Schedule a recurring topic watch. Supports: topic (str), \
+cadence ("daily"|"weekly"|"monthly"), language (str). \
+Use when the user says "keep me updated on X", "monitor Y", "watch for new papers about Z".
+  "generate_report"  Build a cited literature-review report from the corpus. \
+Supports: topic (str), language (str). \
+Use when the user asks for a "review", "report", "survey", or "literature summary".
 
 ROUTING RULES — apply in order, stop at first match:
 0. USER OVERRIDE: If the user's message explicitly names tools \

--- a/agent/state.py
+++ b/agent/state.py
@@ -28,6 +28,7 @@ class AgentState(TypedDict):
     conversation_history: List[dict]
 
     session_id: str
+    user_id: str  # owner of this run; agent-created watches are stamped with it
     strategy: Literal["A", "B"]
 
     # monotonic() timestamp stamped at run start, used by the reflexion loop to

--- a/agent/tool_declarations.py
+++ b/agent/tool_declarations.py
@@ -36,6 +36,13 @@ FUNCTION_DECLARATIONS = [
                         "earlier. Optional."
                     ),
                 },
+                "tags": {
+                    "type": "string",
+                    "description": (
+                        "Comma-separated tags to filter retrieval (e.g. 'transformer,efficiency'). "
+                        "Only return passages from papers tagged with at least one of these tags. Optional."
+                    ),
+                },
             },
             "required": ["query"],
         },

--- a/agent/tool_declarations.py
+++ b/agent/tool_declarations.py
@@ -162,6 +162,54 @@ FUNCTION_DECLARATIONS = [
             "required": ["query"],
         },
     ),
+    types.FunctionDeclaration(
+        name="create_watch",
+        description=(
+            "Create a scheduled topic watch that periodically searches for new papers "
+            "on a topic, ingests them, and builds a digest. Use when the user says "
+            "'keep me updated on X', 'monitor Y', or 'watch for new papers about Z'."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "Topic to watch (e.g. 'transformer antenna optimization').",
+                },
+                "cadence": {
+                    "type": "string",
+                    "description": "How often to check: 'daily', 'weekly', or 'monthly'. Default 'weekly'.",
+                },
+                "language": {
+                    "type": "string",
+                    "description": "Language for the digest (default 'en').",
+                },
+            },
+            "required": ["topic"],
+        },
+    ),
+    types.FunctionDeclaration(
+        name="generate_report",
+        description=(
+            "Generate a structured literature-review report on a topic from the indexed "
+            "corpus. Use when the user asks for a 'review', 'report', 'survey', or "
+            "'summary of the literature'."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "Topic for the literature review.",
+                },
+                "language": {
+                    "type": "string",
+                    "description": "Language for the report (default 'en').",
+                },
+            },
+            "required": ["topic"],
+        },
+    ),
 ]
 
 TOOLS = types.Tool(function_declarations=FUNCTION_DECLARATIONS)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -593,6 +593,49 @@ def execute_open_access_search(
                           "title": "No results", "section": "none"}]}
 
 
+_WATCH_CADENCES = {"daily": 1, "weekly": 7, "monthly": 30}  # days until first auto-run
+
+
+def execute_create_watch(topic: str, cadence: str = "weekly", language: str = "en") -> dict:
+    """Create a scheduled topic watch. Returns watch_id + confirmation."""
+    import uuid
+    from datetime import datetime, timezone, timedelta
+    import persistence
+
+    if cadence not in _WATCH_CADENCES:
+        cadence = "weekly"
+    now = datetime.now(timezone.utc)
+    watch_id = str(uuid.uuid4())
+    watch = {
+        "id": watch_id, "user_id": "agent", "topic": topic, "language": language,
+        "cadence": cadence, "seen_ids": [], "latest_digest": None,
+        "next_run": (now + timedelta(days=_WATCH_CADENCES[cadence])).isoformat(),
+        "last_run": None, "created_at": now.isoformat(),
+    }
+    persistence.save_watch(watch)
+    logger.info(f"[Agent] created watch {watch_id} topic={topic!r} cadence={cadence}")
+    return {
+        "watch_id": watch_id, "status": "created", "topic": topic, "cadence": cadence,
+        "message": f"Watch created for '{topic}'. It will run {cadence} and collect new papers.",
+    }
+
+
+def execute_generate_report(topic: str, language: str = "en") -> dict:
+    """Generate a literature-review report from the corpus. Returns markdown."""
+    try:
+        from report_runner import run_report
+        result = run_report(topic, language)
+        return {
+            "status": "completed", "topic": topic,
+            "markdown": result["markdown"],
+            "citation_count": result["citation_count"],
+            "section_count": len(result.get("sections", [])),
+        }
+    except Exception as e:
+        logger.error(f"[Agent] generate_report failed for {topic!r}: {e}")
+        return {"status": "error", "message": str(e)}
+
+
 TOOL_DISPATCH = {
     "indicrag_retrieval": lambda args: execute_indicrag(
         args["query"], args.get("expand_query", False),
@@ -612,5 +655,13 @@ TOOL_DISPATCH = {
     "open_access_search": lambda args: execute_open_access_search(
         args["query"], args.get("max_results", 5),
         args.get("year_range", ""), args.get("open_access_only", True)
+    ),
+    "create_watch": lambda args: (
+        execute_create_watch(args["topic"], args.get("cadence", "weekly"), args.get("language", "en"))
+        if config.WATCH_ENABLE else {"status": "disabled", "message": "Watches are not enabled."}
+    ),
+    "generate_report": lambda args: (
+        execute_generate_report(args["topic"], args.get("language", "en"))
+        if config.REPORT_ENABLE else {"status": "disabled", "message": "Reports are not enabled."}
     ),
 }

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -93,12 +93,37 @@ def _year_filter(year_from=None, year_to=None):
     return clauses[0] if len(clauses) == 1 else {"$and": clauses}
 
 
+def _tags_filter(tags):
+    """Parse comma-separated tags into a rag.retrieve_context post-filter sentinel, or None.
+
+    Not a ChromaDB where-clause: PATCH /papers stores tags as one unsplit
+    string, so a native $in match against split tag names would never equal
+    the stored value for any paper with more than one tag. rag.retrieve_context
+    (via rag._extract_tags_post_filter) pulls this sentinel back out and
+    applies it as a Python-side post-filter instead.
+    """
+    if not tags:
+        return None
+    tag_list = [t.strip() for t in tags.split(",") if t.strip()]
+    if not tag_list:
+        return None
+    import rag
+    return {rag._TAGS_SENTINEL: tag_list}
+
+
+def _combine_filters(*filters):
+    clauses = [f for f in filters if f]
+    if not clauses:
+        return None
+    return clauses[0] if len(clauses) == 1 else {"$and": clauses}
+
+
 def execute_indicrag(query: str, expand_query: bool = False,
-                     year_from=None, year_to=None) -> dict:
+                     year_from=None, year_to=None, tags=None) -> dict:
     import hashlib
     _MIN_EXPAND_WORDS = 4
     should_expand = expand_query and len(query.split()) >= _MIN_EXPAND_WORDS
-    filter_dict = _year_filter(year_from, year_to)
+    filter_dict = _combine_filters(_year_filter(year_from, year_to), _tags_filter(tags))
 
     if should_expand:
         variants = _expand_query_variants(query)
@@ -571,7 +596,7 @@ def execute_open_access_search(
 TOOL_DISPATCH = {
     "indicrag_retrieval": lambda args: execute_indicrag(
         args["query"], args.get("expand_query", False),
-        args.get("year_from"), args.get("year_to")
+        args.get("year_from"), args.get("year_to"), args.get("tags")
     ),
     "web_search": lambda args: execute_web_search(
         args["query"], args.get("num_results", 5)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -596,7 +596,8 @@ def execute_open_access_search(
 _WATCH_CADENCES = {"daily": 1, "weekly": 7, "monthly": 30}  # days until first auto-run
 
 
-def execute_create_watch(topic: str, cadence: str = "weekly", language: str = "en") -> dict:
+def execute_create_watch(topic: str, cadence: str = "weekly", language: str = "en",
+                         user_id: str = "agent") -> dict:
     """Create a scheduled topic watch. Returns watch_id + confirmation."""
     import uuid
     from datetime import datetime, timezone, timedelta
@@ -607,7 +608,7 @@ def execute_create_watch(topic: str, cadence: str = "weekly", language: str = "e
     now = datetime.now(timezone.utc)
     watch_id = str(uuid.uuid4())
     watch = {
-        "id": watch_id, "user_id": "agent", "topic": topic, "language": language,
+        "id": watch_id, "user_id": user_id, "topic": topic, "language": language,
         "cadence": cadence, "seen_ids": [], "latest_digest": None,
         "next_run": (now + timedelta(days=_WATCH_CADENCES[cadence])).isoformat(),
         "last_run": None, "created_at": now.isoformat(),
@@ -657,7 +658,8 @@ TOOL_DISPATCH = {
         args.get("year_range", ""), args.get("open_access_only", True)
     ),
     "create_watch": lambda args: (
-        execute_create_watch(args["topic"], args.get("cadence", "weekly"), args.get("language", "en"))
+        execute_create_watch(args["topic"], args.get("cadence", "weekly"),
+                             args.get("language", "en"), args.get("user_id", "agent"))
         if config.WATCH_ENABLE else {"status": "disabled", "message": "Watches are not enabled."}
     ),
     "generate_report": lambda args: (

--- a/api_server.py
+++ b/api_server.py
@@ -22,7 +22,7 @@ from deps import (
     limiter,
     verify_api_key,
 )
-from routes import query, chat, ingest, agent, management, feedback, watch, report, models as models_route
+from routes import query, chat, ingest, agent, management, feedback, watch, report, auth, models as models_route
 from middleware import RequestIdFilter, RequestIdMiddleware
 
 # Configure logging
@@ -157,6 +157,7 @@ app.include_router(management.router)
 app.include_router(feedback.router)
 app.include_router(watch.router)
 app.include_router(report.router)
+app.include_router(auth.router)
 app.include_router(models_route.router)
 
 

--- a/auth_utils.py
+++ b/auth_utils.py
@@ -1,0 +1,45 @@
+"""Password hashing for multi-user login — stdlib only (pbkdf2), no new deps.
+
+Format stored per user: a random salt + the pbkdf2-HMAC-SHA256 derivation of the
+password. Verification is constant-time. Iteration count lives in config so it
+can be raised later without a code change.
+"""
+
+import hashlib
+import hmac
+import secrets
+
+import config
+
+
+def hash_password(password: str, salt: str = None, iterations: int = None) -> tuple[str, str]:
+    """Return (salt_hex, hash_hex). Generates a fresh salt unless one is given."""
+    if iterations is None:
+        iterations = config.PBKDF2_ITERATIONS
+    salt = salt or secrets.token_hex(16)
+    dk = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"),
+                             bytes.fromhex(salt), iterations)
+    return salt, dk.hex()
+
+
+def verify_password(password: str, salt: str, expected_hash: str,
+                    iterations: int = None) -> bool:
+    """Constant-time check of a password against a stored (salt, hash)."""
+    if not salt or not expected_hash:
+        return False
+    _, actual = hash_password(password, salt, iterations)
+    return hmac.compare_digest(actual, expected_hash)
+
+
+def new_api_key() -> str:
+    """A fresh per-user bearer key for the X-API-Key header."""
+    return secrets.token_urlsafe(24)
+
+
+if __name__ == "__main__":
+    s, h = hash_password("hunter2")
+    assert verify_password("hunter2", s, h)
+    assert not verify_password("wrong", s, h)
+    assert not verify_password("hunter2", s, h[:-1] + ("0" if h[-1] != "0" else "1"))
+    assert len(new_api_key()) >= 24 and new_api_key() != new_api_key()
+    print("auth_utils self-check ok")

--- a/cache_refresh.py
+++ b/cache_refresh.py
@@ -1,0 +1,24 @@
+"""Shared post-ingest cache/index invalidation, used by both the ingest routes
+and the watch runner so newly indexed papers are searchable everywhere.
+"""
+
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+
+
+def _post_ingest_refresh():
+    """Rebuild BM25 index (async) and invalidate retrieval/tool caches after an ingest."""
+    try:
+        import bm25_search
+        bm25_search.invalidate()
+        threading.Thread(target=bm25_search.get_or_build_index, daemon=True).start()
+    except Exception:
+        pass
+    try:
+        from cache import retrieval_cache, tool_cache
+        retrieval_cache.invalidate()
+        tool_cache.invalidate()
+    except Exception:
+        logger.warning("Failed to invalidate caches after ingestion", exc_info=True)

--- a/config.py
+++ b/config.py
@@ -143,6 +143,13 @@ DEDUP_TITLE_THRESHOLD = float(os.getenv("DEDUP_TITLE_THRESHOLD", "0.9"))
 # exists elsewhere in this app to link it to yet).
 ENABLE_USER_PREFS = os.getenv("ENABLE_USER_PREFS", "false").lower() == "true"
 
+# Multi-user support. Users are pre-provisioned (manage_users.py); login by
+# name+password returns the user's api_key, then used as X-API-Key. When no
+# users are seeded and API_KEYS is unset, auth is off and everyone is
+# DEFAULT_USER_ID (single-user back-compat; legacy NULL-owner rows belong here).
+DEFAULT_USER_ID = os.getenv("DEFAULT_USER_ID", "default")
+PBKDF2_ITERATIONS = int(os.getenv("PBKDF2_ITERATIONS", "200000"))
+
 # Phase 6 — "watch a topic" scheduled ingest + digests. When on, users can
 # register topic watches (POST /watch); each run does external search (arXiv /
 # open-access), dedups against the corpus, ingests genuinely new papers, and

--- a/deps.py
+++ b/deps.py
@@ -47,15 +47,41 @@ limiter = Limiter(key_func=_rate_limit_key)
 # ---------------------------------------------------------------------------
 API_KEY_HEADER = APIKeyHeader(name="X-API-Key", auto_error=False)
 
-raw_keys = os.getenv("API_KEYS")
-if raw_keys:
-    VALID_API_KEYS = {k.strip() for k in raw_keys.split(",") if k.strip()}
-    if not VALID_API_KEYS:
-        VALID_API_KEYS = None
-else:
-    VALID_API_KEYS = None
+def _build_key_to_user():
+    """Map every valid X-API-Key -> user_id, from seeded users + env API_KEYS.
+
+    Users (manage_users.py) supply {api_key: username}. Env API_KEYS entries are
+    bare keys that map to themselves (back-compat with the pre-multi-user setup).
+    Returns None when nothing is configured -> auth disabled (single-user mode).
+    """
+    mapping = {}
+    try:
+        import persistence
+        for api_key, username in persistence.all_key_user_pairs():
+            if api_key:
+                mapping[api_key] = username
+    except Exception:  # persistence not ready (e.g. during early import) — env only
+        pass
+    raw = os.getenv("API_KEYS")
+    if raw:
+        for k in (s.strip() for s in raw.split(",")):
+            if k:
+                mapping.setdefault(k, k)  # bare key: user_id == key
+    return mapping or None
+
+
+KEY_TO_USER = _build_key_to_user()
+# Keys-only set kept for the unchanged bool gate verify_api_key / _key_matches.
+VALID_API_KEYS = set(KEY_TO_USER) if KEY_TO_USER else None
 
 _admin_key = os.getenv("ADMIN_API_KEY")
+
+
+def _refresh_key_map():
+    """Rebuild the key map so a freshly-seeded user works without a restart."""
+    global KEY_TO_USER, VALID_API_KEYS
+    KEY_TO_USER = _build_key_to_user()
+    VALID_API_KEYS = set(KEY_TO_USER) if KEY_TO_USER else None
 
 
 def _key_matches(candidate: Optional[str], valid) -> bool:
@@ -102,6 +128,37 @@ async def verify_admin_key(api_key: str = Security(API_KEY_HEADER)):
             )
         return True
     return await verify_api_key(api_key)
+
+
+async def get_current_user(api_key: str = Security(API_KEY_HEADER)) -> str:
+    """Resolve the caller to a user_id for per-user data ownership.
+
+    Auth disabled (no users seeded and no env API_KEYS) -> everyone is
+    config.DEFAULT_USER_ID (single-user back-compat). Otherwise the presented
+    key must match a known key (401 on miss); returns its owner username.
+    """
+    if KEY_TO_USER is None:
+        return config.DEFAULT_USER_ID
+    user = _lookup_user(api_key)
+    if user is None:  # a user seeded after startup won't be in the cached map yet
+        _refresh_key_map()
+        user = _lookup_user(api_key)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"error": "Invalid or missing API key", "code": "INVALID_API_KEY"},
+        )
+    return user
+
+
+def _lookup_user(api_key: Optional[str]) -> Optional[str]:
+    """Constant-time match of the presented key against the map; owner or None."""
+    if not api_key or not KEY_TO_USER:
+        return None
+    for k, user in KEY_TO_USER.items():
+        if hmac.compare_digest(api_key.encode("utf-8"), k.encode("utf-8")):
+            return user
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -153,8 +210,15 @@ def _evict_stale_sessions():
         persistence.delete_session(sid)
 
 
-def _get_or_create_session(session_id: Optional[str]) -> tuple[str, list]:
-    """Return (session_id, messages_list). Creates a new session when id is None."""
+def _get_or_create_session(session_id: Optional[str], user_id: str = None) -> tuple[str, list]:
+    """Return (session_id, messages_list). Creates a new session when id is None.
+
+    New sessions are stamped with `user_id` (the owner) so chat-history listing
+    and reads can be scoped per user. Reopening an existing session does not
+    re-stamp — ownership is set once, at creation.
+    """
+    if user_id is None:
+        user_id = config.DEFAULT_USER_ID
     with _sessions_lock:
         _evict_stale_sessions()
         if session_id and session_id in _sessions:
@@ -163,12 +227,18 @@ def _get_or_create_session(session_id: Optional[str]) -> tuple[str, list]:
         now = datetime.now(timezone.utc).isoformat()
         _sessions[new_id] = {
             "id": new_id,
+            "user_id": user_id,
             "messages": [],
             "created_at": now,
             "updated_at": now,
         }
         persistence.save_session(new_id, _sessions[new_id])
         return new_id, list(_sessions[new_id]["messages"])
+
+
+def _session_owner(session: dict) -> str:
+    """Owner of a session; legacy sessions with no owner belong to DEFAULT_USER_ID."""
+    return session.get("user_id") or config.DEFAULT_USER_ID
 
 
 def _append_session_messages(session_id: str, user_text: str, assistant_text: str) -> None:

--- a/docs/Eval/evaluate.py
+++ b/docs/Eval/evaluate.py
@@ -43,6 +43,18 @@ STOPWORDS = {
 GROUNDING_THRESHOLD = 0.15
 
 
+def write_history_snapshot(metrics: dict, history_dir: str = None) -> Path:
+    """Write a timestamped copy of the eval report, so quality trends over
+    time are visible instead of each run overwriting the last report."""
+    hist_dir = Path(history_dir) if history_dir else Path(__file__).parent / "eval_history"
+    hist_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    path = hist_dir / f"{ts}_eval_report.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(metrics, f, indent=2, ensure_ascii=False)
+    return path
+
+
 def tokenize(text: str) -> Set[str]:
     return set(re.findall(r"\b[a-z]{2,}\b", text.lower())) - STOPWORDS
 
@@ -455,6 +467,8 @@ def main():
         with open(args.json, "w", encoding="utf-8") as f:
             json.dump(metrics, f, indent=2, ensure_ascii=False)
         print(f"  JSON metrics    -> {args.json}")
+        hist_path = write_history_snapshot(metrics)
+        print(f"  History snapshot -> {hist_path}")
 
     # Per-query regression gate — fail if any query drops vs committed baseline.
     if args.baseline:

--- a/docs/Eval/test_evaluate.py
+++ b/docs/Eval/test_evaluate.py
@@ -7,6 +7,7 @@ and the per-query regression gate.
 from evaluate import (
     ndcg_at_k, recall_at_k, precision_at_k,
     citation_grounding, evaluate, jaccard, make_grounding_scorer,
+    write_history_snapshot,
 )
 
 
@@ -85,6 +86,16 @@ def test_per_query_overall_present():
     res = {"results": [{"query_id": "1", "retrieved_papers": ["a"], "answer_claims": []}]}
     m = evaluate(j, res, 5)
     assert "overall" in m["per_query"][0]
+
+
+def test_write_history_snapshot_creates_timestamped_file():
+    import json as _json
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        path = write_history_snapshot({"overall": 0.9}, history_dir=d)
+        assert path.exists()
+        assert path.name.endswith("_eval_report.json")
+        assert _json.loads(path.read_text())["overall"] == 0.9
 
 
 if __name__ == "__main__":

--- a/download_utils.py
+++ b/download_utils.py
@@ -1,0 +1,125 @@
+"""Shared SSRF-guarded PDF downloader, used by both watches and frictionless ingestion.
+
+Extracted from watch_runner._download_pdf, which only rejected non-http(s)
+schemes — a URL whose hostname resolves to a loopback/private/link-local
+address (127.0.0.1, 169.254.169.254, an internal 10.x service, ...) still got
+fetched. This adds the missing DNS-resolved private-IP check.
+"""
+
+from urllib.parse import urljoin, urlparse
+import ipaddress
+import logging
+import os
+import socket
+import tempfile
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+_MAX_PDF_BYTES = 50 * 1024 * 1024  # 50 MB cap — guards against OOM on hostile URLs
+_MAX_REDIRECTS = 5
+_REDIRECT_CODES = (301, 302, 303, 307, 308)
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse to auto-follow redirects — urlopen()'s default opener follows
+    them transparently, which would let a public (SSRF-guard-passing) URL 302
+    to an internal address and defeat _is_private_ip entirely. Each hop is
+    re-validated by download_pdf() instead."""
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+_NoRedirectOpener = urllib.request.build_opener(_NoRedirectHandler)
+
+
+def _is_private_ip(hostname: str) -> bool:
+    """Reject loopback, link-local, and private IPs after DNS resolution.
+
+    A hostname that fails to resolve is not itself an SSRF vector (the
+    subsequent urlopen() call will simply fail on it), so treat resolution
+    failure as "not private" rather than raising.
+    """
+    try:
+        addrs = socket.getaddrinfo(hostname, None)
+    except socket.gaierror:
+        return False
+    for family, _, _, _, sockaddr in addrs:
+        try:
+            ip = ipaddress.ip_address(sockaddr[0])
+        except ValueError:
+            continue
+        if ip.is_loopback or ip.is_link_local or ip.is_private or ip.is_reserved:
+            return True
+    return False
+
+
+def download_pdf(url: str, _redirects_left: int = _MAX_REDIRECTS) -> str | None:
+    """Fetch a PDF to a temp file; return its path, or None on failure.
+
+    Rejects non-HTTP(S) URLs (blocks file://, ftp://, gopher:// SSRF vectors),
+    rejects URLs whose hostname resolves to a private/loopback/link-local IP,
+    streams with a hard size cap so a huge response can't OOM the process, and
+    manually re-validates each hop of a redirect chain (auto-following would
+    let a public, guard-passing URL 302 to an internal address and bypass the
+    check entirely).
+
+    # ponytail: the private-IP check and urlopen()'s own DNS resolution are two
+    # separate lookups (TOCTOU) — a malicious/rebinding DNS server could return
+    # a public IP for the check and a private one for the actual fetch. Full
+    # fix is connection pinning (resolve once, connect to that exact IP); add
+    # it if this is ever exposed to untrusted third-party DNS at scale.
+    # ponytail: timeout=30 bounds each individual connect/read, not the total
+    # transfer — a slow-drip server can hold the connection open indefinitely
+    # under the byte cap. Add a wall-clock ceiling across the whole read loop
+    # if this becomes a real self-DoS problem (route is auth'd + rate-limited).
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        logger.warning(f"Rejected non-HTTP(S) URL: {url}")
+        return None
+    if _is_private_ip(parsed.hostname or ""):
+        logger.warning(f"Rejected private/loopback URL: {url}")
+        return None
+    req = urllib.request.Request(url, headers={"User-Agent": "IndicRAG/2.0"})
+    try:
+        resp = _NoRedirectOpener.open(req, timeout=30)
+    except urllib.error.HTTPError as e:
+        if e.code in _REDIRECT_CODES:
+            location = e.headers.get("Location") if e.headers else None
+            if not location or _redirects_left <= 0:
+                logger.warning(f"Redirect blocked or exhausted: {url}")
+                return None
+            return download_pdf(urljoin(url, location), _redirects_left - 1)
+        logger.warning(f"PDF download failed {url}: {e}")
+        return None
+    except Exception as e:
+        logger.warning(f"PDF download failed {url}: {e}")
+        return None
+
+    # Only create the temp file once the connection is actually open, so a
+    # rejected/redirected request never leaves an unclosed fd or a stray file.
+    fd, path = tempfile.mkstemp(suffix=".pdf")
+    try:
+        with resp, os.fdopen(fd, "wb") as f:
+            total = 0
+            while True:
+                chunk = resp.read(8192)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > _MAX_PDF_BYTES:
+                    logger.warning(f"PDF too large (>{_MAX_PDF_BYTES} bytes), aborting: {url}")
+                    f.close()
+                    os.unlink(path)
+                    return None
+                f.write(chunk)
+        return path
+    except Exception as e:
+        logger.warning(f"PDF download failed {url}: {e}")
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        return None

--- a/manage_users.py
+++ b/manage_users.py
@@ -1,0 +1,74 @@
+"""Admin CLI to pre-provision users (no self-signup path exists in the app).
+
+    python manage_users.py add <username>       # prompts for a password
+    python manage_users.py list
+    python manage_users.py remove <username>
+
+`add` generates the user's api_key and prints it once. The user logs in with
+name+password (POST /login) to retrieve that key; the key is then their
+X-API-Key credential.
+"""
+
+import getpass
+import sys
+from datetime import datetime, timezone
+
+import auth_utils
+import persistence
+
+
+def _add(username: str) -> None:
+    if persistence.get_user(username):
+        print(f"User {username!r} already exists. Use 'remove' first to reset.")
+        sys.exit(1)
+    pw = getpass.getpass(f"Password for {username}: ")
+    pw2 = getpass.getpass("Confirm password: ")
+    if pw != pw2:
+        print("Passwords do not match.")
+        sys.exit(1)
+    if not pw:
+        print("Password must not be empty.")
+        sys.exit(1)
+    salt, pw_hash = auth_utils.hash_password(pw)
+    api_key = auth_utils.new_api_key()
+    persistence.save_user(username, salt, pw_hash, api_key,
+                          datetime.now(timezone.utc).isoformat())
+    print(f"Created user {username!r}.")
+    print(f"API key (share with the user, shown once): {api_key}")
+
+
+def _list() -> None:
+    users = persistence.list_users()
+    if not users:
+        print("(no users)")
+        return
+    for u in users:
+        print(f"{u['username']}\t{u['created_at']}")
+
+
+def _remove(username: str) -> None:
+    if not persistence.get_user(username):
+        print(f"User {username!r} not found.")
+        sys.exit(1)
+    persistence.delete_user(username)
+    print(f"Removed user {username!r}.")
+
+
+def main(argv: list) -> None:
+    if len(argv) < 1:
+        print(__doc__)
+        sys.exit(2)
+    cmd = argv[0]
+    if cmd == "add" and len(argv) == 2:
+        _add(argv[1])
+    elif cmd == "list" and len(argv) == 1:
+        _list()
+    elif cmd == "remove" and len(argv) == 2:
+        _remove(argv[1])
+    else:
+        print(__doc__)
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/persistence.py
+++ b/persistence.py
@@ -53,7 +53,31 @@ _conn.execute(
 )
 _conn.execute("CREATE INDEX IF NOT EXISTS idx_edges_source ON graph_edges(source_paper)")
 _conn.execute("CREATE INDEX IF NOT EXISTS idx_edges_target ON graph_edges(target_paper)")
+_conn.execute(
+    "CREATE TABLE IF NOT EXISTS users ("
+    "username TEXT PRIMARY KEY, pw_salt TEXT, pw_hash TEXT, "
+    "api_key TEXT UNIQUE, created_at TEXT)"
+)
 _conn.commit()
+
+
+def _migrate_add_column(table: str, column: str, decl: str) -> None:
+    """Idempotently add a column to an existing table (older DBs predate it).
+
+    Existing rows get NULL for the new column; callers treat NULL owner as the
+    config.DEFAULT_USER_ID so legacy single-user data stays reachable.
+    """
+    cols = [r[1] for r in _conn.execute(f"PRAGMA table_info({table})").fetchall()]
+    if column not in cols:
+        _conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {decl}")
+
+
+# Owner columns for per-user isolation (multi-user support). watches already has
+# user_id; user_prefs is keyed by it; sessions carry it inside the JSON blob.
+for _t in ("reports", "feedback", "query_log"):
+    _migrate_add_column(_t, "user_id", "TEXT")
+_conn.commit()
+
 _db_lock = threading.Lock()
 
 
@@ -117,27 +141,29 @@ def save_job(job_id: str, job: dict) -> None:
         _conn.commit()
 
 
-def save_feedback(feedback_id: str, query_id: str, rating: str, comment: str, created_at: str) -> None:
+def save_feedback(feedback_id: str, query_id: str, rating: str, comment: str,
+                  created_at: str, user_id: str = None) -> None:
     with _db_lock:
         _conn.execute(
-            "INSERT INTO feedback (id, query_id, rating, comment, created_at) VALUES (?, ?, ?, ?, ?)",
-            (feedback_id, query_id, rating, comment, created_at),
+            "INSERT INTO feedback (id, query_id, rating, comment, created_at, user_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (feedback_id, query_id, rating, comment, created_at, user_id),
         )
         _conn.commit()
 
 
 def log_query(query_id: str, question: str, answer: str, mode: str,
               model: str, language: str, confidence: float, coverage: float,
-              created_at: str) -> None:
+              created_at: str, user_id: str = None) -> None:
     """Persist a query/answer record so feedback can be correlated with it."""
     with _db_lock:
         _conn.execute(
             "INSERT INTO query_log "
-            "(query_id, question, answer, mode, model, language, confidence, coverage, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "(query_id, question, answer, mode, model, language, confidence, coverage, created_at, user_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(query_id) DO UPDATE SET "
             "answer=excluded.answer, confidence=excluded.confidence, coverage=excluded.coverage",
-            (query_id, question, answer, mode, model, language, confidence, coverage, created_at),
+            (query_id, question, answer, mode, model, language, confidence, coverage, created_at, user_id),
         )
         _conn.commit()
 
@@ -148,15 +174,23 @@ _FEEDBACK_CONTEXT_COLUMNS = [
 ]
 
 
-def get_feedback_with_context(limit: int = 50, offset: int = 0) -> list[dict]:
-    """Return feedback joined with its query context, newest first."""
+def get_feedback_with_context(limit: int = 50, offset: int = 0, user_id: str = None) -> list[dict]:
+    """Return feedback joined with its query context, newest first.
+
+    Scoped to `user_id` when given (NULL-owner legacy rows map to DEFAULT_USER_ID).
+    """
+    where, params = "", []
+    if user_id is not None:
+        where = "WHERE COALESCE(f.user_id, ?) = ? "
+        params = [config.DEFAULT_USER_ID, user_id]
     with _db_lock:
         rows = _conn.execute(
             "SELECT f.id, f.query_id, f.rating, f.comment, f.created_at, "
             "q.question, q.answer, q.mode, q.model, q.language, q.confidence, q.coverage "
             "FROM feedback f LEFT JOIN query_log q ON f.query_id = q.query_id "
+            + where +
             "ORDER BY f.created_at DESC LIMIT ? OFFSET ?",
-            (limit, offset),
+            (*params, limit, offset),
         ).fetchall()
     return [
         dict(zip(_FEEDBACK_CONTEXT_COLUMNS, r))
@@ -164,16 +198,22 @@ def get_feedback_with_context(limit: int = 50, offset: int = 0) -> list[dict]:
     ]
 
 
-def feedback_stats() -> dict:
-    """Aggregate feedback totals and per-language approval rate."""
+def feedback_stats(user_id: str = None) -> dict:
+    """Aggregate feedback totals and per-language approval rate, optionally per user."""
+    where, params = "", []
+    if user_id is not None:
+        where = "WHERE COALESCE(f.user_id, ?) = ? "
+        params = [config.DEFAULT_USER_ID, user_id]
     with _db_lock:
-        total = _conn.execute("SELECT COUNT(*) FROM feedback").fetchone()[0]
-        up = _conn.execute("SELECT COUNT(*) FROM feedback WHERE rating='up'").fetchone()[0]
-        down = _conn.execute("SELECT COUNT(*) FROM feedback WHERE rating='down'").fetchone()[0]
+        total = _conn.execute("SELECT COUNT(*) FROM feedback f " + where, params).fetchone()[0]
+        up = _conn.execute("SELECT COUNT(*) FROM feedback f " + where + ("AND" if where else "WHERE") + " rating='up'", params).fetchone()[0]
+        down = _conn.execute("SELECT COUNT(*) FROM feedback f " + where + ("AND" if where else "WHERE") + " rating='down'", params).fetchone()[0]
         by_lang = _conn.execute(
             "SELECT q.language, COUNT(*), AVG(CASE WHEN f.rating='up' THEN 1.0 ELSE 0.0 END) "
             "FROM feedback f JOIN query_log q ON f.query_id = q.query_id "
-            "GROUP BY q.language"
+            + where +
+            "GROUP BY q.language",
+            params,
         ).fetchall()
     return {
         "total": total, "up": up, "down": down,
@@ -263,16 +303,16 @@ def delete_watch(watch_id: str) -> None:
 # review" needs to survive indefinitely and be regenerated in place.
 # ---------------------------------------------------------------------------
 def save_report(report_id: str, watch_id: str, topic: str, language: str,
-                markdown: str, citation_count: int, created_at: str) -> None:
+                markdown: str, citation_count: int, created_at: str, user_id: str = None) -> None:
     """Insert or update a report. Re-saving the same report_id overwrites in place
     (that's how a watch-owned living review gets regenerated)."""
     with _db_lock:
         _conn.execute(
-            "INSERT INTO reports (id, watch_id, topic, language, markdown, citation_count, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?) "
+            "INSERT INTO reports (id, watch_id, topic, language, markdown, citation_count, created_at, user_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(id) DO UPDATE SET topic=excluded.topic, language=excluded.language, "
             "markdown=excluded.markdown, citation_count=excluded.citation_count",
-            (report_id, watch_id, topic, language, markdown, citation_count, created_at),
+            (report_id, watch_id, topic, language, markdown, citation_count, created_at, user_id),
         )
         _conn.commit()
 
@@ -280,28 +320,35 @@ def save_report(report_id: str, watch_id: str, topic: str, language: str,
 def get_report(report_id: str) -> dict | None:
     with _db_lock:
         row = _conn.execute(
-            "SELECT id, watch_id, topic, language, markdown, citation_count, created_at "
+            "SELECT id, watch_id, topic, language, markdown, citation_count, created_at, user_id "
             "FROM reports WHERE id = ?", (report_id,),
         ).fetchone()
     if not row:
         return None
     return {"id": row[0], "watch_id": row[1], "topic": row[2], "language": row[3],
-            "markdown": row[4], "citation_count": row[5], "created_at": row[6]}
+            "markdown": row[4], "citation_count": row[5], "created_at": row[6],
+            "user_id": row[7] if row[7] is not None else config.DEFAULT_USER_ID}
 
 
-def list_reports(watch_id: str | None = None) -> list[dict]:
-    """Summary rows (no markdown body) — newest first, or scoped to one watch."""
+def list_reports(watch_id: str | None = None, user_id: str | None = None) -> list[dict]:
+    """Summary rows (no markdown body) — newest first; scoped to a watch and/or owner.
+
+    NULL-owner legacy rows map to DEFAULT_USER_ID when filtering by user_id.
+    """
+    clauses, params = [], []
+    if watch_id:
+        clauses.append("watch_id = ?")
+        params.append(watch_id)
+    if user_id is not None:
+        clauses.append("COALESCE(user_id, ?) = ?")
+        params.extend([config.DEFAULT_USER_ID, user_id])
+    where = ("WHERE " + " AND ".join(clauses) + " ") if clauses else ""
     with _db_lock:
-        if watch_id:
-            rows = _conn.execute(
-                "SELECT id, watch_id, topic, language, citation_count, created_at "
-                "FROM reports WHERE watch_id = ? ORDER BY created_at DESC", (watch_id,),
-            ).fetchall()
-        else:
-            rows = _conn.execute(
-                "SELECT id, watch_id, topic, language, citation_count, created_at "
-                "FROM reports ORDER BY created_at DESC",
-            ).fetchall()
+        rows = _conn.execute(
+            "SELECT id, watch_id, topic, language, citation_count, created_at "
+            "FROM reports " + where + "ORDER BY created_at DESC",
+            params,
+        ).fetchall()
     return [{"id": r[0], "watch_id": r[1], "topic": r[2], "language": r[3],
              "citation_count": r[4], "created_at": r[5]} for r in rows]
 
@@ -356,3 +403,50 @@ def get_paper_edges(paper_id: str) -> list[dict]:
         ).fetchall()
     return [{"source": r[0], "target": r[1], "type": r[2], "score": r[3],
              "metadata": json.loads(r[4])} for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Users (multi-user support). Pre-provisioned via manage_users.py — no signup
+# path here. api_key is the per-user X-API-Key; deps.py maps key -> username.
+# ---------------------------------------------------------------------------
+def save_user(username: str, pw_salt: str, pw_hash: str, api_key: str, created_at: str) -> None:
+    with _db_lock:
+        _conn.execute(
+            "INSERT INTO users (username, pw_salt, pw_hash, api_key, created_at) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(username) DO UPDATE SET pw_salt=excluded.pw_salt, "
+            "pw_hash=excluded.pw_hash, api_key=excluded.api_key",
+            (username, pw_salt, pw_hash, api_key, created_at),
+        )
+        _conn.commit()
+
+
+def get_user(username: str) -> dict | None:
+    with _db_lock:
+        row = _conn.execute(
+            "SELECT username, pw_salt, pw_hash, api_key, created_at FROM users WHERE username = ?",
+            (username,),
+        ).fetchone()
+    if not row:
+        return None
+    return {"username": row[0], "pw_salt": row[1], "pw_hash": row[2],
+            "api_key": row[3], "created_at": row[4]}
+
+
+def list_users() -> list[dict]:
+    with _db_lock:
+        rows = _conn.execute("SELECT username, created_at FROM users ORDER BY username").fetchall()
+    return [{"username": r[0], "created_at": r[1]} for r in rows]
+
+
+def delete_user(username: str) -> None:
+    with _db_lock:
+        _conn.execute("DELETE FROM users WHERE username = ?", (username,))
+        _conn.commit()
+
+
+def all_key_user_pairs() -> list[tuple]:
+    """(api_key, username) for every user — deps.py builds its key->user map from this."""
+    with _db_lock:
+        rows = _conn.execute("SELECT api_key, username FROM users").fetchall()
+    return [(r[0], r[1]) for r in rows]

--- a/persistence.py
+++ b/persistence.py
@@ -35,6 +35,12 @@ _conn.execute(
     "CREATE TABLE IF NOT EXISTS watches (id TEXT PRIMARY KEY, user_id TEXT, data TEXT, "
     "next_run TEXT, last_run TEXT, created_at TEXT)"
 )
+_conn.execute(
+    "CREATE TABLE IF NOT EXISTS query_log ("
+    "query_id TEXT PRIMARY KEY, question TEXT, answer TEXT, mode TEXT, "
+    "model TEXT, language TEXT, confidence REAL, coverage REAL, "
+    "created_at TEXT)"
+)
 _conn.commit()
 _db_lock = threading.Lock()
 
@@ -106,6 +112,61 @@ def save_feedback(feedback_id: str, query_id: str, rating: str, comment: str, cr
             (feedback_id, query_id, rating, comment, created_at),
         )
         _conn.commit()
+
+
+def log_query(query_id: str, question: str, answer: str, mode: str,
+              model: str, language: str, confidence: float, coverage: float,
+              created_at: str) -> None:
+    """Persist a query/answer record so feedback can be correlated with it."""
+    with _db_lock:
+        _conn.execute(
+            "INSERT INTO query_log "
+            "(query_id, question, answer, mode, model, language, confidence, coverage, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(query_id) DO UPDATE SET "
+            "answer=excluded.answer, confidence=excluded.confidence, coverage=excluded.coverage",
+            (query_id, question, answer, mode, model, language, confidence, coverage, created_at),
+        )
+        _conn.commit()
+
+
+_FEEDBACK_CONTEXT_COLUMNS = [
+    "id", "query_id", "rating", "comment", "created_at",
+    "question", "answer", "mode", "model", "language", "confidence", "coverage",
+]
+
+
+def get_feedback_with_context(limit: int = 50, offset: int = 0) -> list[dict]:
+    """Return feedback joined with its query context, newest first."""
+    with _db_lock:
+        rows = _conn.execute(
+            "SELECT f.id, f.query_id, f.rating, f.comment, f.created_at, "
+            "q.question, q.answer, q.mode, q.model, q.language, q.confidence, q.coverage "
+            "FROM feedback f LEFT JOIN query_log q ON f.query_id = q.query_id "
+            "ORDER BY f.created_at DESC LIMIT ? OFFSET ?",
+            (limit, offset),
+        ).fetchall()
+    return [
+        dict(zip(_FEEDBACK_CONTEXT_COLUMNS, r))
+        for r in rows
+    ]
+
+
+def feedback_stats() -> dict:
+    """Aggregate feedback totals and per-language approval rate."""
+    with _db_lock:
+        total = _conn.execute("SELECT COUNT(*) FROM feedback").fetchone()[0]
+        up = _conn.execute("SELECT COUNT(*) FROM feedback WHERE rating='up'").fetchone()[0]
+        down = _conn.execute("SELECT COUNT(*) FROM feedback WHERE rating='down'").fetchone()[0]
+        by_lang = _conn.execute(
+            "SELECT q.language, COUNT(*), AVG(CASE WHEN f.rating='up' THEN 1.0 ELSE 0.0 END) "
+            "FROM feedback f JOIN query_log q ON f.query_id = q.query_id "
+            "GROUP BY q.language"
+        ).fetchall()
+    return {
+        "total": total, "up": up, "down": down,
+        "by_language": {r[0]: {"count": r[1], "approval_rate": round(r[2], 3)} for r in by_lang},
+    }
 
 
 def get_prefs(user_id: str) -> dict:

--- a/persistence.py
+++ b/persistence.py
@@ -45,6 +45,14 @@ _conn.execute(
     "CREATE TABLE IF NOT EXISTS reports (id TEXT PRIMARY KEY, watch_id TEXT, topic TEXT, "
     "language TEXT, markdown TEXT, citation_count INTEGER, created_at TEXT)"
 )
+_conn.execute(
+    "CREATE TABLE IF NOT EXISTS graph_edges ("
+    "source_paper TEXT, target_paper TEXT, edge_type TEXT, "
+    "score REAL, metadata TEXT, created_at TEXT, "
+    "PRIMARY KEY (source_paper, target_paper, edge_type))"
+)
+_conn.execute("CREATE INDEX IF NOT EXISTS idx_edges_source ON graph_edges(source_paper)")
+_conn.execute("CREATE INDEX IF NOT EXISTS idx_edges_target ON graph_edges(target_paper)")
 _conn.commit()
 _db_lock = threading.Lock()
 
@@ -296,3 +304,55 @@ def list_reports(watch_id: str | None = None) -> list[dict]:
             ).fetchall()
     return [{"id": r[0], "watch_id": r[1], "topic": r[2], "language": r[3],
              "citation_count": r[4], "created_at": r[5]} for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Knowledge/citation graph (Task 3.3). Edges are undirected — endpoints
+# normalize to source<=target so (A,B) and (B,A) dedupe to one row. Repeated
+# detections of the same pair accumulate score (co-citation frequency /
+# contradiction evidence) via the composite-PK upsert, so the table stays
+# bounded no matter how many queries run.
+# ---------------------------------------------------------------------------
+def save_graph_edges(edges: list) -> None:
+    """Batch upsert edges: list of (source, target, edge_type, score, metadata_dict).
+
+    One lock + commit for the whole batch (a query co-cites up to ~C(k,2) pairs).
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    rows = []
+    for source, target, edge_type, score, metadata in edges:
+        s, t = sorted((source, target))  # undirected: normalize ordering
+        rows.append((s, t, edge_type, score, json.dumps(metadata or {}), now))
+    with _db_lock:
+        _conn.executemany(
+            "INSERT INTO graph_edges (source_paper, target_paper, edge_type, score, metadata, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(source_paper, target_paper, edge_type) DO UPDATE SET "
+            "score = score + excluded.score, created_at = excluded.created_at",
+            rows,
+        )
+        _conn.commit()
+
+
+def save_graph_edge(source: str, target: str, edge_type: str,
+                    score: float, metadata: dict = None) -> None:
+    save_graph_edges([(source, target, edge_type, score, metadata)])
+
+
+def get_all_edges() -> list[dict]:
+    with _db_lock:
+        rows = _conn.execute(
+            "SELECT source_paper, target_paper, edge_type, score FROM graph_edges"
+        ).fetchall()
+    return [{"source": r[0], "target": r[1], "type": r[2], "score": r[3]} for r in rows]
+
+
+def get_paper_edges(paper_id: str) -> list[dict]:
+    with _db_lock:
+        rows = _conn.execute(
+            "SELECT source_paper, target_paper, edge_type, score, metadata "
+            "FROM graph_edges WHERE source_paper = ? OR target_paper = ?",
+            (paper_id, paper_id),
+        ).fetchall()
+    return [{"source": r[0], "target": r[1], "type": r[2], "score": r[3],
+             "metadata": json.loads(r[4])} for r in rows]

--- a/persistence.py
+++ b/persistence.py
@@ -41,6 +41,10 @@ _conn.execute(
     "model TEXT, language TEXT, confidence REAL, coverage REAL, "
     "created_at TEXT)"
 )
+_conn.execute(
+    "CREATE TABLE IF NOT EXISTS reports (id TEXT PRIMARY KEY, watch_id TEXT, topic TEXT, "
+    "language TEXT, markdown TEXT, citation_count INTEGER, created_at TEXT)"
+)
 _conn.commit()
 _db_lock = threading.Lock()
 
@@ -243,3 +247,52 @@ def delete_watch(watch_id: str) -> None:
     with _db_lock:
         _conn.execute("DELETE FROM watches WHERE id = ?", (watch_id,))
         _conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Literature-review reports — a durable artifact, unlike the generic job store
+# (deps._jobs) which prunes completed entries after 24h. A watch-owned "living
+# review" needs to survive indefinitely and be regenerated in place.
+# ---------------------------------------------------------------------------
+def save_report(report_id: str, watch_id: str, topic: str, language: str,
+                markdown: str, citation_count: int, created_at: str) -> None:
+    """Insert or update a report. Re-saving the same report_id overwrites in place
+    (that's how a watch-owned living review gets regenerated)."""
+    with _db_lock:
+        _conn.execute(
+            "INSERT INTO reports (id, watch_id, topic, language, markdown, citation_count, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(id) DO UPDATE SET topic=excluded.topic, language=excluded.language, "
+            "markdown=excluded.markdown, citation_count=excluded.citation_count",
+            (report_id, watch_id, topic, language, markdown, citation_count, created_at),
+        )
+        _conn.commit()
+
+
+def get_report(report_id: str) -> dict | None:
+    with _db_lock:
+        row = _conn.execute(
+            "SELECT id, watch_id, topic, language, markdown, citation_count, created_at "
+            "FROM reports WHERE id = ?", (report_id,),
+        ).fetchone()
+    if not row:
+        return None
+    return {"id": row[0], "watch_id": row[1], "topic": row[2], "language": row[3],
+            "markdown": row[4], "citation_count": row[5], "created_at": row[6]}
+
+
+def list_reports(watch_id: str | None = None) -> list[dict]:
+    """Summary rows (no markdown body) — newest first, or scoped to one watch."""
+    with _db_lock:
+        if watch_id:
+            rows = _conn.execute(
+                "SELECT id, watch_id, topic, language, citation_count, created_at "
+                "FROM reports WHERE watch_id = ? ORDER BY created_at DESC", (watch_id,),
+            ).fetchall()
+        else:
+            rows = _conn.execute(
+                "SELECT id, watch_id, topic, language, citation_count, created_at "
+                "FROM reports ORDER BY created_at DESC",
+            ).fetchall()
+    return [{"id": r[0], "watch_id": r[1], "topic": r[2], "language": r[3],
+             "citation_count": r[4], "created_at": r[5]} for r in rows]

--- a/rag.py
+++ b/rag.py
@@ -607,11 +607,14 @@ def safe_extract_text(response) -> str:
     return ""
 
 
-def _run_faithfulness(answer: str, chunks: List[str], metadatas: List[Dict] = None) -> List[dict]:
+def _run_faithfulness(answer: str, chunks: List[str], metadatas: List[Dict] = None) -> dict:
     """Run faithfulness verification if configured; log warnings for ungrounded claims.
 
     metadatas (aligned with chunks) lets each [N] resolve to the right paper's
     chunk(s), since citations are numbered per-paper, not per-chunk.
+
+    Returns {"claims": [...], "confidence": float} — confidence is the mean
+    per-claim support score, surfaced to callers as answer_confidence.
     """
     try:
         import verify
@@ -619,10 +622,11 @@ def _run_faithfulness(answer: str, chunks: List[str], metadatas: List[Dict] = No
         for r in results:
             if not r["grounded"]:
                 logger.warning(f"Ungrounded claim (score={r['support']:.2f}): {r['claim'][:120]}")
-        return results
+        confidence = sum(r["support"] for r in results) / len(results) if results else 0.0
+        return {"claims": results, "confidence": round(confidence, 4)}
     except Exception as e:
         logger.warning(f"Faithfulness check failed: {e}", exc_info=True)
-        return []
+        return {"claims": [], "confidence": 0.0}
 
 
 def answer_question_strategy_a(
@@ -705,8 +709,10 @@ def answer_question_strategy_a(
         'chunks_used': context_data['chunks_used'],
         'citations': citations
     }
-    result['faithfulness'] = _run_faithfulness(
+    faith_result = _run_faithfulness(
         answer, context_data.get('chunks', []), context_data.get('metadatas', []))
+    result['faithfulness'] = faith_result["claims"]
+    result['answer_confidence'] = faith_result["confidence"]
     return result
 
 
@@ -801,8 +807,10 @@ def answer_question_strategy_b(
         'citations': citations,
         'english_answer': english_answer
     }
-    result['faithfulness'] = _run_faithfulness(
+    faith_result = _run_faithfulness(
         english_answer, context_data.get('chunks', []), context_data.get('metadatas', []))
+    result['faithfulness'] = faith_result["claims"]
+    result['answer_confidence'] = faith_result["confidence"]
     return result
 
 
@@ -943,8 +951,10 @@ def answer_with_history(
     }
     if strategy == "B" and answer != english_answer:
         result["english_answer"] = english_answer
-    result["faithfulness"] = _run_faithfulness(
+    faith_result = _run_faithfulness(
         english_answer, context_data.get("chunks", []), context_data.get("metadatas", []))
+    result["faithfulness"] = faith_result["claims"]
+    result["answer_confidence"] = faith_result["confidence"]
     return result
 
 

--- a/rag.py
+++ b/rag.py
@@ -445,6 +445,35 @@ def _retrieve_scoped(filter_dict: Dict[str, Any], collection) -> Dict[str, Any]:
     }
 
 
+def compare_papers(paper_ids: List[str], dimensions: List[str], model: str = None) -> Dict[str, Any]:
+    """Build a papers x dimensions comparison matrix.
+
+    Reuses the paper-scoped exhaustive retrieval (_retrieve_scoped) to see the
+    whole paper per row, then asks one grounded extraction per dimension.
+    Returns {"dimensions": [...], "matrix": {paper_id: {dimension: text}}}.
+    """
+    collection = vector_store.get_or_create_collection()
+
+    matrix: Dict[str, Dict[str, str]] = {}
+    for paper_id in paper_ids:
+        scoped = _retrieve_scoped({"paper_id": {"$in": [paper_id]}}, collection)
+        context = scoped["formatted_context"]
+        matrix[paper_id] = {}
+        if not context:
+            for dim in dimensions:
+                matrix[paper_id][dim] = "N/A — paper not found in corpus"
+            continue
+        for dim in dimensions:
+            prompt = (
+                f"Based ONLY on the following paper text, extract the information about: {dim}\n"
+                f"If the paper does not address this dimension, say 'N/A'.\n"
+                f"Be concise — 1-3 sentences. Cite with [1] if possible.\n\n{context}"
+            )
+            matrix[paper_id][dim] = llm_generate(prompt, max_tokens=300, model=model)
+
+    return {"dimensions": dimensions, "matrix": matrix}
+
+
 def build_prompt(
     user_query: str,
     context: str,

--- a/rag.py
+++ b/rag.py
@@ -732,6 +732,34 @@ def _run_faithfulness(answer: str, chunks: List[str], metadatas: List[Dict] = No
         return {"claims": [], "confidence": 0.0}
 
 
+def extract_co_citations(citations: List[Dict]) -> List[tuple]:
+    """Distinct-title pairs among papers actually cited in one answer.
+
+    Uses the resolved `citations` (papers the answer referenced), not all
+    retrieved chunks — retrieval returns top-k, but only the cited papers are a
+    real co-citation signal. Undirected pairs; caller persists them.
+    """
+    titles = []
+    for c in citations:
+        t = ((c or {}).get("title") or "").strip()
+        if t and t not in titles:
+            titles.append(t)
+    return [(titles[i], titles[j])
+            for i in range(len(titles)) for j in range(i + 1, len(titles))]
+
+
+def _persist_co_citations(citations: List[Dict]) -> None:
+    """Best-effort: record co-citation edges. Never breaks answering."""
+    try:
+        pairs = extract_co_citations(citations)
+        if pairs:
+            import persistence
+            persistence.save_graph_edges(
+                [(a, b, "co_citation", 1.0, None) for a, b in pairs])
+    except Exception as e:
+        logger.warning(f"[Graph] co-citation persist failed: {e}")
+
+
 def answer_question_strategy_a(
     user_query: str,
     top_k: int = None,
@@ -804,6 +832,7 @@ def answer_question_strategy_a(
     
     # Extract citations using robust parser
     citations = extract_citations(answer, context_data['metadatas'], context_data.get('chunks'))
+    _persist_co_citations(citations)
 
     result = {
         'answer': answer,
@@ -894,6 +923,7 @@ def answer_question_strategy_b(
     
     # Extract citations from ENGLISH answer (before translation) using robust parser
     citations = extract_citations(english_answer, context_data['metadatas'], context_data.get('chunks'))
+    _persist_co_citations(citations)
     
     # Translate answer to target language if needed
     if detected_lang != "en" and lang_utils.is_indic_language(detected_lang):

--- a/rag.py
+++ b/rag.py
@@ -145,6 +145,64 @@ def _hyde_embedding(user_query: str):
     return embeddings.embed_query(user_query)
 
 
+_TAGS_SENTINEL = "$tags_post_filter"
+
+
+def _extract_tags_post_filter(filter_dict: Optional[Dict]) -> tuple:
+    """Pull a tags post-filter out of an opaque filter_dict blob, if present.
+
+    Tags can't be a ChromaDB `where` clause: PATCH /papers stores the tags
+    string verbatim (unsplit), so a native $in match against split tag names
+    never equals the stored comma-joined value — it would silently return
+    zero results for any paper tagged with more than one tag. Instead, tags
+    travel inside filter_dict as a reserved sentinel key and are applied as
+    a Python-side post-filter in retrieve_context, while paper_id/year
+    clauses still go to ChromaDB as before.
+
+    Returns (chromadb_safe_filter_dict_or_None, tag_list_or_None).
+    """
+    if not filter_dict:
+        return filter_dict, None
+    if _TAGS_SENTINEL in filter_dict:
+        return None, filter_dict[_TAGS_SENTINEL]
+    if "$and" in filter_dict:
+        tags = None
+        remaining = []
+        for clause in filter_dict["$and"]:
+            if _TAGS_SENTINEL in clause:
+                tags = clause[_TAGS_SENTINEL]
+            else:
+                remaining.append(clause)
+        if tags is not None:
+            if not remaining:
+                return None, tags
+            return (remaining[0] if len(remaining) == 1 else {"$and": remaining}), tags
+    return filter_dict, None
+
+
+_TAGS_POST_FILTER_KEYS = ("ids", "chunks", "documents", "metadatas", "distances")
+
+
+def _apply_tags_post_filter(results: Dict[str, list], tags: list) -> Dict[str, list]:
+    """Keep only results whose stored `tags` metadata shares at least one tag.
+
+    Only touches the parallel list-valued keys (chunks/metadatas/distances/...);
+    any other key (formatted_context, chunks_used, ...) passes through unchanged.
+    """
+    wanted = {t.strip() for t in tags if t.strip()}
+    if not wanted:
+        return results
+    keep = [
+        i for i, meta in enumerate(results.get("metadatas", []))
+        if wanted & {t.strip() for t in (meta or {}).get("tags", "").split(",") if t.strip()}
+    ]
+    filtered = dict(results)
+    for key in _TAGS_POST_FILTER_KEYS:
+        if key in filtered:
+            filtered[key] = [filtered[key][i] for i in keep]
+    return filtered
+
+
 def retrieve_context(
     user_query: str,
     top_k: int = None,
@@ -187,27 +245,40 @@ def retrieve_context(
     if collection is None:
         collection = vector_store.get_or_create_collection()
 
+    # Tags can't go to ChromaDB as a native where-clause (see _extract_tags_post_filter).
+    # chroma_filter_dict is the ChromaDB-safe remainder; `filter_dict` itself is left
+    # untouched since the cache-bypass checks below key off "was any filter requested".
+    chroma_filter_dict, tags_post_filter = _extract_tags_post_filter(filter_dict)
+
     # Paper-scoped queries → exhaustive retrieval (all chunks of the selected
     # papers in document order), not top-k similarity. This is what makes
     # "reconstruct everything in this paper" work: the LLM sees the whole paper
     # instead of a semantic sample that can miss equations/hyperparameters.
-    if filter_dict and 'paper_id' in filter_dict:
-        return _retrieve_scoped(filter_dict, collection)
+    if chroma_filter_dict and 'paper_id' in chroma_filter_dict:
+        scoped = _retrieve_scoped(chroma_filter_dict, collection)
+        if tags_post_filter and scoped["chunks"]:
+            filtered = _apply_tags_post_filter(scoped, tags_post_filter)
+            formatted_context, chunks_used = format_context(
+                chunks=filtered["chunks"], metadatas=filtered["metadatas"])
+            filtered["formatted_context"] = formatted_context
+            filtered["chunks_used"] = chunks_used
+            return filtered
+        return scoped
 
     # Embed the query — HyDE embeds a drafted hypothetical answer instead of
     # the bare question; lexical (BM25) search below always uses the real query.
     query_embedding = _hyde_embedding(user_query) if use_hyde else embeddings.embed_query(user_query)
-    
+
     # Search vector store (dense)
     results = vector_store.search(
         query_embedding=query_embedding,
         top_k=top_k,
-        filter_dict=filter_dict,
+        filter_dict=chroma_filter_dict,
         collection=collection
     )
 
     # Hybrid: fuse dense results with BM25 lexical search
-    if config.USE_HYBRID_SEARCH and results['documents'] and not filter_dict:
+    if config.USE_HYBRID_SEARCH and results['documents'] and not chroma_filter_dict:
         try:
             import bm25_search
             bm25_idx = bm25_search.get_or_build_index(collection)
@@ -233,6 +304,9 @@ def retrieve_context(
                 }
         except Exception as e:
             logger.debug(f"Hybrid search skipped: {e}")
+
+    if tags_post_filter:
+        results = _apply_tags_post_filter(results, tags_post_filter)
 
     # Check if search returned results
     if not results['documents']:

--- a/routes/agent.py
+++ b/routes/agent.py
@@ -17,7 +17,7 @@ import persistence
 import rag
 from agent.state import AgentState
 from agent.nodes.finalizer import citation_coverage
-from deps import limiter, verify_api_key, _get_or_create_session, _append_session_messages
+from deps import limiter, verify_api_key, get_current_user, _get_or_create_session, _append_session_messages
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -88,14 +88,14 @@ class AgentQueryResponse(BaseModel):
 async def agent_query(
     request: Request,
     body: AgentQueryRequest,
-    authenticated: bool = Depends(verify_api_key),
+    user_id: str = Depends(get_current_user),
 ):
     """
     Answer a question using the agentic IndicRAG pipeline with reflexion loops.
     Supports the same 10+ languages as /query and /chat.
     """
     start_time = time.time()
-    session_id, messages = _get_or_create_session(body.session_id)
+    session_id, messages = _get_or_create_session(body.session_id, user_id)
 
     initial_state = AgentState(
         original_query=body.question,
@@ -110,6 +110,7 @@ async def agent_query(
         tool_calls_log=[],
         conversation_history=list(messages),
         session_id=session_id,
+        user_id=user_id,
         strategy=body.strategy,
         start_time=time.monotonic(),
         requested_model=body.model,
@@ -209,7 +210,7 @@ async def agent_query(
             language=result.get("detected_language", "en"),
             confidence=result.get("answer_confidence") or 0.0,
             coverage=citation_coverage(result["final_answer"]),
-            created_at=datetime.now(timezone.utc).isoformat(),
+            created_at=datetime.now(timezone.utc).isoformat(), user_id=user_id,
         )
     except Exception:
         logger.warning("Failed to log query for feedback correlation", exc_info=True)

--- a/routes/agent.py
+++ b/routes/agent.py
@@ -17,7 +17,7 @@ import persistence
 import rag
 from agent.state import AgentState
 from agent.nodes.finalizer import citation_coverage
-from deps import limiter, verify_api_key, get_current_user, _get_or_create_session, _append_session_messages
+from deps import limiter, get_current_user, _get_or_create_session, _append_session_messages
 
 logger = logging.getLogger(__name__)
 router = APIRouter()

--- a/routes/agent.py
+++ b/routes/agent.py
@@ -6,14 +6,17 @@ import asyncio
 import logging
 import threading
 import time
+import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field, field_validator
 
 import config
+import persistence
 import rag
 from agent.state import AgentState
+from agent.nodes.finalizer import citation_coverage
 from deps import limiter, verify_api_key, _get_or_create_session, _append_session_messages
 
 logger = logging.getLogger(__name__)
@@ -77,6 +80,7 @@ class AgentQueryResponse(BaseModel):
     timestamp: str
     answer_confidence: Optional[float] = None
     abstained: bool = False
+    query_id: str = ""
 
 
 @router.post("/agent/query", response_model=AgentQueryResponse, tags=["Agent"])
@@ -197,6 +201,19 @@ async def agent_query(
     # Order the panel by citation number so [1],[2],... read in sequence.
     sources.sort(key=lambda s: s.number)
 
+    query_id = str(uuid.uuid4())
+    try:
+        persistence.log_query(
+            query_id=query_id, question=body.question, answer=result["final_answer"],
+            mode=f"agent_{body.strategy}", model=body.model or "default",
+            language=result.get("detected_language", "en"),
+            confidence=result.get("answer_confidence") or 0.0,
+            coverage=citation_coverage(result["final_answer"]),
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+    except Exception:
+        logger.warning("Failed to log query for feedback correlation", exc_info=True)
+
     return AgentQueryResponse(
         answer=result["final_answer"],
         session_id=session_id,
@@ -208,4 +225,5 @@ async def agent_query(
         timestamp=datetime.now(timezone.utc).isoformat(),
         answer_confidence=result.get("answer_confidence"),
         abstained=result.get("abstained", False),
+        query_id=query_id,
     )

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -1,0 +1,46 @@
+"""Routes: /login — exchange name+password for the user's API key.
+
+Users are pre-provisioned (manage_users.py); there is no signup endpoint. The
+returned api_key is then sent as X-API-Key on every later request, which the
+server resolves back to this user (deps.get_current_user).
+"""
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+import auth_utils
+import persistence
+from deps import limiter, _refresh_key_map
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+class LoginRequest(BaseModel):
+    username: str = Field(..., min_length=1, max_length=128)
+    password: str = Field(..., min_length=1, max_length=1024)
+
+
+class LoginResponse(BaseModel):
+    username: str
+    api_key: str
+
+
+# Generic message for every failure mode — never reveal whether the username
+# exists or the password was the wrong part (no user-enumeration oracle).
+_BAD_LOGIN = {"error": "Invalid username or password", "code": "INVALID_CREDENTIALS"}
+
+
+@router.post("/login", response_model=LoginResponse, tags=["Auth"])
+@limiter.limit("10/minute")  # blunt password guessing
+async def login(request: Request, body: LoginRequest):
+    user = persistence.get_user(body.username)
+    if user is None or not auth_utils.verify_password(
+        body.password, user["pw_salt"], user["pw_hash"]
+    ):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=_BAD_LOGIN)
+    _refresh_key_map()  # ensure this user's key resolves even if seeded post-startup
+    logger.info(f"[Auth] login ok user={body.username!r}")
+    return LoginResponse(username=user["username"], api_key=user["api_key"])

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, Field, field_validator
 
 import rag
 from deps import limiter, verify_api_key, _get_or_create_session, _append_session_messages
-from routes.query import Citation, build_paper_filter
+from routes.query import Citation, build_paper_filter, build_tags_filter, combine_filters
 from sse_utils import sse_stream
 
 logger = logging.getLogger(__name__)
@@ -30,6 +30,7 @@ class ChatRequest(BaseModel):
     paper_ids: Optional[List[str]] = Field(
         None, description="Restrict retrieval to these paper_ids (PDF filename stems). Omit for whole corpus."
     )
+    tags: Optional[str] = Field(None, description="Comma-separated tags to filter retrieval.")
     model: Optional[str] = Field(None, description="LLM model id from the /models allowlist. Omit for default.")
     provider: Optional[str] = Field(None, description="LLM provider override (gemini|openrouter). Usually inferred from model.")
 
@@ -93,7 +94,7 @@ async def chat(
             messages=full_messages,
             strategy=body.strategy,
             top_k=top_k,
-            filter_dict=build_paper_filter(body.paper_ids),
+            filter_dict=combine_filters(build_paper_filter(body.paper_ids), build_tags_filter(body.tags)),
             model=body.model,
             provider=body.provider,
         )
@@ -141,7 +142,7 @@ async def chat_stream(
     full_messages = list(messages) + [{"role": "user", "content": body.message}]
 
     prepared = await run_in_threadpool(rag.prepare_chat_for_stream, full_messages, body.strategy, top_k,
-                                       build_paper_filter(body.paper_ids))
+                                       combine_filters(build_paper_filter(body.paper_ids), build_tags_filter(body.tags)))
     query_id = str(uuid.uuid4())
 
     if prepared["chunks_used"] == 0:

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -13,7 +13,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 
 import rag
-from deps import (limiter, verify_api_key, get_current_user, _get_or_create_session,
+from deps import (limiter, get_current_user, _get_or_create_session,
                   _append_session_messages, _session_owner)
 from routes.query import Citation, build_paper_filter, build_tags_filter, combine_filters
 from sse_utils import sse_stream

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -13,7 +13,8 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 
 import rag
-from deps import limiter, verify_api_key, _get_or_create_session, _append_session_messages
+from deps import (limiter, verify_api_key, get_current_user, _get_or_create_session,
+                  _append_session_messages, _session_owner)
 from routes.query import Citation, build_paper_filter, build_tags_filter, combine_filters
 from sse_utils import sse_stream
 
@@ -68,7 +69,7 @@ class ChatResponse(BaseModel):
 async def chat(
     request: Request,
     body: ChatRequest,
-    authenticated: bool = Depends(verify_api_key),
+    user_id: str = Depends(get_current_user),
 ):
     """
     Send a message in a multi-turn conversation.
@@ -83,7 +84,7 @@ async def chat(
     if top_k is not None:
         top_k = max(1, min(top_k, 20))
 
-    session_id, messages = _get_or_create_session(body.session_id)
+    session_id, messages = _get_or_create_session(body.session_id, user_id)
     turn_index = len(messages) // 2  # number of completed user+assistant pairs
 
     full_messages = list(messages) + [{"role": "user", "content": body.message}]
@@ -131,14 +132,14 @@ async def chat(
 async def chat_stream(
     request: Request,
     body: ChatRequest,
-    authenticated: bool = Depends(verify_api_key),
+    user_id: str = Depends(get_current_user),
 ):
     """Stream a multi-turn chat answer as Server-Sent Events."""
     top_k = body.top_k
     if top_k is not None:
         top_k = max(1, min(top_k, 20))
 
-    session_id, messages = _get_or_create_session(body.session_id)
+    session_id, messages = _get_or_create_session(body.session_id, user_id)
     full_messages = list(messages) + [{"role": "user", "content": body.message}]
 
     prepared = await run_in_threadpool(rag.prepare_chat_for_stream, full_messages, body.strategy, top_k,
@@ -196,13 +197,15 @@ class ChatHistoryResponse(BaseModel):
 
 
 @router.get("/chat", response_model=List[ChatSessionSummary], tags=["Chat"])
-async def list_sessions(authenticated: bool = Depends(verify_api_key)):
-    """List saved chat sessions, most-recent first. Global — no per-user isolation."""
+async def list_sessions(user_id: str = Depends(get_current_user)):
+    """List the caller's own saved chat sessions, most-recent first."""
     from deps import _sessions, _sessions_lock, _evict_stale_sessions
     summaries: List[ChatSessionSummary] = []
     with _sessions_lock:
         _evict_stale_sessions()
         for sid, s in _sessions.items():
+            if _session_owner(s) != user_id:  # only the caller's conversations
+                continue
             msgs = s.get("messages", [])
             if not msgs:  # skip empty sessions (created but never used)
                 continue
@@ -219,12 +222,12 @@ async def list_sessions(authenticated: bool = Depends(verify_api_key)):
 
 
 @router.get("/chat/{session_id}", response_model=ChatHistoryResponse, tags=["Chat"])
-async def get_session_history(session_id: str, authenticated: bool = Depends(verify_api_key)):
+async def get_session_history(session_id: str, user_id: str = Depends(get_current_user)):
     """Return a session's full message history so the UI can reopen the conversation."""
     from deps import _sessions, _sessions_lock
     with _sessions_lock:
         s = _sessions.get(session_id)
-        if s is None:
+        if s is None or _session_owner(s) != user_id:  # 404 (not 403) on someone else's session
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Session '{session_id}' not found.")
         return ChatHistoryResponse(
             session_id=session_id,
@@ -237,13 +240,14 @@ async def get_session_history(session_id: str, authenticated: bool = Depends(ver
 @router.delete("/chat/{session_id}", tags=["Chat"])
 async def delete_session(
     session_id: str,
-    authenticated: bool = Depends(verify_api_key),
+    user_id: str = Depends(get_current_user),
 ):
     """Delete a chat session and its history."""
     import persistence
     from deps import _sessions, _sessions_lock
     with _sessions_lock:
-        if session_id not in _sessions:
+        s = _sessions.get(session_id)
+        if s is None or _session_owner(s) != user_id:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Session '{session_id}' not found.")
         del _sessions[session_id]
         persistence.delete_session(session_id)

--- a/routes/feedback.py
+++ b/routes/feedback.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field, field_validator
 
 import config
 import persistence
-from deps import verify_api_key
+from deps import verify_api_key, get_current_user
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -37,13 +37,13 @@ class FeedbackResponse(BaseModel):
 @router.post("/feedback", response_model=FeedbackResponse, tags=["Feedback"])
 async def submit_feedback(
     body: FeedbackRequest,
-    authenticated: bool = Depends(verify_api_key),
+    user_id: str = Depends(get_current_user),
 ):
     """Record thumbs up/down feedback for a previously returned answer."""
     feedback_id = str(uuid.uuid4())
     persistence.save_feedback(
         feedback_id, body.query_id, body.rating, body.comment or "",
-        datetime.now(timezone.utc).isoformat(),
+        datetime.now(timezone.utc).isoformat(), user_id=user_id,
     )
     return FeedbackResponse(status="recorded", feedback_id=feedback_id)
 
@@ -52,16 +52,16 @@ async def submit_feedback(
 async def list_feedback(
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
-    authenticated: bool = Depends(verify_api_key),
+    user_id: str = Depends(get_current_user),
 ):
-    """Return feedback entries joined with their query context, newest first."""
-    return persistence.get_feedback_with_context(limit, offset)
+    """Return the caller's own feedback entries joined with query context, newest first."""
+    return persistence.get_feedback_with_context(limit, offset, user_id=user_id)
 
 
 @router.get("/feedback/stats", tags=["Feedback"])
-async def get_feedback_stats(authenticated: bool = Depends(verify_api_key)):
-    """Aggregate feedback totals and per-language approval rates."""
-    return persistence.feedback_stats()
+async def get_feedback_stats(user_id: str = Depends(get_current_user)):
+    """Aggregate the caller's feedback totals and per-language approval rates."""
+    return persistence.feedback_stats(user_id=user_id)
 
 
 class PrefsRequest(BaseModel):
@@ -79,14 +79,15 @@ def _require_enabled():
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User preferences are not enabled")
 
 
-@router.get("/prefs/{user_id}", response_model=PrefsResponse, tags=["Preferences"])
-async def get_user_prefs(user_id: str, authenticated: bool = Depends(verify_api_key)):
+@router.get("/prefs", response_model=PrefsResponse, tags=["Preferences"])
+async def get_user_prefs(user_id: str = Depends(get_current_user)):
+    """The caller's own preferences (owner derived from the API key)."""
     _require_enabled()
     return PrefsResponse(user_id=user_id, prefs=persistence.get_prefs(user_id))
 
 
-@router.put("/prefs/{user_id}", response_model=PrefsResponse, tags=["Preferences"])
-async def put_user_prefs(user_id: str, body: PrefsRequest, authenticated: bool = Depends(verify_api_key)):
+@router.put("/prefs", response_model=PrefsResponse, tags=["Preferences"])
+async def put_user_prefs(body: PrefsRequest, user_id: str = Depends(get_current_user)):
     _require_enabled()
     persistence.save_prefs(user_id, body.prefs, datetime.now(timezone.utc).isoformat())
     return PrefsResponse(user_id=user_id, prefs=body.prefs)

--- a/routes/feedback.py
+++ b/routes/feedback.py
@@ -5,7 +5,7 @@ from typing import Optional
 import logging
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, field_validator
 
 import config
@@ -46,6 +46,22 @@ async def submit_feedback(
         datetime.now(timezone.utc).isoformat(),
     )
     return FeedbackResponse(status="recorded", feedback_id=feedback_id)
+
+
+@router.get("/feedback", tags=["Feedback"])
+async def list_feedback(
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    authenticated: bool = Depends(verify_api_key),
+):
+    """Return feedback entries joined with their query context, newest first."""
+    return persistence.get_feedback_with_context(limit, offset)
+
+
+@router.get("/feedback/stats", tags=["Feedback"])
+async def get_feedback_stats(authenticated: bool = Depends(verify_api_key)):
+    """Aggregate feedback totals and per-language approval rates."""
+    return persistence.feedback_stats()
 
 
 class PrefsRequest(BaseModel):

--- a/routes/feedback.py
+++ b/routes/feedback.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field, field_validator
 
 import config
 import persistence
-from deps import verify_api_key, get_current_user
+from deps import get_current_user
 
 logger = logging.getLogger(__name__)
 router = APIRouter()

--- a/routes/ingest.py
+++ b/routes/ingest.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Optional
 import logging
 import re as _re
-import threading
 import time
 import uuid
 
@@ -15,6 +14,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 
 import config
+from cache_refresh import _post_ingest_refresh
 from deps import limiter, verify_api_key, _jobs, _jobs_lock, _update_job
 
 logger = logging.getLogger(__name__)
@@ -24,22 +24,6 @@ router = APIRouter()
 # We rely on the is_absolute() + relative_to() checks for traversal; the regex
 # only needs to reject characters that can't appear in safe filenames.
 _UNSAFE_CHARS_RE = _re.compile(r'[\x00\|;&`$<>"\'\!\*\?\{\}\[\]\\~]')
-
-
-def _post_ingest_refresh():
-    """Rebuild BM25 index (async) and invalidate retrieval/tool caches after an ingest."""
-    try:
-        import bm25_search
-        bm25_search.invalidate()
-        threading.Thread(target=bm25_search.get_or_build_index, daemon=True).start()
-    except Exception:
-        pass
-    try:
-        from cache import retrieval_cache, tool_cache
-        retrieval_cache.invalidate()
-        tool_cache.invalidate()
-    except Exception:
-        logger.warning("Failed to invalidate caches after ingestion", exc_info=True)
 
 
 def _resolve_papers_path(rel_path: str) -> Path:

--- a/routes/ingest.py
+++ b/routes/ingest.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 import logging
 import re as _re
 import time
@@ -14,6 +14,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 
 import config
+from agent.tool_executor import execute_arxiv_search, execute_open_access_search
 from cache_refresh import _post_ingest_refresh
 from deps import limiter, verify_api_key, _jobs, _jobs_lock, _update_job
 
@@ -412,6 +413,175 @@ async def reindex_document(
         paper_id=body.paper_id,
         title=title,
         processing_time=time.time() - start_time,
+    )
+
+
+class IngestURLRequest(BaseModel):
+    """Frictionless ingestion: arXiv ID, DOI, direct PDF URL, or a reading list
+    (newline-separated mix of any of the above)."""
+    url: Optional[str] = Field(None, description="Direct PDF URL.")
+    arxiv_id: Optional[str] = Field(None, description="arXiv ID, e.g. '2301.07041'.")
+    doi: Optional[str] = Field(None, description="DOI, resolved via open-access search.")
+    reading_list: Optional[str] = Field(
+        None, description="Newline-separated arXiv IDs, DOIs, and/or direct URLs."
+    )
+
+
+def _resolve_one(item: str) -> Optional[dict]:
+    """Resolve a single arXiv ID, DOI, or URL to a downloadable {url, id, title}."""
+    item = item.strip()
+    if not item:
+        return None
+    if item.startswith("http"):
+        return {"url": item, "id": item, "title": ""}
+    if item.startswith("10.") or "doi.org" in item:
+        result = execute_open_access_search(item, max_results=1)
+        passages = result.get("passages", [])
+        if passages and passages[0].get("pdf_url"):
+            return {"url": passages[0]["pdf_url"], "id": item, "title": passages[0].get("title", "")}
+        return None
+    # Assume arXiv ID
+    result = execute_arxiv_search(item, max_results=1)
+    passages = result.get("passages", [])
+    if passages and passages[0].get("pdf_url"):
+        return {"url": passages[0]["pdf_url"], "id": item, "title": passages[0].get("title", "")}
+    return None
+
+
+def _resolve_urls_to_ingest(
+    url: str = None, arxiv_id: str = None, doi: str = None, reading_list: str = None,
+) -> List[dict]:
+    """Resolve any combination of url/arxiv_id/doi/reading_list into a flat,
+    order-preserving list of {url, id, title} dicts ready for download_pdf()."""
+    resolved: List[dict] = []
+
+    if arxiv_id:
+        # arxiv_id is a bare ID, not free text — resolve directly, not via _resolve_one's sniffing.
+        result = execute_arxiv_search(arxiv_id.strip(), max_results=1)
+        passages = result.get("passages", [])
+        if passages and passages[0].get("pdf_url"):
+            resolved.append({"url": passages[0]["pdf_url"], "id": arxiv_id.strip(),
+                              "title": passages[0].get("title", "")})
+
+    if doi:
+        result = execute_open_access_search(doi.strip(), max_results=1)
+        passages = result.get("passages", [])
+        if passages and passages[0].get("pdf_url"):
+            resolved.append({"url": passages[0]["pdf_url"], "id": doi.strip(),
+                              "title": passages[0].get("title", "")})
+
+    if url:
+        resolved.append({"url": url.strip(), "id": url.strip(), "title": ""})
+
+    if reading_list:
+        for line in reading_list.strip().split("\n"):
+            item = _resolve_one(line)
+            if item:
+                resolved.append(item)
+
+    return resolved
+
+
+def _run_batch_url_ingest(job_id: str, urls_to_ingest: List[dict]):
+    """Background worker: download → ingest → refresh caches for each resolved URL.
+
+    Skips any item whose sanitized paper_id already exists in the corpus —
+    unlike /upload (409s on filename collision) or /reindex (explicit,
+    intentional overwrite), this route has no confirmation step, so silently
+    ingesting over an existing paper_id would let a crafted arxiv_id/doi/url
+    overwrite another paper's chunks with attacker-supplied content.
+    """
+    import ingest as ingest_module
+    import vector_store
+
+    from download_utils import download_pdf
+
+    start_time = time.time()
+    _update_job(job_id, status="running")
+    progress_cb = _make_progress_cb(job_id)
+    collection = vector_store.get_or_create_collection()
+    got = vector_store._chroma_call(collection.get, include=["metadatas"])
+    existing_paper_ids = {
+        (m or {}).get("paper_id", "") for m in got.get("metadatas", [])
+    } - {""}
+    successful = failed = chunks_ingested = 0
+    for i, item in enumerate(urls_to_ingest):
+        progress_cb(i, len(urls_to_ingest), f"Downloading {item['id']}")
+        paper_id = _bibtex_safe_id(item["id"])
+        if paper_id in existing_paper_ids:
+            logger.warning(f"Skipping {item['id']}: paper_id '{paper_id}' already exists")
+            failed += 1
+            continue
+        path = download_pdf(item["url"])
+        if not path:
+            failed += 1
+            continue
+        try:
+            n_chunks, _ = ingest_module.ingest_pdf(
+                path, paper_id=paper_id,
+                metadata={"title": item.get("title", "")},
+            )
+            chunks_ingested += n_chunks
+            successful += 1
+            existing_paper_ids.add(paper_id)  # a reading_list can carry duplicate ids too
+        except Exception as e:
+            logger.warning(f"Ingest failed for {item['id']}: {e}")
+            failed += 1
+        finally:
+            try:
+                Path(path).unlink()
+            except OSError:
+                pass
+
+    if successful:
+        _post_ingest_refresh()
+
+    status_value = "partial" if failed and successful else ("failed" if failed else "success")
+    _update_job(
+        job_id, status=status_value, total_files=len(urls_to_ingest),
+        successful=successful, failed=failed, chunks_ingested=chunks_ingested,
+        processing_time=time.time() - start_time,
+        completed_at=datetime.now(timezone.utc).isoformat(),
+    )
+    logger.info(f"URL ingest job {job_id} finished: {status_value}")
+
+
+def _bibtex_safe_id(raw_id: str) -> str:
+    """arXiv IDs/DOIs/URLs can contain '/', '.', ':' — none of which are safe as a
+    ChromaDB paper_id used in file-adjacent contexts. Keep it short and filesystem-safe."""
+    return _re.sub(r"[^A-Za-z0-9_-]", "_", raw_id)[:100] or "paper"
+
+
+@router.post("/ingest/from-url", response_model=IngestJobResponse, status_code=202, tags=["Ingest"])
+@limiter.limit("5/minute")
+async def ingest_from_url(
+    request: Request,
+    body: IngestURLRequest,
+    background_tasks: BackgroundTasks,
+    authenticated: bool = Depends(verify_api_key),
+):
+    """Ingest paper(s) by arXiv ID, DOI, direct PDF URL, or a reading list of any mix."""
+    urls_to_ingest = await run_in_threadpool(
+        _resolve_urls_to_ingest, body.url, body.arxiv_id, body.doi, body.reading_list
+    )
+    if not urls_to_ingest:
+        raise HTTPException(status_code=400, detail="Could not resolve any URLs from the provided input")
+
+    job_id = str(uuid.uuid4())
+    with _jobs_lock:
+        _jobs[job_id] = {
+            "job_id": job_id, "status": "pending",
+            "submitted_at": datetime.now(timezone.utc).isoformat(),
+            "completed_at": None, "total_files": len(urls_to_ingest),
+            "successful": None, "failed": None, "chunks_ingested": None,
+            "processing_time": None, "error": None,
+            "progress_current": 0, "progress_total": len(urls_to_ingest),
+            "progress_message": "Queued",
+        }
+    background_tasks.add_task(_run_batch_url_ingest, job_id, urls_to_ingest)
+    return IngestJobResponse(
+        job_id=job_id, status="pending",
+        message=f"Resolved {len(urls_to_ingest)} paper(s). Poll /ingest/status/{{job_id}} for progress.",
     )
 
 

--- a/routes/ingest.py
+++ b/routes/ingest.py
@@ -124,6 +124,32 @@ class UploadResponse(BaseModel):
     message: str
 
 
+@router.get("/ingest/health", tags=["Ingest"])
+async def ingest_health(authenticated: bool = Depends(verify_api_key)):
+    """Per-paper indexed chunk counts, so a corrupted/failed PDF (0 chunks)
+    doesn't silently vanish from the corpus without anyone noticing."""
+    import vector_store
+    chunk_counts = await run_in_threadpool(vector_store.get_paper_chunk_counts)
+
+    papers = []
+    for pdf_file in sorted(config.PAPERS_DIR.glob("*.pdf")):
+        paper_id = pdf_file.stem
+        chunks = chunk_counts.get(paper_id, 0)
+        papers.append({
+            "paper_id": paper_id,
+            "filename": pdf_file.name,
+            "chunks": chunks,
+            "status": "indexed" if chunks > 0 else "failed",
+        })
+
+    return {
+        "paper_count": len(papers),
+        "chunk_count": sum(p["chunks"] for p in papers),
+        "failed_count": sum(1 for p in papers if p["status"] == "failed"),
+        "papers": papers,
+    }
+
+
 @router.post("/ingest", response_model=IngestResponse, tags=["Management"])
 @limiter.limit("5/minute")
 async def ingest_document(

--- a/routes/management.py
+++ b/routes/management.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, Field, field_validator
 
 import config
 import lang_utils
+import persistence
 import rag
 from deps import verify_api_key, verify_admin_key
 
@@ -519,6 +520,14 @@ async def corpus_map(authenticated: bool = Depends(verify_api_key)):
     timeline = [{"year": y, "count": c} for y, c in sorted(year_counts.items())]
 
     return {"clusters": clusters, "timeline": timeline}
+
+
+@router.get("/graph", tags=["Graph"])
+async def get_graph(paper_id: str = None, authenticated: bool = Depends(verify_api_key)):
+    """Knowledge graph edges (co-citation + contradiction). All edges, or one paper's."""
+    if paper_id:
+        return {"edges": persistence.get_paper_edges(paper_id)}
+    return {"edges": persistence.get_all_edges()}
 
 
 @router.get("/stats", tags=["Management"])

--- a/routes/management.py
+++ b/routes/management.py
@@ -1,7 +1,9 @@
 """Routes: /search, /papers, /papers/{id}, /purge/*, /stats, /cache/*."""
 
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import List, Optional
+import json
 import logging
 import re
 import threading
@@ -16,6 +18,8 @@ import config
 import lang_utils
 import rag
 from deps import verify_api_key, verify_admin_key
+
+_EVAL_REPORT_PATH = Path(__file__).resolve().parent.parent / "docs" / "Eval" / "eval_report.json"
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -432,6 +436,14 @@ async def clear_caches(authenticated: bool = Depends(verify_api_key)):
     retrieval_cache.invalidate()
     tool_cache.invalidate()
     return {"status": "cleared"}
+
+
+@router.get("/quality", tags=["Management"])
+async def get_quality_metrics(authenticated: bool = Depends(verify_api_key)):
+    """Return the latest retrieval/generation eval metrics (docs/Eval/evaluate.py)."""
+    if _EVAL_REPORT_PATH.exists():
+        return json.loads(_EVAL_REPORT_PATH.read_text(encoding="utf-8"))
+    return {"error": "No eval report available"}
 
 
 @router.get("/stats", tags=["Management"])

--- a/routes/management.py
+++ b/routes/management.py
@@ -1,5 +1,6 @@
 """Routes: /search, /papers, /papers/{id}, /purge/*, /stats, /cache/*."""
 
+from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
@@ -9,6 +10,7 @@ import re
 import threading
 import time
 
+import numpy as np
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import PlainTextResponse
@@ -444,6 +446,79 @@ async def get_quality_metrics(authenticated: bool = Depends(verify_api_key)):
     if _EVAL_REPORT_PATH.exists():
         return json.loads(_EVAL_REPORT_PATH.read_text(encoding="utf-8"))
     return {"error": "No eval report available"}
+
+
+def _kmeans(X: np.ndarray, k: int, iters: int = 20, seed: int = 42) -> np.ndarray:
+    """Minimal Lloyd's-algorithm k-means; returns a cluster label per row.
+
+    # ponytail: no k-means++ init, no empty-cluster reseeding -- fine for a
+    # corpus-overview feature (approximate topic grouping, not precision
+    # clustering). Pull in scikit-learn if this ever needs real convergence
+    # guarantees; not worth the dependency for "roughly group my papers".
+    """
+    rng = np.random.default_rng(seed)
+    n = X.shape[0]
+    k = min(k, n)
+    centroids = X[rng.choice(n, size=k, replace=False)].copy()
+    labels = np.zeros(n, dtype=int)
+    x_sq = (X ** 2).sum(axis=1)
+    for _ in range(iters):
+        c_sq = (centroids ** 2).sum(axis=1)
+        dists = x_sq[:, None] + c_sq[None, :] - 2 * X @ centroids.T
+        new_labels = dists.argmin(axis=1)
+        if np.array_equal(new_labels, labels):
+            break
+        labels = new_labels
+        for i in range(k):
+            mask = labels == i
+            if mask.any():
+                centroids[i] = X[mask].mean(axis=0)
+    return labels
+
+
+@router.get("/corpus/map", tags=["Corpus"])
+async def corpus_map(authenticated: bool = Depends(verify_api_key)):
+    """Topic clusters + publication-year timeline, so hundreds of ingested
+    papers become a browsable overview instead of just a chunk count."""
+    import vector_store
+
+    collection = await run_in_threadpool(vector_store.get_or_create_collection)
+    got = await run_in_threadpool(vector_store._chroma_call, collection.get, include=["embeddings", "metadatas"])
+    embeddings = got.get("embeddings")
+    metadatas = got.get("metadatas") or []
+
+    if embeddings is None or len(embeddings) == 0:
+        return {"clusters": [], "timeline": []}
+
+    X = np.asarray(embeddings, dtype=np.float32)
+    n_clusters = min(10, len(X) // 3 + 1)
+    labels = await run_in_threadpool(_kmeans, X, n_clusters)
+
+    clusters = []
+    for i in range(int(labels.max()) + 1):
+        mask = labels == i
+        cluster_metas = [m for m, keep in zip(metadatas, mask) if keep]
+        titles, years, seen_titles = [], [], []
+        for m in cluster_metas:
+            title = (m or {}).get("title", "Unknown")
+            titles.append(title)
+            if title not in seen_titles:
+                seen_titles.append(title)
+            year = (m or {}).get("year")
+            if year:
+                years.append(year)
+        clusters.append({
+            "id": i,
+            "chunk_count": int(mask.sum()),
+            "paper_count": len(seen_titles),
+            "sample_titles": seen_titles[:3],
+            "year_range": f"{min(years)}-{max(years)}" if years else "unknown",
+        })
+
+    year_counts = Counter((m or {}).get("year") or "unknown" for m in metadatas)
+    timeline = [{"year": y, "count": c} for y, c in sorted(year_counts.items())]
+
+    return {"clusters": clusters, "timeline": timeline}
 
 
 @router.get("/stats", tags=["Management"])

--- a/routes/management.py
+++ b/routes/management.py
@@ -56,6 +56,7 @@ class SearchResponse(BaseModel):
 
 class PaperInfo(BaseModel):
     """Information about an uploaded paper."""
+    paper_id: str
     filename: str
     size_bytes: int
     size_mb: float
@@ -270,6 +271,7 @@ def list_papers(authenticated: bool = Depends(verify_api_key)):
         for pdf_file in config.PAPERS_DIR.glob("*.pdf"):
             size = pdf_file.stat().st_size
             papers.append(PaperInfo(
+                paper_id=pdf_file.stem,
                 filename=pdf_file.name,
                 size_bytes=size,
                 size_mb=round(size / (1024 * 1024), 2)

--- a/routes/management.py
+++ b/routes/management.py
@@ -213,6 +213,55 @@ async def export_search_results(
     return "\n\n".join(entries)
 
 
+class BibtexSource(BaseModel):
+    """One cited source, as carried by a QueryResponse/AgentQueryResponse citation."""
+    title: str = Field(..., min_length=1)
+    authors: str = ""
+    year: str = ""
+
+
+class ExportBibtexRequest(BaseModel):
+    sources: List[BibtexSource] = Field(..., min_length=1)
+
+
+def _cite_key(authors: str, year: str, index: int) -> str:
+    """First-author-surname + year, e.g. 'Smith2020'; falls back to 'refN' when
+    authors/year are unknown (common for Standard RAG citations, which don't
+    carry bibliographic metadata)."""
+    first_author_words = (authors or "").split(",")[0].split()
+    surname = re.sub(r"[^A-Za-z0-9]", "", first_author_words[-1]) if first_author_words else ""
+    yr = re.sub(r"[^0-9]", "", year or "")
+    if surname:
+        return f"{surname}{yr}" if yr else surname
+    return f"ref{index + 1}"
+
+
+@router.post("/export/bibtex", response_class=PlainTextResponse, tags=["Export"])
+async def export_bibtex(
+    body: ExportBibtexRequest,
+    authenticated: bool = Depends(verify_api_key),
+):
+    """Export a generated answer/report's cited sources as BibTeX entries."""
+    seen_keys: dict = {}
+    entries = []
+    for i, src in enumerate(body.sources):
+        base_key = _cite_key(src.authors, src.year, i)
+        n = seen_keys.get(base_key, 0)
+        seen_keys[base_key] = n + 1
+        # ponytail: a-z suffixes only, wraps past 26 dupes on identical author+year
+        # for one export — switch to aa/ab if that ever bites.
+        key = base_key if n == 0 else f"{base_key}{chr(ord('a') + n - 1)}"
+
+        fields = [f"  title = {{{_bibtex_escape(src.title)}}}"]
+        if src.authors:
+            fields.append(f"  author = {{{_bibtex_escape(src.authors)}}}")
+        if src.year:
+            fields.append(f"  year = {{{_bibtex_escape(src.year)}}}")
+        entries.append(f"@article{{{key},\n" + ",\n".join(fields) + "\n}")
+
+    return "\n\n".join(entries)
+
+
 @router.get("/papers", response_model=List[PaperInfo], tags=["Management"])
 def list_papers(authenticated: bool = Depends(verify_api_key)):
     """List all PDF files in the papers directory."""

--- a/routes/query.py
+++ b/routes/query.py
@@ -33,6 +33,30 @@ def build_paper_filter(paper_ids: Optional[List[str]]) -> Optional[Dict]:
     return {"paper_id": {"$in": ids}}
 
 
+def build_tags_filter(tags: Optional[str]) -> Optional[Dict]:
+    """Parse comma-separated tags into a rag.retrieve_context post-filter sentinel, or None.
+
+    Not a ChromaDB where-clause: PATCH /papers stores tags as one unsplit
+    string, so a native $in match against split tag names would never equal
+    the stored value for any paper with more than one tag. rag.retrieve_context
+    (via rag._extract_tags_post_filter) pulls this sentinel back out and
+    applies it as a Python-side post-filter instead.
+    """
+    tag_list = [t.strip() for t in (tags or "").split(",") if t.strip()]
+    if not tag_list:
+        return None
+    import rag
+    return {rag._TAGS_SENTINEL: tag_list}
+
+
+def combine_filters(*filters: Optional[Dict]) -> Optional[Dict]:
+    """AND together any number of ChromaDB filters, dropping the None ones."""
+    clauses = [f for f in filters if f]
+    if not clauses:
+        return None
+    return clauses[0] if len(clauses) == 1 else {"$and": clauses}
+
+
 class QueryRequest(BaseModel):
     """Request model for question answering."""
     question: str = Field(..., min_length=1, max_length=1000, description="User question in any language")
@@ -41,6 +65,7 @@ class QueryRequest(BaseModel):
     paper_ids: Optional[List[str]] = Field(
         None, description="Restrict retrieval to these paper_ids (PDF filename stems). Omit for whole corpus."
     )
+    tags: Optional[str] = Field(None, description="Comma-separated tags to filter retrieval.")
     model: Optional[str] = Field(None, description="LLM model id from the /models allowlist. Omit for default.")
     provider: Optional[str] = Field(None, description="LLM provider override (gemini|openrouter). Usually inferred from model.")
 
@@ -197,7 +222,7 @@ async def query_question(
             user_query=body.question,
             strategy=body.strategy,
             top_k=top_k,
-            filter_dict=build_paper_filter(body.paper_ids),
+            filter_dict=combine_filters(build_paper_filter(body.paper_ids), build_tags_filter(body.tags)),
             model=body.model,
             provider=body.provider,
         )
@@ -259,7 +284,7 @@ async def query_stream(
         top_k = max(1, min(top_k, 20))
 
     prepared = await run_in_threadpool(rag.prepare_query_for_stream, body.question, body.strategy, top_k,
-                                       build_paper_filter(body.paper_ids))
+                                       combine_filters(build_paper_filter(body.paper_ids), build_tags_filter(body.tags)))
     query_id = str(uuid.uuid4())
 
     if prepared["chunks_used"] == 0:

--- a/routes/query.py
+++ b/routes/query.py
@@ -6,7 +6,7 @@ import json
 import logging
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import FileResponse, StreamingResponse
 from pydantic import BaseModel, Field, field_validator
@@ -15,7 +15,7 @@ import config
 import persistence
 import rag
 from agent.nodes.finalizer import citation_coverage
-from deps import STATIC_DIR, limiter, verify_api_key
+from deps import STATIC_DIR, limiter, verify_api_key, _jobs, _jobs_lock, _update_job
 from sse_utils import sse_stream
 
 logger = logging.getLogger(__name__)
@@ -318,3 +318,70 @@ async def query_stream(
                    model=body.model, provider=body.provider),
         media_type="text/event-stream",
     )
+
+
+class CompareRequest(BaseModel):
+    """Request model for a cross-paper comparison table."""
+    paper_ids: List[str] = Field(..., min_length=2, description="Paper IDs to compare (2 or more)")
+    dimensions: List[str] = Field(..., min_length=1, description="Dimensions to compare on")
+    model: Optional[str] = Field(None, description="LLM model id from the /models allowlist. Omit for default.")
+
+
+class CompareJobResponse(BaseModel):
+    job_id: str
+    status: str
+    message: str
+
+
+def _run_compare_job(job_id: str, paper_ids: List[str], dimensions: List[str], model: Optional[str]):
+    """Background worker: N papers x M dimensions is N*M LLM calls, so this
+    runs as a job rather than blocking the request (same pattern as bulk ingest)."""
+    _update_job(job_id, status="running")
+    try:
+        result = rag.compare_papers(paper_ids, dimensions, model)
+        _update_job(
+            job_id, status="success",
+            dimensions=result["dimensions"], matrix=result["matrix"],
+            completed_at=datetime.now(timezone.utc).isoformat(),
+        )
+    except Exception as e:
+        logger.error(f"Compare job {job_id} failed: {e}", exc_info=True)
+        _update_job(
+            job_id, status="failed", error=str(e),
+            completed_at=datetime.now(timezone.utc).isoformat(),
+        )
+
+
+@router.post("/compare", response_model=CompareJobResponse, status_code=202, tags=["Comparison"])
+@limiter.limit("5/minute")
+async def compare_papers_endpoint(
+    request: Request,
+    body: CompareRequest,
+    background_tasks: BackgroundTasks,
+    authenticated: bool = Depends(verify_api_key),
+):
+    """Generate a papers x dimensions comparison table across the corpus.
+
+    Returns 202 with a job_id immediately; poll GET /compare/status/{job_id}.
+    """
+    job_id = str(uuid.uuid4())
+    with _jobs_lock:
+        _jobs[job_id] = {
+            "job_id": job_id, "status": "pending",
+            "submitted_at": datetime.now(timezone.utc).isoformat(),
+            "completed_at": None, "dimensions": None, "matrix": None, "error": None,
+        }
+    background_tasks.add_task(_run_compare_job, job_id, body.paper_ids, body.dimensions, body.model)
+    return CompareJobResponse(
+        job_id=job_id, status="pending",
+        message="Comparison started. Poll /compare/status/{job_id} for the result.",
+    )
+
+
+@router.get("/compare/status/{job_id}", tags=["Comparison"])
+async def get_compare_status(job_id: str, authenticated: bool = Depends(verify_api_key)):
+    with _jobs_lock:
+        job = _jobs.get(job_id)
+    if job is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Job '{job_id}' not found.")
+    return job

--- a/routes/query.py
+++ b/routes/query.py
@@ -84,6 +84,8 @@ class QueryResponse(BaseModel):
     citations: List[Citation]
     processing_time: float
     timestamp: str
+    confidence: float = 0.0
+    evidence: List[dict] = []
 
 
 class HealthResponse(BaseModel):
@@ -226,7 +228,9 @@ async def query_question(
             chunks_used=result['chunks_used'],
             citations=citations,
             processing_time=processing_time,
-            timestamp=datetime.now(timezone.utc).isoformat()
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            confidence=result.get('answer_confidence', 0.0),
+            evidence=result.get('faithfulness', []),
         )
 
     except ValueError as e:

--- a/routes/query.py
+++ b/routes/query.py
@@ -15,7 +15,7 @@ import config
 import persistence
 import rag
 from agent.nodes.finalizer import citation_coverage
-from deps import STATIC_DIR, limiter, verify_api_key, _jobs, _jobs_lock, _update_job
+from deps import STATIC_DIR, limiter, verify_api_key, get_current_user, _jobs, _jobs_lock, _update_job
 from sse_utils import sse_stream
 
 logger = logging.getLogger(__name__)
@@ -200,7 +200,7 @@ async def health_check(deep: bool = False):
 async def query_question(
     request: Request,
     body: QueryRequest,
-    authenticated: bool = Depends(verify_api_key)
+    user_id: str = Depends(get_current_user),
 ):
     """
     Answer a question in any language using the RAG system.
@@ -254,7 +254,7 @@ async def query_question(
                 mode=f"standard_{body.strategy}", model=body.model or "default",
                 language=result['language'], confidence=0.0,
                 coverage=citation_coverage(result['answer']),
-                created_at=datetime.now(timezone.utc).isoformat(),
+                created_at=datetime.now(timezone.utc).isoformat(), user_id=user_id,
             )
         except Exception:
             logger.warning("Failed to log query for feedback correlation", exc_info=True)

--- a/routes/query.py
+++ b/routes/query.py
@@ -12,7 +12,9 @@ from fastapi.responses import FileResponse, StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 
 import config
+import persistence
 import rag
+from agent.nodes.finalizer import citation_coverage
 from deps import STATIC_DIR, limiter, verify_api_key
 from sse_utils import sse_stream
 
@@ -218,8 +220,20 @@ async def query_question(
             for cite in result['citations']
         ]
 
+        query_id = str(uuid.uuid4())
+        try:
+            persistence.log_query(
+                query_id=query_id, question=body.question, answer=result['answer'],
+                mode=f"standard_{body.strategy}", model=body.model or "default",
+                language=result['language'], confidence=0.0,
+                coverage=citation_coverage(result['answer']),
+                created_at=datetime.now(timezone.utc).isoformat(),
+            )
+        except Exception:
+            logger.warning("Failed to log query for feedback correlation", exc_info=True)
+
         return QueryResponse(
-            query_id=str(uuid.uuid4()),
+            query_id=query_id,
             answer=result['answer'],
             language=result['language'],
             language_name=result['language_name'],

--- a/routes/report.py
+++ b/routes/report.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response
 from pydantic import BaseModel, Field
 
 import config
+import persistence
 from deps import verify_api_key, _jobs, _jobs_lock, _update_job
 
 logger = logging.getLogger(__name__)
@@ -72,13 +73,19 @@ def _run_report_job(job_id: str, topic: str, language: str):
     _update_job(job_id, status="running")
     try:
         result = report_runner.run_report(topic, language, progress_cb=_make_progress_cb(job_id))
+        completed_at = datetime.now(timezone.utc).isoformat()
         _update_job(
             job_id,
             status="success",
             sections=result["sections"],
             citation_count=result["citation_count"],
             markdown=result["markdown"],
-            completed_at=datetime.now(timezone.utc).isoformat(),
+            completed_at=completed_at,
+        )
+        persistence.save_report(
+            report_id=job_id, watch_id="", topic=topic, language=language,
+            markdown=result["markdown"], citation_count=result["citation_count"],
+            created_at=completed_at,
         )
         logger.info(f"[Report] job {job_id} finished ({len(result['sections'])} sections)")
     except Exception as e:
@@ -135,3 +142,22 @@ async def download_report(job_id: str, authenticated: bool = Depends(verify_api_
         content=job["markdown"], media_type="text/markdown",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
+
+
+@router.get("/reports", tags=["Report"])
+async def list_persisted_reports(watch_id: str = None, authenticated: bool = Depends(verify_api_key)):
+    """List durably-stored reports (survives restart), newest first.
+
+    Distinct from GET /report/status/{job_id}: that's the in-memory job store
+    for a report still being generated; this is the persisted artifact,
+    including watch-owned living reviews that get regenerated in place.
+    """
+    return persistence.list_reports(watch_id)
+
+
+@router.get("/reports/{report_id}", tags=["Report"])
+async def get_persisted_report(report_id: str, authenticated: bool = Depends(verify_api_key)):
+    report = persistence.get_report(report_id)
+    if report is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Report '{report_id}' not found.")
+    return report

--- a/routes/report.py
+++ b/routes/report.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, Field
 
 import config
 import persistence
-from deps import verify_api_key, _jobs, _jobs_lock, _update_job
+from deps import verify_api_key, get_current_user, _jobs, _jobs_lock, _update_job
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -67,7 +67,7 @@ def _make_progress_cb(job_id: str):
     return _cb
 
 
-def _run_report_job(job_id: str, topic: str, language: str):
+def _run_report_job(job_id: str, topic: str, language: str, user_id: str):
     """Background worker: build the report and store the Markdown on the job."""
     import report_runner
     _update_job(job_id, status="running")
@@ -85,7 +85,7 @@ def _run_report_job(job_id: str, topic: str, language: str):
         persistence.save_report(
             report_id=job_id, watch_id="", topic=topic, language=language,
             markdown=result["markdown"], citation_count=result["citation_count"],
-            created_at=completed_at,
+            created_at=completed_at, user_id=user_id,
         )
         logger.info(f"[Report] job {job_id} finished ({len(result['sections'])} sections)")
     except Exception as e:
@@ -96,7 +96,7 @@ def _run_report_job(job_id: str, topic: str, language: str):
 
 @router.post("/report", response_model=ReportJobResponse, status_code=202, tags=["Report"])
 async def create_report(body: ReportRequest, background_tasks: BackgroundTasks,
-                        authenticated: bool = Depends(verify_api_key)):
+                        user_id: str = Depends(get_current_user)):
     """Start a literature-review report job. Returns 202 with a job_id to poll."""
     _require_enabled()
     job_id = str(uuid.uuid4())
@@ -108,7 +108,7 @@ async def create_report(body: ReportRequest, background_tasks: BackgroundTasks,
             "submitted_at": datetime.now(timezone.utc).isoformat(), "completed_at": None,
             "progress_current": 0, "progress_total": None, "progress_message": "Queued",
         }
-    background_tasks.add_task(_run_report_job, job_id, body.topic, body.language)
+    background_tasks.add_task(_run_report_job, job_id, body.topic, body.language, user_id)
     logger.info(f"[Report] job {job_id} queued topic={body.topic!r}")
     return ReportJobResponse(job_id=job_id, status="pending",
                              message="Report started. Poll /report/status/{job_id}.")
@@ -145,19 +145,19 @@ async def download_report(job_id: str, authenticated: bool = Depends(verify_api_
 
 
 @router.get("/reports", tags=["Report"])
-async def list_persisted_reports(watch_id: str = None, authenticated: bool = Depends(verify_api_key)):
-    """List durably-stored reports (survives restart), newest first.
+async def list_persisted_reports(watch_id: str = None, user_id: str = Depends(get_current_user)):
+    """List the caller's durably-stored reports (survives restart), newest first.
 
     Distinct from GET /report/status/{job_id}: that's the in-memory job store
     for a report still being generated; this is the persisted artifact,
     including watch-owned living reviews that get regenerated in place.
     """
-    return persistence.list_reports(watch_id)
+    return persistence.list_reports(watch_id, user_id=user_id)
 
 
 @router.get("/reports/{report_id}", tags=["Report"])
-async def get_persisted_report(report_id: str, authenticated: bool = Depends(verify_api_key)):
+async def get_persisted_report(report_id: str, user_id: str = Depends(get_current_user)):
     report = persistence.get_report(report_id)
-    if report is None:
+    if report is None or report.get("user_id") != user_id:  # 404 (not 403) on another user's report
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Report '{report_id}' not found.")
     return report

--- a/routes/watch.py
+++ b/routes/watch.py
@@ -18,10 +18,19 @@ from pydantic import BaseModel, Field, field_validator
 
 import config
 import persistence
-from deps import verify_api_key
+from deps import verify_api_key, get_current_user
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+def _owned_or_404(watch_id: str, user_id: str) -> dict:
+    """Load a watch and 404 unless it belongs to user_id (404, not 403 — don't
+    leak that a watch exists for someone else)."""
+    w = persistence.get_watch(watch_id)
+    if w is None or (w.get("user_id") or config.DEFAULT_USER_ID) != user_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Watch not found")
+    return w
 
 _CADENCES = {"daily": timedelta(days=1), "weekly": timedelta(days=7), "monthly": timedelta(days=30)}
 
@@ -37,7 +46,6 @@ def _next_run_from(now: datetime, cadence: str) -> str:
 
 
 class WatchCreateRequest(BaseModel):
-    user_id: str = Field(..., min_length=1)
     topic: str = Field(..., min_length=1, max_length=500)
     language: str = Field("en", min_length=2, max_length=8)
     cadence: Optional[str] = None  # defaults to config.WATCH_DEFAULT_CADENCE
@@ -73,7 +81,7 @@ def _to_response(w: dict) -> WatchResponse:
 
 
 @router.post("/watch", response_model=WatchResponse, tags=["Watch"])
-async def create_watch(body: WatchCreateRequest, authenticated: bool = Depends(verify_api_key)):
+async def create_watch(body: WatchCreateRequest, user_id: str = Depends(get_current_user)):
     """Register a topic watch. Runs on POST /watch/{id}/run (or the schedule loop)."""
     _require_enabled()
     now = datetime.now(timezone.utc)
@@ -82,7 +90,7 @@ async def create_watch(body: WatchCreateRequest, authenticated: bool = Depends(v
         cadence = "weekly"
     watch = {
         "id": str(uuid.uuid4()),
-        "user_id": body.user_id,
+        "user_id": user_id,
         "topic": body.topic,
         "language": body.language,
         "cadence": cadence,
@@ -98,28 +106,26 @@ async def create_watch(body: WatchCreateRequest, authenticated: bool = Depends(v
 
 
 @router.get("/watch", response_model=list[WatchResponse], tags=["Watch"])
-async def list_watches(user_id: Optional[str] = None, authenticated: bool = Depends(verify_api_key)):
-    """List all watches, or just one user's when user_id is supplied."""
+async def list_watches(user_id: str = Depends(get_current_user)):
+    """List the caller's own watches (owner derived from the API key)."""
     _require_enabled()
     return [_to_response(w) for w in persistence.list_watches(user_id)]
 
 
 @router.get("/watch/{watch_id}", response_model=WatchResponse, tags=["Watch"])
-async def get_watch(watch_id: str, authenticated: bool = Depends(verify_api_key)):
+async def get_watch(watch_id: str, user_id: str = Depends(get_current_user)):
     _require_enabled()
-    w = persistence.get_watch(watch_id)
-    if w is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Watch not found")
-    return _to_response(w)
+    return _to_response(_owned_or_404(watch_id, user_id))
 
 
 @router.post("/watch/{watch_id}/run", tags=["Watch"])
-async def run_watch_now(watch_id: str, authenticated: bool = Depends(verify_api_key)):
+async def run_watch_now(watch_id: str, user_id: str = Depends(get_current_user)):
     """Run a watch immediately: search the topic, ingest new papers, refresh the digest.
 
     Synchronous — ingest blocks, so it runs in a threadpool to keep the event loop free.
     """
     _require_enabled()
+    _owned_or_404(watch_id, user_id)  # ownership gate before doing any work
     import watch_runner  # lazy: keeps arxiv/ingest imports off the request-path cold start
     try:
         return await run_in_threadpool(watch_runner.run_watch, watch_id)
@@ -128,19 +134,16 @@ async def run_watch_now(watch_id: str, authenticated: bool = Depends(verify_api_
 
 
 @router.get("/watch/{watch_id}/digest", tags=["Watch"])
-async def get_watch_digest(watch_id: str, authenticated: bool = Depends(verify_api_key)):
+async def get_watch_digest(watch_id: str, user_id: str = Depends(get_current_user)):
     """Return the watch's latest stored digest (persists between runs)."""
     _require_enabled()
-    w = persistence.get_watch(watch_id)
-    if w is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Watch not found")
+    w = _owned_or_404(watch_id, user_id)
     return {"watch_id": watch_id, "digest": w.get("latest_digest"), "last_run": w.get("last_run")}
 
 
 @router.delete("/watch/{watch_id}", tags=["Watch"])
-async def delete_watch(watch_id: str, authenticated: bool = Depends(verify_api_key)):
+async def delete_watch(watch_id: str, user_id: str = Depends(get_current_user)):
     _require_enabled()
-    if persistence.get_watch(watch_id) is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Watch not found")
+    _owned_or_404(watch_id, user_id)
     persistence.delete_watch(watch_id)
     return {"status": "deleted", "id": watch_id}

--- a/routes/watch.py
+++ b/routes/watch.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, Field, field_validator
 
 import config
 import persistence
-from deps import verify_api_key, get_current_user
+from deps import get_current_user
 
 logger = logging.getLogger(__name__)
 router = APIRouter()

--- a/static/index.html
+++ b/static/index.html
@@ -551,6 +551,7 @@
         <button class="sfooter-btn" onclick="showHistoryModal()">🕘 Chat History</button>
         <button class="sfooter-btn" onclick="showWatchModal()">📡 Topic Watches</button>
         <button class="sfooter-btn" onclick="showReportModal()">📄 Lit Review</button>
+        <button class="sfooter-btn" onclick="showHealthModal()">🩺 Ingestion Health</button>
         <button class="sfooter-btn danger" onclick="showPurgeModal('papers')">🗑 Delete All Papers</button>
         <button class="sfooter-btn danger" onclick="showPurgeModal('database')">⚠ Clear Vector Database</button>
     </div>
@@ -703,6 +704,19 @@
         <div id="reportStatus" style="margin-top:1.1rem"></div>
         <div class="modal-actions">
             <button class="modal-btn" onclick="hideReportModal()">Close</button>
+        </div>
+    </div>
+</div>
+
+<div class="overlay" id="healthOverlay">
+    <div class="modal" style="max-width:560px">
+        <h3>🩺 Ingestion Health</h3>
+        <p>Per-paper indexed chunk counts. A paper with 0 chunks failed to index — re-ingest it in place.</p>
+        <div id="healthSummary" style="margin-top:.6rem;font-size:.8rem;color:var(--text-3)"></div>
+        <div id="healthList" style="margin-top:.8rem;max-height:50vh;overflow-y:auto"></div>
+        <div class="modal-actions">
+            <button class="modal-btn" onclick="loadIngestHealth()">Refresh</button>
+            <button class="modal-btn" onclick="hideHealthModal()">Close</button>
         </div>
     </div>
 </div>
@@ -1486,6 +1500,44 @@ async function viewDigest(id, btn){
 let reportPoll=null;
 function showReportModal(){ document.getElementById('reportOverlay').classList.add('active'); }
 function hideReportModal(){ document.getElementById('reportOverlay').classList.remove('active'); if(reportPoll){clearInterval(reportPoll);reportPoll=null;} }
+
+// ── INGESTION HEALTH ───────────────────────────────────────────
+function showHealthModal(){ document.getElementById('healthOverlay').classList.add('active'); loadIngestHealth(); }
+function hideHealthModal(){ document.getElementById('healthOverlay').classList.remove('active'); }
+
+async function loadIngestHealth(){
+    const summary=document.getElementById('healthSummary');
+    const list=document.getElementById('healthList');
+    summary.textContent=''; list.innerHTML='<div style="color:var(--text-3);font-size:.82rem;padding:.5rem 0">Loading…</div>';
+    try{
+        const r=await fetch(`${API}/ingest/health`,{headers:authHeaders()});
+        const d=await r.json();
+        if(!r.ok) throw new Error(formatError(d)||'Failed to load ingestion health');
+        summary.textContent=`${d.paper_count} papers · ${d.chunk_count} chunks · ${d.failed_count} failed`;
+        if(!d.papers.length){ list.innerHTML='<div style="color:var(--text-3);font-size:.82rem;padding:.5rem 0">No PDFs in the papers directory.</div>'; return; }
+        list.innerHTML=d.papers.map(p=>{
+            const ok=p.status==='indexed';
+            return `<div style="border:1px solid var(--border);border-radius:8px;padding:.55rem .7rem;margin-bottom:.45rem;display:flex;justify-content:space-between;gap:.6rem;align-items:center">
+                <div style="min-width:0">
+                    <div style="font-weight:600;font-size:.82rem;color:var(--text-1);word-break:break-word">${esc(p.filename)}</div>
+                    <div style="font-size:.72rem;color:${ok?'var(--text-3)':'#ef4444'}">${ok?`${p.chunks} chunks`:'Failed — 0 chunks indexed'}</div>
+                </div>
+                <button class="modal-btn" style="padding:.25rem .55rem;font-size:.75rem;flex-shrink:0" onclick="reindexPaper('${esc(p.paper_id)}',this)">Re-ingest</button>
+            </div>`;
+        }).join('');
+    }catch(e){ list.innerHTML=`<div style="color:#ef4444;font-size:.82rem;padding:.5rem 0">${esc(e.message)}</div>`; }
+}
+
+async function reindexPaper(paperId,btn){
+    btn.disabled=true; btn.textContent='Re-ingesting…';
+    try{
+        const r=await fetch(`${API}/ingest/reindex`,{method:'POST',headers:authHeaders({'Content-Type':'application/json'}),body:JSON.stringify({paper_id:paperId})});
+        const d=await r.json();
+        if(!r.ok) throw new Error(formatError(d)||'Re-ingest failed');
+        showToast(`Re-ingested ${paperId}: ${d.chunks_ingested} chunks`,'success');
+        loadIngestHealth();
+    }catch(e){ showToast(e.message,'error'); btn.disabled=false; btn.textContent='Re-ingest'; }
+}
 
 async function generateReport(){
     const topic=document.getElementById('reportTopic').value.trim();

--- a/static/index.html
+++ b/static/index.html
@@ -982,6 +982,7 @@
         <button class="sfooter-btn" onclick="showReportModal()">📄 Lit Review</button>
         <button class="sfooter-btn" onclick="showHealthModal()">🩺 Ingestion Health</button>
         <button class="sfooter-btn" onclick="showCompareModal()">🔀 Compare Papers</button>
+        <button class="sfooter-btn" onclick="showMapModal()">🗺 Library Map</button>
         <button class="sfooter-btn danger" onclick="showPurgeModal('papers')">🗑 Delete All Papers</button>
         <button class="sfooter-btn danger" onclick="showPurgeModal('database')">⚠ Clear Vector Database</button>
     </div>
@@ -1173,6 +1174,18 @@
         <div id="compareTableWrap" style="margin-top:.8rem;max-height:55vh;overflow:auto"></div>
         <div class="modal-actions">
             <button class="modal-btn" onclick="hideCompareModal()">Close</button>
+        </div>
+    </div>
+</div>
+
+<div class="overlay" id="mapOverlay">
+    <div class="modal" style="max-width:720px">
+        <h3>🗺 Library Map</h3>
+        <p>Topic clusters and publication-year coverage across your ingested corpus.</p>
+        <div id="mapBody" style="margin-top:.8rem;max-height:60vh;overflow-y:auto"></div>
+        <div class="modal-actions">
+            <button class="modal-btn" onclick="loadCorpusMap()">Refresh</button>
+            <button class="modal-btn" onclick="hideMapModal()">Close</button>
         </div>
     </div>
 </div>
@@ -2116,6 +2129,50 @@ function renderCompareTable(paperIds, dimensions, matrix){
     }).join('');
     const header=paperIds.map(pid=>`<th style="padding:.5rem .6rem;border:1px solid var(--border);text-align:left;font-size:.8rem">${esc(pid)}</th>`).join('');
     tableWrap.innerHTML=`<table style="border-collapse:collapse;width:100%"><thead><tr><th style="padding:.5rem .6rem;border:1px solid var(--border)"></th>${header}</tr></thead><tbody>${rows}</tbody></table>`;
+}
+
+// ── CORPUS MAP ─────────────────────────────────────────────────
+function showMapModal(){ document.getElementById('mapOverlay').classList.add('active'); loadCorpusMap(); }
+function hideMapModal(){ document.getElementById('mapOverlay').classList.remove('active'); }
+
+async function loadCorpusMap(){
+    const body=document.getElementById('mapBody');
+    body.innerHTML='<div style="color:var(--text-3);font-size:.82rem;padding:.5rem 0">Loading…</div>';
+    try{
+        const r=await fetch(`${API}/corpus/map`,{headers:authHeaders()});
+        const d=await r.json();
+        if(!r.ok) throw new Error(formatError(d)||'Failed to load corpus map');
+        if(!d.clusters.length){ body.innerHTML='<div style="color:var(--text-3);font-size:.82rem;padding:.5rem 0">No papers ingested yet.</div>'; return; }
+
+        const years=d.timeline.filter(t=>t.year!=='unknown');
+        const maxCount=Math.max(1,...d.timeline.map(t=>t.count));
+        const timelineHtml=d.timeline.length?`
+            <div style="font-weight:600;font-size:.82rem;color:var(--text-1);margin-bottom:.4rem">Publication years</div>
+            <div style="display:flex;align-items:flex-end;gap:.35rem;height:90px;margin-bottom:1rem">
+                ${d.timeline.map(t=>`
+                    <div style="display:flex;flex-direction:column;align-items:center;flex:1;min-width:0" title="${esc(t.year)}: ${t.count} chunks">
+                        <div style="width:100%;background:var(--primary);border-radius:3px 3px 0 0;height:${Math.max(4,t.count/maxCount*70)}px"></div>
+                        <div style="font-size:.65rem;color:var(--text-3);margin-top:.25rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%">${esc(t.year)}</div>
+                    </div>`).join('')}
+            </div>` : '';
+
+        const gapNote=years.length>=2 ? (()=>{
+            const nums=[...new Set(years.map(t=>parseInt(t.year)).filter(n=>!isNaN(n)))].sort((a,b)=>a-b);
+            const gaps=[];
+            for(let i=1;i<nums.length;i++){ if(nums[i]-nums[i-1]>1) gaps.push(`${nums[i-1]}–${nums[i]}`); }
+            return gaps.length ? `<div style="font-size:.75rem;color:var(--text-3);margin-bottom:1rem">⚠ Coverage gap: no papers between ${gaps.join(', ')}</div>` : '';
+        })() : '';
+
+        const clustersHtml=`
+            <div style="font-weight:600;font-size:.82rem;color:var(--text-1);margin-bottom:.4rem">Topic clusters</div>
+            ${d.clusters.map(c=>`
+                <div style="border:1px solid var(--border);border-radius:8px;padding:.55rem .7rem;margin-bottom:.45rem">
+                    <div style="font-size:.82rem;font-weight:600;color:var(--text-1)">Cluster ${c.id} — ${c.paper_count} paper${c.paper_count===1?'':'s'} (${c.year_range})</div>
+                    <div style="font-size:.75rem;color:var(--text-3);margin-top:.2rem">${c.sample_titles.map(esc).join(' · ') || 'Untitled'}</div>
+                </div>`).join('')}`;
+
+        body.innerHTML = timelineHtml + gapNote + clustersHtml;
+    }catch(e){ body.innerHTML=`<div style="color:#ef4444;font-size:.82rem;padding:.5rem 0">${esc(e.message)}</div>`; }
 }
 
 async function generateReport(){

--- a/static/index.html
+++ b/static/index.html
@@ -1154,10 +1154,11 @@
 <div class="overlay" id="compareOverlay">
     <div class="modal" style="max-width:720px">
         <h3>🔀 Compare Papers</h3>
-        <p>Comma-separated paper IDs (2+) and dimensions to compare them on.</p>
+        <p>Pick 2+ papers and list dimensions to compare them on.</p>
         <div style="display:flex;flex-direction:column;gap:.5rem;margin-top:.8rem">
-            <input id="comparePaperIds" placeholder="paper_id_1, paper_id_2, ..."
-                style="padding:.5rem .6rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.85rem;font-family:'Inter',system-ui,sans-serif;">
+            <div id="comparePaperList" style="max-height:180px;overflow-y:auto;border:1px solid var(--border);border-radius:7px;padding:.4rem .6rem;background:var(--surface-up)">
+                <div style="color:var(--text-3);font-size:.8rem;padding:.3rem 0">Loading papers…</div>
+            </div>
             <input id="compareDimensions" placeholder="methodology, dataset, results, ..."
                 style="padding:.5rem .6rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.85rem;font-family:'Inter',system-ui,sans-serif;">
             <button id="compareBtn" class="modal-btn" style="background:var(--primary);color:#fff;border-color:var(--primary);align-self:flex-start" onclick="runCompare()">Compare</button>
@@ -2025,15 +2026,30 @@ async function reindexPaper(paperId,btn){
 }
 
 // ── COMPARE PAPERS ─────────────────────────────────────────────
-function showCompareModal(){ document.getElementById('compareOverlay').classList.add('active'); }
+function showCompareModal(){ document.getElementById('compareOverlay').classList.add('active'); loadComparePapers(); }
 function hideCompareModal(){ document.getElementById('compareOverlay').classList.remove('active'); }
 
+async function loadComparePapers(){
+    const list=document.getElementById('comparePaperList');
+    list.innerHTML='<div style="color:var(--text-3);font-size:.8rem;padding:.3rem 0">Loading papers…</div>';
+    try{
+        const r=await fetch(`${API}/papers`,{headers:authHeaders()});
+        const papers=r.ok?await r.json():[];
+        if(!papers.length){ list.innerHTML='<div style="color:var(--text-3);font-size:.8rem;padding:.3rem 0">No papers ingested yet.</div>'; return; }
+        list.innerHTML=papers.map(p=>`
+            <label style="display:flex;align-items:center;gap:.4rem;padding:.25rem 0;font-size:.82rem;color:var(--text-1);cursor:pointer">
+                <input type="checkbox" class="compare-pid" value="${esc(p.paper_id)}">
+                <span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${esc(p.filename)}</span>
+            </label>`).join('');
+    }catch(e){ list.innerHTML=`<div style="color:#ef4444;font-size:.8rem;padding:.3rem 0">${esc(e.message)}</div>`; }
+}
+
 async function runCompare(){
-    const paperIds=document.getElementById('comparePaperIds').value.split(',').map(s=>s.trim()).filter(Boolean);
+    const paperIds=[...document.querySelectorAll('.compare-pid:checked')].map(el=>el.value);
     const dimensions=document.getElementById('compareDimensions').value.split(',').map(s=>s.trim()).filter(Boolean);
     const statusEl=document.getElementById('compareStatus');
     const tableWrap=document.getElementById('compareTableWrap');
-    if(paperIds.length<2){ showToast('Enter at least 2 paper IDs','error'); return; }
+    if(paperIds.length<2){ showToast('Select at least 2 papers','error'); return; }
     if(!dimensions.length){ showToast('Enter at least 1 dimension','error'); return; }
 
     const btn=document.getElementById('compareBtn');

--- a/static/index.html
+++ b/static/index.html
@@ -22,69 +22,69 @@
     <style>
         /* ── THEME VARIABLES ───────────────────────────────── */
         :root {
-                /* Premium enterprise — indigo accent on refined slate neutrals */
-            --bg:               #F7F8FA;
-            --sidebar-bg:       #FFFFFF;
+                /* Scholarly academic — warm neutrals with scholarly blue accent */
+            --bg:               #FAFBFC;
+            --sidebar-bg:       #F4F1EA;
             --surface:          #FFFFFF;
-            --surface-up:       #F9FAFB;
-            --surface-2:        #F3F4F6;
-            --border:           #E5E7EB;
+            --surface-up:       #F8F7F4;
+            --surface-2:        #EEEDE8;
+            --border:           #E2E6EB;
             --border-muted:     #D1D5DB;
-            --border-accent:    #7DD3FC;
-            --primary:          #0369A1;
-            --primary-hover:    #075985;
-            --primary-bg:       #F0F9FF;
-            --primary-bg2:      #E0F2FE;
-            --primary-border:   #BAE6FD;
-            --text-1:           #111827;
+            --border-accent:    #A3BFFA;
+            --primary:          #2E5090;
+            --primary-hover:    #1E3A6E;
+            --primary-bg:       #EBF0FA;
+            --primary-bg2:      #D6E2F5;
+            --primary-border:   #B3CCEB;
+            --text-1:           #1A1F36;
             --text-2:           #374151;
             --text-3:           #6B7280;
             --text-4:           #9CA3AF;
-            --user-bubble-bg:   #0369A1;
+            --user-bubble-bg:   #2E5090;
             --user-bubble-text: #FFFFFF;
-            --code-bg:          #0C1E2E;
-            --code-text:        #E0F2FE;
-            --chip-lang-bg:     #F3F4F6; --chip-lang-c:  #374151;
-            --chip-cite-bg:     #F0F9FF; --chip-cite-c:  #0369A1;
-            --chip-time-bg:     #F9FAFB; --chip-time-c:  #6B7280;
-            --cite-bar:         #0284C7;
+            --code-bg:          #1A1F36;
+            --code-text:        #E8ECF1;
+            --chip-lang-bg:     #EEEDE8; --chip-lang-c:  #374151;
+            --chip-cite-bg:     #EBF0FA; --chip-cite-c:  #2E5090;
+            --chip-time-bg:     #F8F7F4; --chip-time-c:  #6B7280;
+            --cite-bar:         #C49A2A;
             --ts-bg: #F0FDF4; --ts-c: #15803D; --ts-br: #BBF7D0;
             --te-bg: #FEF2F2; --te-c: #B91C1C; --te-br: #FECACA;
-            --ti-bg: #F0F9FF; --ti-c: #0369A1; --ti-br: #BAE6FD;
-            --shadow: 0 1px 2px rgba(16,24,40,.04), 0 1px 3px rgba(16,24,40,.06);
-            --shadow-lg: 0 12px 32px rgba(16,24,40,.10), 0 4px 8px rgba(16,24,40,.05);
+            --ti-bg: #EBF0FA; --ti-c: #2E5090; --ti-br: #B3CCEB;
+            --shadow: 0 1px 2px rgba(26,31,54,.04), 0 1px 3px rgba(26,31,54,.06);
+            --shadow-lg: 0 12px 32px rgba(26,31,54,.10), 0 4px 8px rgba(26,31,54,.05);
             --transition: background .25s, color .25s, border-color .25s;
         }
         [data-theme="dark"] {
-            /* Premium enterprise dark — near-black navy with luminous indigo accent */
-            --bg:               #0A0B10;
-            --sidebar-bg:       #0F1017;
-            --surface:          #14161F;
-            --surface-up:       #1A1D28;
-            --surface-2:        #1E212D;
-            --border:           #272B37;
-            --border-muted:     #363B4A;
-            --border-accent:    #0284C7;
-            --primary:          #38BDF8;
-            --primary-hover:    #7DD3FC;
-            --primary-bg:       #082F49;
-            --primary-bg2:      #0C4A6E;
-            --primary-border:   #075985;
-            --text-1:           #F9FAFB;
-            --text-2:           #D1D5DB;
-            --text-3:           #9CA3AF;
-            --text-4:           #6B7280;
-            --user-bubble-bg:   #0284C7;
+            /* Scholarly dark — deep navy with warm gold accent */
+            --bg:               #0D1117;
+            --sidebar-bg:       #161B22;
+            --surface:          #1C2128;
+            --surface-up:       #21262D;
+            --surface-2:        #2D333B;
+            --border:           #373E47;
+            --border-muted:     #444C56;
+            --border-accent:    #58A6FF;
+            --primary:          #58A6FF;
+            --primary-hover:    #79C0FF;
+            --primary-bg:       #0D1D30;
+            --primary-bg2:      #132D4A;
+            --primary-border:   #1F3D5C;
+            --text-1:           #F0F3F6;
+            --text-2:           #C9D1D9;
+            --text-3:           #8B949E;
+            --text-4:           #6E7681;
+            --user-bubble-bg:   #2E5090;
             --user-bubble-text: #FFFFFF;
-            --code-bg:          #0A0B10;
-            --code-text:        #E0F2FE;
-            --chip-lang-bg:     #1E212D; --chip-lang-c:  #9CA3AF;
-            --chip-cite-bg:     #0C2A3E; --chip-cite-c:  #7DD3FC;
-            --chip-time-bg:     #0F1017; --chip-time-c:  #6B7280;
-            --cite-bar:         #38BDF8;
+            --code-bg:          #0D1117;
+            --code-text:        #E8ECF1;
+            --chip-lang-bg:     #2D333B; --chip-lang-c:  #8B949E;
+            --chip-cite-bg:     #0D1D30; --chip-cite-c:  #58A6FF;
+            --chip-time-bg:     #161B22; --chip-time-c:  #6E7681;
+            --cite-bar:         #D29922;
             --ts-bg: #052E16; --ts-c: #4ADE80; --ts-br: #14532D;
             --te-bg: #450A0A; --te-c: #FCA5A5; --te-br: #7F1D1D;
-            --ti-bg: #0C2A3E; --ti-c: #7DD3FC; --ti-br: #075985;
+            --ti-bg: #0D1D30; --ti-c: #58A6FF; --ti-br: #1F3D5C;
             --shadow: 0 1px 3px rgba(0,0,0,.4), 0 1px 2px rgba(0,0,0,.3);
             --shadow-lg: 0 16px 48px rgba(0,0,0,.6), 0 4px 12px rgba(0,0,0,.4);
         }
@@ -94,7 +94,7 @@
         html, body { height: 100%; overflow: hidden; }
 
         body {
-            font-family: 'Inter', sans-serif;
+            font-family: 'Inter', system-ui, sans-serif;
             background: var(--bg);
             color: var(--text-1);
             display: flex;
@@ -110,6 +110,9 @@
             display: flex; flex-direction: column;
             height: 100vh; overflow: hidden;
             transition: var(--transition);
+            background-image: 
+                radial-gradient(circle at 20% 80%, rgba(196, 154, 42, 0.03) 0%, transparent 50%),
+                radial-gradient(circle at 80% 20%, rgba(46, 80, 144, 0.03) 0%, transparent 50%);
         }
         .sidebar-logo {
             display: flex; align-items: center; gap: .65rem;
@@ -118,13 +121,14 @@
             font-size: 1.05rem; font-weight: 700;
             color: var(--text-1); letter-spacing: -.3px; flex-shrink: 0;
             transition: var(--transition);
+            font-family: Georgia, 'Times New Roman', serif;
         }
         .logo-wrap {
             width: 30px; height: 30px;
             background: var(--primary);
             border-radius: 7px; display: flex; align-items: center;
             justify-content: center; font-size: 15px; color: var(--surface); font-weight: 700;
-            font-family: 'Noto Sans Devanagari', 'Inter', sans-serif;
+            font-family: 'Noto Sans Devanagari', Georgia, serif;
         }
         .sidebar-scroll {
             flex: 1; overflow-y: auto; padding: 1.1rem 1rem .75rem;
@@ -137,6 +141,8 @@
             color: var(--text-4); text-transform: uppercase;
             margin-bottom: .65rem; display: flex; align-items: center; gap: .4rem;
             transition: var(--transition);
+            font-family: Georgia, 'Times New Roman', serif;
+            letter-spacing: 1.5px;
         }
         .section-label svg { width: 12px; height: 12px; flex-shrink: 0; }
         .sidebar-section { margin-bottom: 1.5rem; }
@@ -146,9 +152,14 @@
             border: 1.5px solid var(--border); border-radius: 10px;
             padding: .85rem .9rem; margin-bottom: .5rem; cursor: pointer;
             transition: var(--transition), border-color .2s;
+            background: var(--surface);
         }
         .strategy-card:hover { border-color: var(--border-accent); background: var(--primary-bg); }
-        .strategy-card.selected { border-color: var(--primary); background: var(--primary-bg); }
+        .strategy-card.selected { 
+            border-color: var(--primary); 
+            background: var(--primary-bg);
+            border-left: 3px solid var(--primary);
+        }
         .strategy-card label { display: flex; align-items: flex-start; gap: .6rem; cursor: pointer; pointer-events: none; }
         .strategy-card input[type="radio"] { width: 15px; height: 15px; accent-color: var(--primary); margin-top: 2px; flex-shrink: 0; }
         .strategy-card-body { flex: 1; }
@@ -162,6 +173,8 @@
             padding: 1.4rem 1rem; text-align: center; cursor: pointer;
             background: var(--surface-up); margin-bottom: .6rem;
             transition: var(--transition), border-color .2s;
+            background-image: 
+                radial-gradient(circle at 50% 50%, rgba(196, 154, 42, 0.02) 0%, transparent 70%);
         }
         .upload-zone:hover, .upload-zone.dragover { border-color: var(--primary); background: var(--primary-bg); }
         .upload-zone .up-icon { color: var(--text-4); margin: 0 auto .45rem; display: block; transition: color .2s; }
@@ -173,7 +186,7 @@
         .ingest-all-btn {
             width: 100%; padding: .5rem;
             font-size: .75rem; font-weight: 600;
-            font-family: 'Inter', sans-serif;
+            font-family: 'Inter', system-ui, sans-serif;
             background: var(--primary-bg); color: var(--primary);
             border: 1.5px solid var(--primary-border); border-radius: 7px;
             cursor: pointer; margin-bottom: .55rem; transition: var(--transition), background .15s;
@@ -198,19 +211,65 @@
             border: none; border-radius: 4px; cursor: pointer;
             font-weight: 500; flex-shrink: 0; transition: background .15s;
         }
+        .paper-copy-btn {
+            font-size: .6rem; padding: .2rem .4rem;
+            background: var(--surface-2); color: var(--text-3);
+            border: 1px solid var(--border); border-radius: 4px; cursor: pointer;
+            font-weight: 500; flex-shrink: 0; transition: color .15s, border-color .15s;
+            font-family: 'JetBrains Mono', monospace;
+        }
+        .paper-copy-btn:hover { color: var(--primary); border-color: var(--border-accent); }
+        .paper-copy-btn.copied { color: #10b981; border-color: #10b981; }
         .paper-ingest-btn:hover:not(:disabled) { background: var(--primary-hover); }
         .paper-ingest-btn:disabled { background: var(--border-muted); cursor: not-allowed; }
 
         /* KB stats */
         .kb-stats { display: flex; gap: .5rem; margin-top: .65rem; }
-        .kb-stat { flex: 1; background: var(--surface-up); border: 1px solid var(--border); border-radius: 7px; padding: .5rem; text-align: center; transition: var(--transition); }
-        .kb-stat-value { font-family: 'JetBrains Mono', monospace; font-size: .95rem; font-weight: 600; color: var(--primary); display: block; }
+        .kb-stat { 
+            flex: 1; 
+            background: var(--surface-up); 
+            border: 1px solid var(--border); 
+            border-radius: 7px; 
+            padding: .5rem; 
+            text-align: center; 
+            transition: var(--transition);
+        }
+        .kb-stat-value { 
+            font-family: 'JetBrains Mono', monospace; 
+            font-size: .95rem; 
+            font-weight: 600; 
+            color: var(--primary); 
+            display: block;
+        }
         .kb-stat-label { font-size: .6rem; color: var(--text-4); text-transform: uppercase; letter-spacing: .5px; transition: var(--transition); margin-top: 2px;}
 
         /* Tool calls in agent responses */
         .asst-tools { margin-top: .75rem; padding-top: .65rem; border-top: 1px solid var(--border); }
-        .tools-label { font-size: .65rem; font-weight: 600; text-transform: uppercase; letter-spacing: 1px; color: var(--text-4); margin-bottom: .45rem; transition: var(--transition); }
-        .tool-row { font-family: 'JetBrains Mono', monospace; font-size: .7rem; color: var(--text-3); padding: .35rem .6rem; background: var(--surface-up); border-radius: 5px; margin-bottom: .3rem; border: 1px solid var(--border); display: flex; align-items: center; gap: .5rem; transition: var(--transition); overflow: hidden; }
+        .tools-label { 
+            font-size: .65rem; 
+            font-weight: 600; 
+            text-transform: uppercase; 
+            letter-spacing: 1px; 
+            color: var(--text-4); 
+            margin-bottom: .45rem; 
+            transition: var(--transition);
+            font-family: Georgia, 'Times New Roman', serif;
+        }
+        .tool-row { 
+            font-family: 'JetBrains Mono', monospace; 
+            font-size: .7rem; 
+            color: var(--text-3); 
+            padding: .35rem .6rem; 
+            background: var(--surface-up); 
+            border-radius: 5px; 
+            margin-bottom: .3rem; 
+            border: 1px solid var(--border); 
+            display: flex; 
+            align-items: center; 
+            gap: .5rem; 
+            transition: var(--transition); 
+            overflow: hidden;
+        }
         .tool-row .tool-args { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-4); font-size: .65rem; }
         .tool-row:last-child { margin-bottom: 0; }
         .tool-icon { flex-shrink: 0; font-size: .8rem; }
@@ -225,30 +284,85 @@
 
         /* Agent sources */
         .asst-sources { margin-top: .85rem; padding-top: .75rem; border-top: 1px solid var(--border); }
-        .sources-label { font-size: .65rem; font-weight: 600; text-transform: uppercase; letter-spacing: 1px; color: var(--text-4); margin-bottom: .55rem; }
-        .source-card { background: var(--surface-up); border: 1px solid var(--border); border-radius: 8px; padding: .65rem .8rem; margin-bottom: .45rem; transition: var(--transition), border-color .15s; }
+        .sources-label { 
+            font-size: .65rem; 
+            font-weight: 600; 
+            text-transform: uppercase; 
+            letter-spacing: 1px; 
+            color: var(--text-4); 
+            margin-bottom: .55rem;
+            font-family: Georgia, 'Times New Roman', serif;
+        }
+        .source-card { 
+            background: var(--surface-up); 
+            border: 1px solid var(--border); 
+            border-radius: 8px; 
+            padding: .65rem .8rem; 
+            margin-bottom: .45rem; 
+            transition: var(--transition), border-color .15s;
+        }
         .source-card:hover { border-color: var(--border-accent); }
         .source-card:last-child { margin-bottom: 0; }
         .source-header { display: flex; align-items: flex-start; gap: .5rem; }
-        .source-badge { font-size: .55rem; font-weight: 600; text-transform: uppercase; letter-spacing: .5px; padding: .1rem .4rem; border-radius: 3px; flex-shrink: 0; margin-top: 2px; }
+        .source-badge { 
+            font-size: .55rem; 
+            font-weight: 600; 
+            text-transform: uppercase; 
+            letter-spacing: .5px; 
+            padding: .1rem .4rem; 
+            border-radius: 3px; 
+            flex-shrink: 0; 
+            margin-top: 2px;
+        }
         .source-badge.arxiv { background: #FEF3C7; color: #92400E; } [data-theme="dark"] .source-badge.arxiv { background: #451A03; color: #FCD34D; }
         .source-badge.semantic_scholar { background: #EDE9FE; color: #5B21B6; } [data-theme="dark"] .source-badge.semantic_scholar { background: #2E1065; color: #C4B5FD; }
         .source-badge.openalex { background: #DBEAFE; color: #1E40AF; } [data-theme="dark"] .source-badge.openalex { background: #172554; color: #93C5FD; }
         .source-badge.corpus { background: #ECFDF5; color: #065F46; } [data-theme="dark"] .source-badge.corpus { background: #022C22; color: #6EE7B7; }
         .source-badge.web { background: #FFF7ED; color: #C2410C; } [data-theme="dark"] .source-badge.web { background: #431407; color: #FDBA74; }
-        .source-title { font-size: .8rem; font-weight: 600; color: var(--text-1); line-height: 1.35; flex: 1; }
+        .source-title { 
+            font-size: .8rem; 
+            font-weight: 600; 
+            color: var(--text-1); 
+            line-height: 1.35; 
+            flex: 1;
+            font-family: Georgia, 'Times New Roman', serif;
+        }
         .source-title a { color: inherit; text-decoration: none; }
         .source-title a:hover { text-decoration: underline; }
-        .source-meta { display: flex; align-items: center; gap: .6rem; margin-top: .35rem; flex-wrap: wrap; }
-        .source-meta-item { font-family: 'JetBrains Mono', monospace; font-size: .65rem; color: var(--text-3); display: flex; align-items: center; gap: .2rem; }
-        .source-pdf-link { font-size: .65rem; font-weight: 600; color: var(--primary); text-decoration: none; padding: .15rem .45rem; border: 1px solid var(--primary-border); border-radius: 4px; margin-left: auto; transition: background .15s; flex-shrink: 0; }
+        .source-meta { 
+            display: flex; 
+            align-items: center; 
+            gap: .6rem; 
+            margin-top: .35rem; 
+            flex-wrap: wrap;
+        }
+        .source-meta-item { 
+            font-family: 'JetBrains Mono', monospace; 
+            font-size: .65rem; 
+            color: var(--text-3); 
+            display: flex; 
+            align-items: center; 
+            gap: .2rem;
+        }
+        .source-pdf-link { 
+            font-size: .65rem; 
+            font-weight: 600; 
+            color: var(--primary); 
+            text-decoration: none; 
+            padding: .15rem .45rem; 
+            border: 1px solid var(--primary-border); 
+            border-radius: 4px; 
+            margin-left: auto; 
+            transition: background .15s; 
+            flex-shrink: 0;
+        }
         .source-pdf-link:hover { background: var(--primary-bg); }
 
         /* Sidebar footer */
         .sidebar-footer { padding: .7rem 1rem; border-top: 1px solid var(--border); flex-shrink: 0; display: flex; flex-direction: column; gap: .35rem; transition: var(--transition); }
         .sfooter-btn {
             width: 100%; padding: .45rem .7rem; font-size: .75rem; font-weight: 500;
-            border-radius: 6px; cursor: pointer; font-family: 'Inter', sans-serif;
+            border-radius: 6px; cursor: pointer; font-family: 'Inter', system-ui, sans-serif;
             border: 1px solid var(--border); background: var(--surface); color: var(--text-3);
             text-align: left; transition: var(--transition); display: flex; align-items: center; gap: .4rem;
         }
@@ -277,12 +391,47 @@
         }
         .icon-btn:hover { background: var(--primary-bg); border-color: var(--border-accent); color: var(--primary); }
         .header-info { flex: 1; }
-        .header-title { font-size: .95rem; font-weight: 700; color: var(--text-1); letter-spacing: -.2px; transition: var(--transition); }
-        .header-sub { font-size: .7rem; color: var(--text-4); display: flex; align-items: center; gap: .3rem; margin-top: 1px; transition: var(--transition); }
+        .header-title { 
+            font-size: .95rem; 
+            font-weight: 700; 
+            color: var(--text-1); 
+            letter-spacing: -.2px; 
+            transition: var(--transition);
+            font-family: Georgia, 'Times New Roman', serif;
+        }
+        .header-sub { 
+            font-size: .7rem; 
+            color: var(--text-4); 
+            display: flex; 
+            align-items: center; 
+            gap: .3rem; 
+            margin-top: 1px; 
+            transition: var(--transition);
+        }
         .header-sub svg { width: 12px; height: 12px; }
         .header-actions { display: flex; gap: .5rem; align-items: center; }
-        .session-badge { font-size: .7rem; font-weight: 500; color: var(--text-4); padding: .25rem .6rem; border: 1px solid var(--border); border-radius: 50px; background: var(--surface-up); transition: var(--transition); }
-        .new-chat-btn { padding: .4rem .8rem; font-size: .75rem; font-weight: 500; font-family: 'Inter', sans-serif; border-radius: 6px; cursor: pointer; border: 1px solid var(--primary); background: var(--primary); color: var(--surface); transition: background .15s, border-color .15s; }
+        .session-badge { 
+            font-size: .7rem; 
+            font-weight: 500; 
+            color: var(--text-4); 
+            padding: .25rem .6rem; 
+            border: 1px solid var(--border); 
+            border-radius: 50px; 
+            background: var(--surface-up); 
+            transition: var(--transition);
+        }
+        .new-chat-btn { 
+            padding: .4rem .8rem; 
+            font-size: .75rem; 
+            font-weight: 500; 
+            font-family: 'Inter', system-ui, sans-serif; 
+            border-radius: 6px; 
+            cursor: pointer; 
+            border: 1px solid var(--primary); 
+            background: var(--primary); 
+            color: var(--surface); 
+            transition: background .15s, border-color .15s;
+        }
         .new-chat-btn:hover { background: var(--primary-hover); border-color: var(--primary-hover); }
 
         /* Theme toggle */
@@ -296,25 +445,94 @@
         .theme-toggle:hover { background: var(--primary-bg); border-color: var(--border-accent); color: var(--primary); }
 
         /* Chat area */
-        .chat-area { flex: 1; overflow-y: auto; padding: 1.5rem 2rem; display: flex; flex-direction: column; gap: 1.1rem; }
+        .chat-area { 
+            flex: 1; 
+            overflow-y: auto; 
+            padding: 1.5rem 2rem; 
+            display: flex; 
+            flex-direction: column; 
+            gap: 1.1rem;
+        }
         .chat-area::-webkit-scrollbar { width: 5px; }
         .chat-area::-webkit-scrollbar-thumb { background: var(--border-muted); border-radius: 3px; }
 
         /* Welcome */
-        .welcome-row { display: flex; gap: .8rem; align-items: flex-start; animation: fadeUp .4s ease; }
-        .bot-avatar { width: 36px; height: 36px; background: var(--surface-2); border: 1px solid var(--border); border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; box-shadow: var(--shadow); color: var(--text-1); }
-        .welcome-bubble { background: var(--surface); border: 1px solid var(--border); border-radius: 0 12px 12px 12px; padding: 1rem 1.25rem; font-size: .875rem; line-height: 1.6; color: var(--text-2); max-width: 520px; box-shadow: var(--shadow); transition: var(--transition); }
+        .welcome-row { 
+            display: flex; 
+            gap: .8rem; 
+            align-items: flex-start; 
+            animation: fadeUp .4s ease;
+        }
+        .bot-avatar { 
+            width: 36px; 
+            height: 36px; 
+            background: var(--primary-bg); 
+            border: 1px solid var(--primary-border); 
+            border-radius: 50%; 
+            display: flex; 
+            align-items: center; 
+            justify-content: center; 
+            flex-shrink: 0; 
+            box-shadow: var(--shadow); 
+            color: var(--primary);
+        }
+        .welcome-bubble { 
+            background: var(--surface); 
+            border: 1px solid var(--border); 
+            border-left: 3px solid var(--cite-bar);
+            border-radius: 0 12px 12px 12px; 
+            padding: 1rem 1.25rem; 
+            font-size: .875rem; 
+            line-height: 1.6; 
+            color: var(--text-2); 
+            max-width: 520px; 
+            box-shadow: var(--shadow); 
+            transition: var(--transition); 
+        }
         @keyframes fadeUp { from{opacity:0;transform:translateY(8px)} to{opacity:1;transform:translateY(0)} }
 
         /* Messages */
-        .msg-row { display: flex; gap: .75rem; align-items: flex-start; animation: fadeUp .3s ease; }
+        .msg-row { 
+            display: flex; 
+            gap: .75rem; 
+            align-items: flex-start; 
+            animation: fadeUp .3s ease;
+        }
         .msg-row.user { justify-content: flex-end; }
-        .user-bubble { background: var(--user-bubble-bg); color: var(--user-bubble-text); border-radius: 12px 12px 0 12px; padding: .8rem 1.1rem; font-size: .875rem; line-height: 1.6; max-width: 65%; box-shadow: var(--shadow); transition: var(--transition); }
-        .asst-bubble { background: var(--surface); border: 1px solid var(--border); border-radius: 0 12px 12px 12px; padding: 1rem 1.25rem; max-width: 82%; box-shadow: var(--shadow); transition: var(--transition); overflow-wrap: break-word; word-break: break-word; }
+        .user-bubble { 
+            background: var(--user-bubble-bg); 
+            color: var(--user-bubble-text); 
+            border-radius: 12px 12px 0 12px; 
+            padding: .8rem 1.1rem; 
+            font-size: .875rem; 
+            line-height: 1.6; 
+            max-width: 65%; 
+            box-shadow: var(--shadow); 
+            transition: var(--transition);
+        }
+        .asst-bubble { 
+            background: var(--surface); 
+            border: 1px solid var(--border); 
+            border-left: 3px solid var(--cite-bar);
+            border-radius: 0 12px 12px 12px; 
+            padding: 1rem 1.25rem; 
+            max-width: 82%; 
+            box-shadow: var(--shadow); 
+            transition: var(--transition); 
+            overflow-wrap: break-word; 
+            word-break: break-word; 
+            position: relative;
+        }
 
         /* Chips */
         .asst-meta { display: flex; align-items: center; gap: .4rem; margin-bottom: .6rem; flex-wrap: wrap; }
-        .meta-chip { font-family: 'JetBrains Mono', monospace; font-size: .65rem; padding: .15rem .5rem; border-radius: 50px; font-weight: 500; }
+        .meta-chip { 
+            font-family: 'JetBrains Mono', monospace; 
+            font-size: .65rem; 
+            padding: .15rem .5rem; 
+            border-radius: 50px; 
+            font-weight: 500;
+        }
         .chip-lang { background: var(--chip-lang-bg); color: var(--chip-lang-c); border: 1px solid var(--border); }
         .chip-cite { background: var(--chip-cite-bg); color: var(--chip-cite-c); border: 1px solid var(--border-accent); }
         .chip-time { background: var(--chip-time-bg); color: var(--chip-time-c); border: 1px solid var(--border); }
@@ -325,17 +543,51 @@
         .asst-text p:last-child { margin-bottom: 0; }
         .asst-text strong { color: var(--text-1); font-weight: 600; }
         .asst-text em { font-style: italic; }
-        .asst-text h1,.asst-text h2,.asst-text h3 { font-family: 'Inter', sans-serif; font-weight: 700; color: var(--text-1); margin: 1rem 0 .5rem; transition: var(--transition); }
+        .asst-text h1,.asst-text h2,.asst-text h3 { font-family: Georgia, 'Times New Roman', serif; font-weight: 700; color: var(--text-1); margin: 1rem 0 .5rem; transition: var(--transition); }
         .asst-text h1{font-size:1.1rem} .asst-text h2{font-size:1rem} .asst-text h3{font-size:.9rem}
         .asst-text code { background: var(--surface-2); padding: .15rem .4rem; border-radius: 4px; font-size: .85em; font-family: 'JetBrains Mono', monospace; color: var(--primary); transition: var(--transition); }
-        .asst-text pre { background: var(--code-bg); color: var(--code-text); padding: 1rem; border-radius: 8px; overflow-x: auto; margin: .75rem 0; font-size: .8rem; border: 1px solid var(--border); }
+        .asst-text pre { 
+            background: var(--code-bg); 
+            color: var(--code-text); 
+            padding: 1rem; 
+            border-radius: 8px; 
+            overflow-x: auto; 
+            margin: .75rem 0; 
+            font-size: .8rem; 
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--primary);
+        }
         .asst-text pre code { background: none; color: inherit; padding: 0; }
         .asst-text ul,.asst-text ol { padding-left: 1.5rem; margin-bottom: .75rem; }
         .asst-text li { margin-bottom: .25rem; }
-        .asst-text table { width: 100%; border-collapse: collapse; margin: .75rem 0; font-size: .8rem; border-radius: 8px; overflow: hidden; border: 1px solid var(--border); }
-        .asst-text th { background: var(--surface-2); padding: .5rem .75rem; text-align: left; font-weight: 600; border-bottom: 2px solid var(--border); color: var(--text-1); transition: var(--transition); }
+        .asst-text table { 
+            width: 100%; 
+            border-collapse: collapse; 
+            margin: .75rem 0; 
+            font-size: .8rem; 
+            border-radius: 8px; 
+            overflow: hidden; 
+            border: 1px solid var(--border);
+        }
+        .asst-text th { 
+            background: var(--surface-2); 
+            padding: .5rem .75rem; 
+            text-align: left; 
+            font-weight: 600; 
+            border-bottom: 2px solid var(--border); 
+            color: var(--text-1); 
+            transition: var(--transition);
+            font-family: Georgia, 'Times New Roman', serif;
+        }
         .asst-text td { padding: .5rem .75rem; border-bottom: 1px solid var(--border); color: var(--text-2); transition: var(--transition); }
-        .asst-text blockquote { border-left: 3px solid var(--primary); padding-left: .85rem; color: var(--text-3); margin: .75rem 0; font-style: italic; }
+        .asst-text blockquote { 
+            border-left: 3px solid var(--cite-bar); 
+            padding-left: .85rem; 
+            color: var(--text-3); 
+            margin: .75rem 0; 
+            font-style: italic;
+            font-family: Georgia, 'Times New Roman', serif;
+        }
         .asst-text hr { border: 0; height: 1px; background: var(--border); margin: 1rem 0; }
         .asst-text .katex-display { overflow-x: auto; padding: .5rem 0; }
 
@@ -368,8 +620,28 @@
 
         /* Citations */
         .asst-citations { margin-top: 1rem; padding-top: .85rem; border-top: 1px solid var(--border); }
-        .citations-label { font-size: .65rem; font-weight: 600; text-transform: uppercase; letter-spacing: 1px; color: var(--text-4); margin-bottom: .5rem; transition: var(--transition); }
-        .cite-row { font-family: 'JetBrains Mono', monospace; font-size: .7rem; color: var(--text-3); padding: .35rem .6rem; background: var(--surface-up); border-radius: 5px; margin-bottom: .3rem; border-left: 2px solid var(--cite-bar); transition: var(--transition); border: 1px solid var(--border); }
+        .citations-label { 
+            font-size: .65rem; 
+            font-weight: 600; 
+            text-transform: uppercase; 
+            letter-spacing: 1px; 
+            color: var(--text-4); 
+            margin-bottom: .5rem; 
+            transition: var(--transition);
+            font-family: Georgia, 'Times New Roman', serif;
+        }
+        .cite-row { 
+            font-family: 'JetBrains Mono', monospace; 
+            font-size: .7rem; 
+            color: var(--text-3); 
+            padding: .35rem .6rem; 
+            background: var(--surface-up); 
+            border-radius: 5px; 
+            margin-bottom: .3rem; 
+            border-left: 2px solid var(--cite-bar); 
+            transition: var(--transition); 
+            border: 1px solid var(--border);
+        }
         .cite-row:last-child { margin-bottom: 0; }
         .cite-num { font-weight: 600; color: var(--primary); margin-right: .35rem; }
         .cite-fig-link { display: inline-block; margin: .4rem .4rem 0 0; }
@@ -378,22 +650,71 @@
 
         /* Typing (standard mode) */
         .typing-row { display: flex; gap: .75rem; align-items: flex-start; }
-        .typing-bubble { background: var(--surface); border: 1px solid var(--border); border-radius: 0 12px 12px 12px; padding: .85rem 1.1rem; display: flex; align-items: center; gap: 5px; box-shadow: var(--shadow); transition: var(--transition); }
+        .typing-bubble { 
+            background: var(--surface); 
+            border: 1px solid var(--border); 
+            border-left: 3px solid var(--primary);
+            border-radius: 0 12px 12px 12px; 
+            padding: .85rem 1.1rem; 
+            display: flex; 
+            align-items: center; 
+            gap: 5px; 
+            box-shadow: var(--shadow); 
+            transition: var(--transition);
+        }
         .typing-bubble span { width: 6px; height: 6px; border-radius: 50%; background: var(--text-4); animation: tdot 1.2s ease-in-out infinite; }
         .typing-bubble span:nth-child(2){animation-delay:.2s} .typing-bubble span:nth-child(3){animation-delay:.4s}
         @keyframes tdot{0%,80%,100%{transform:scale(.65);opacity:.45}40%{transform:scale(1);opacity:1}}
 
         /* Agent progress stepper */
-        .agent-progress { background: var(--surface); border: 1px solid var(--border); border-radius: 0 12px 12px 12px; padding: 1rem 1.25rem; box-shadow: var(--shadow); min-width: 320px; max-width: 420px; }
-        .agent-progress-title { font-size: .75rem; font-weight: 600; color: var(--text-1); margin-bottom: .75rem; display: flex; align-items: center; gap: .45rem; }
+        .agent-progress { 
+            background: var(--surface); 
+            border: 1px solid var(--border); 
+            border-left: 3px solid var(--primary);
+            border-radius: 0 12px 12px 12px; 
+            padding: 1rem 1.25rem; 
+            box-shadow: var(--shadow); 
+            min-width: 320px; 
+            max-width: 420px;
+        }
+        .agent-progress-title { 
+            font-size: .75rem; 
+            font-weight: 600; 
+            color: var(--text-1); 
+            margin-bottom: .75rem; 
+            display: flex; 
+            align-items: center; 
+            gap: .45rem;
+        }
         .agent-progress-title .spinner { width: 14px; height: 14px; border: 2px solid var(--border); border-top-color: var(--primary); border-radius: 50%; animation: spin .8s linear infinite; flex-shrink: 0; }
         @keyframes spin { to { transform: rotate(360deg); } }
         .agent-progress-timer { margin-left: auto; font-family: 'JetBrains Mono', monospace; font-size: .65rem; color: var(--text-4); font-weight: 400; }
         .agent-steps { display: flex; flex-direction: column; gap: 0; }
-        .agent-step { display: flex; align-items: center; gap: .55rem; padding: .35rem 0; font-size: .75rem; color: var(--text-4); transition: color .3s, opacity .3s; position: relative; }
+        .agent-step { 
+            display: flex; 
+            align-items: center; 
+            gap: .55rem; 
+            padding: .35rem 0; 
+            font-size: .75rem; 
+            color: var(--text-4); 
+            transition: color .3s, opacity .3s; 
+            position: relative;
+        }
         .agent-step.active { color: var(--primary); font-weight: 600; }
         .agent-step.done { color: var(--ts-c); }
-        .agent-step .step-icon { width: 18px; height: 18px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: .65rem; flex-shrink: 0; border: 1.5px solid var(--border); background: var(--surface-up); transition: all .3s; }
+        .agent-step .step-icon { 
+            width: 18px; 
+            height: 18px; 
+            border-radius: 50%; 
+            display: flex; 
+            align-items: center; 
+            justify-content: center; 
+            font-size: .65rem; 
+            flex-shrink: 0; 
+            border: 1.5px solid var(--border); 
+            background: var(--surface-up); 
+            transition: all .3s;
+        }
         .agent-step.active .step-icon { border-color: var(--primary); background: var(--primary-bg); animation: pulse-ring 1.5s ease infinite; }
         .agent-step.done .step-icon { border-color: var(--ts-br); background: var(--ts-bg); }
         @keyframes pulse-ring { 0%,100% { box-shadow: 0 0 0 0 rgba(51,65,85,.2); } 50% { box-shadow: 0 0 0 4px rgba(51,65,85,.08); } }
@@ -402,41 +723,144 @@
         .agent-step.done .step-line { background: var(--ts-br); }
 
         /* ── INPUT BAR ──────────────────────────────────── */
-        .input-area { padding: .85rem 1.5rem .85rem; background: var(--bg); flex-shrink: 0; transition: var(--transition); }
-        .input-bar { display: flex; align-items: flex-end; gap: .5rem; background: var(--surface); border: 1.5px solid var(--border); border-radius: 12px; padding: .5rem .6rem .5rem .75rem; transition: var(--transition), border-color .2s, box-shadow .2s; box-shadow: var(--shadow); }
+        .input-area { 
+            padding: .85rem 1.5rem .85rem; 
+            background: var(--bg); 
+            flex-shrink: 0; 
+            transition: var(--transition);
+        }
+        .input-bar { 
+            display: flex; 
+            align-items: flex-end; 
+            gap: .5rem; 
+            background: var(--surface); 
+            border: 1.5px solid var(--border); 
+            border-radius: 12px; 
+            padding: .5rem .6rem .5rem .75rem; 
+            transition: var(--transition), border-color .2s, box-shadow .2s; 
+            box-shadow: var(--shadow);
+            border-left: 3px solid var(--primary);
+        }
         .input-bar:focus-within { border-color: var(--primary); box-shadow: 0 0 0 3px rgba(51,65,85,.12); }
         .attach-btn { width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; background: none; border: none; cursor: pointer; color: var(--text-4); border-radius: 6px; transition: color .15s, background .15s; flex-shrink: 0; }
         .attach-btn:hover { color: var(--primary); background: var(--primary-bg); }
         #chatInput { flex: 1; background: none; border: none; outline: none; font-size: .875rem; color: var(--text-1); resize: none; min-height: 24px; max-height: 140px; line-height: 1.6; padding: .2rem 0; transition: color .25s; }
         #chatInput::placeholder { color: var(--text-4); }
-        .send-btn { width: 36px; height: 36px; background: var(--primary); border: none; border-radius: 8px; display: flex; align-items: center; justify-content: center; cursor: pointer; flex-shrink: 0; transition: background .15s; color: var(--surface); }
+        .send-btn { 
+            width: 36px; 
+            height: 36px; 
+            background: var(--primary); 
+            border: none; 
+            border-radius: 8px; 
+            display: flex; 
+            align-items: center; 
+            justify-content: center; 
+            cursor: pointer; 
+            flex-shrink: 0; 
+            transition: background .15s; 
+            color: var(--surface);
+        }
         .send-btn:hover:not(:disabled) { background: var(--primary-hover); }
         .send-btn:disabled { background: var(--border-muted); color: var(--surface-2); cursor: not-allowed; }
         .send-btn svg { width: 16px; height: 16px; }
         .input-error { font-size: .75rem; font-weight: 500; color: #ef4444; margin-top: .4rem; display: none; }
         .input-error.show { display: block; }
-        .input-disclaimer { font-size: .65rem; color: var(--text-4); text-align: center; margin-top: .5rem; letter-spacing: .2px; display: flex; align-items: center; justify-content: center; gap: .35rem; transition: var(--transition); }
+        .input-disclaimer { 
+            font-size: .65rem; 
+            color: var(--text-4); 
+            text-align: center; 
+            margin-top: .5rem; 
+            letter-spacing: .2px; 
+            display: flex; 
+            align-items: center; 
+            justify-content: center; 
+            gap: .35rem; 
+            transition: var(--transition);
+        }
         .input-disclaimer svg { width: 12px; height: 12px; }
 
         /* ── MODALS ─────────────────────────────────────── */
-        .overlay { display: none; position: fixed; inset: 0; background: rgba(11,18,32,.5); z-index: 1000; align-items: center; justify-content: center; backdrop-filter: blur(4px); }
+        .overlay { 
+            display: none; 
+            position: fixed; 
+            inset: 0; 
+            background: rgba(11,18,32,.5); 
+            z-index: 1000; 
+            align-items: center; 
+            justify-content: center; 
+            backdrop-filter: blur(4px);
+        }
         .overlay.active { display: flex; }
-        .modal { background: var(--surface); border: 1px solid var(--border); border-radius: 14px; padding: 1.5rem; max-width: 420px; width: 90%; box-shadow: var(--shadow-lg); animation: fadeUp .25s ease; max-height: 90vh; overflow-y: auto; transition: var(--transition); }
+        .modal { 
+            background: var(--surface); 
+            border: 1px solid var(--border); 
+            border-left: 3px solid var(--cite-bar);
+            border-radius: 14px; 
+            padding: 1.5rem; 
+            max-width: 420px; 
+            width: 90%; 
+            box-shadow: var(--shadow-lg); 
+            animation: fadeUp .25s ease; 
+            max-height: 90vh; 
+            overflow-y: auto; 
+            transition: var(--transition); 
+        }
         .modal h3 { font-size: 1rem; font-weight: 700; color: var(--text-1); margin-bottom: .5rem; transition: var(--transition); }
         .modal p  { font-size: .875rem; color: var(--text-3); line-height: 1.6; transition: var(--transition); }
         .modal-actions { display: flex; gap: .5rem; justify-content: flex-end; margin-top: 1.25rem; }
-        .modal-btn { padding: .45rem 1rem; border-radius: 7px; font-size: .85rem; font-weight: 500; cursor: pointer; border: 1px solid var(--border); background: var(--surface-up); color: var(--text-2); transition: var(--transition); font-family: 'Inter', sans-serif; }
+        .modal-btn { 
+            padding: .45rem 1rem; 
+            border-radius: 7px; 
+            font-size: .85rem; 
+            font-weight: 500; 
+            cursor: pointer; 
+            border: 1px solid var(--border); 
+            background: var(--surface-up); 
+            color: var(--text-2); 
+            transition: var(--transition); 
+            font-family: 'Inter', system-ui, sans-serif;
+        }
         .modal-btn:hover { background: var(--surface-2); }
         .modal-btn.danger { background: #ef4444; color: #fff; border-color: #ef4444; }
         .modal-btn.danger:hover { background: #dc2626; }
-        .lang-table { width: 100%; border-collapse: collapse; margin-top: .75rem; }
-        .lang-table th { text-align: left; padding: .5rem .6rem; border-bottom: 2px solid var(--border); color: var(--primary); font-size: .75rem; text-transform: uppercase; letter-spacing: .5px; transition: var(--transition); }
-        .lang-table td { padding: .5rem .6rem; border-bottom: 1px solid var(--border); color: var(--text-2); font-family: 'JetBrains Mono', monospace; font-size: .8rem; transition: var(--transition); }
+        .lang-table { 
+            width: 100%; 
+            border-collapse: collapse; 
+            margin-top: .75rem;
+        }
+        .lang-table th { 
+            text-align: left; 
+            padding: .5rem .6rem; 
+            border-bottom: 2px solid var(--border); 
+            color: var(--primary); 
+            font-size: .75rem; 
+            text-transform: uppercase; 
+            letter-spacing: .5px; 
+            transition: var(--transition);
+            font-family: Georgia, 'Times New Roman', serif;
+        }
+        .lang-table td { 
+            padding: .5rem .6rem; 
+            border-bottom: 1px solid var(--border); 
+            color: var(--text-2); 
+            font-family: 'JetBrains Mono', monospace; 
+            font-size: .8rem; 
+            transition: var(--transition);
+        }
         .lang-table tbody tr:hover td { background: var(--surface-up); }
 
         /* ── TOASTS ─────────────────────────────────────── */
         .toast-wrap { position: fixed; bottom: 1.5rem; right: 1.5rem; z-index: 2000; display: flex; flex-direction: column; gap: .4rem; }
-        .toast { padding: .6rem 1rem; border-radius: 8px; font-size: .8rem; font-weight: 500; animation: fadeUp .25s ease; max-width: 320px; box-shadow: var(--shadow-lg); border: 1px solid; }
+        .toast { 
+            padding: .6rem 1rem; 
+            border-radius: 8px; 
+            font-size: .8rem; 
+            font-weight: 500; 
+            animation: fadeUp .25s ease; 
+            max-width: 320px; 
+            box-shadow: var(--shadow-lg); 
+            border: 1px solid;
+        }
         .toast-success { background: var(--ts-bg); color: var(--ts-c); border-color: var(--ts-br); }
         .toast-error   { background: var(--te-bg); color: var(--te-c); border-color: var(--te-br); }
         .toast-info    { background: var(--ti-bg); color: var(--ti-c); border-color: var(--ti-br); }
@@ -536,7 +960,7 @@
             <button class="ingest-all-btn" id="ingestAllBtn" onclick="ingestAll()">⚡ Ingest All PDFs</button>
             <div style="display:flex;gap:.4rem;margin-top:.5rem">
                 <input id="urlIngestInput" placeholder="arXiv ID, DOI, or PDF URL…"
-                    style="flex:1;min-width:0;padding:.45rem .55rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.8rem;font-family:'Inter',sans-serif;">
+                    style="flex:1;min-width:0;padding:.45rem .55rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.8rem;font-family:'Inter',system-ui,sans-serif;">
                 <button class="modal-btn" style="padding:.35rem .6rem;font-size:.78rem;flex-shrink:0" onclick="ingestFromUrl()">+ Add</button>
             </div>
             <div id="papersList">
@@ -557,6 +981,7 @@
         <button class="sfooter-btn" onclick="showWatchModal()">📡 Topic Watches</button>
         <button class="sfooter-btn" onclick="showReportModal()">📄 Lit Review</button>
         <button class="sfooter-btn" onclick="showHealthModal()">🩺 Ingestion Health</button>
+        <button class="sfooter-btn" onclick="showCompareModal()">🔀 Compare Papers</button>
         <button class="sfooter-btn danger" onclick="showPurgeModal('papers')">🗑 Delete All Papers</button>
         <button class="sfooter-btn danger" onclick="showPurgeModal('database')">⚠ Clear Vector Database</button>
     </div>
@@ -660,14 +1085,14 @@
         <p>Register a topic to auto-ingest matching papers and build a cited digest on a cadence.</p>
         <div style="display:flex;gap:.5rem;flex-wrap:wrap;margin-top:1rem">
             <input id="watchTopic" maxlength="500" placeholder="Topic — e.g. graph neural networks for materials"
-                style="flex:1 1 100%;padding:.5rem .6rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.85rem;font-family:'Inter',sans-serif;">
-            <select id="watchLang" style="flex:1;min-width:120px;padding:.5rem .6rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.85rem;font-family:'Inter',sans-serif;">
+                style="flex:1 1 100%;padding:.5rem .6rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.85rem;font-family:'Inter',system-ui,sans-serif;">
+            <select id="watchLang" style="flex:1;min-width:120px;padding:.5rem .6rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.85rem;font-family:'Inter',system-ui,sans-serif;">
                 <option value="en">English</option><option value="hi">हिंदी</option><option value="te">తెలుగు</option>
                 <option value="ta">தமிழ்</option><option value="bn">বাংলা</option><option value="mr">मराठी</option>
                 <option value="gu">ગુજરાતી</option><option value="kn">ಕನ್ನಡ</option><option value="ml">മലയാളം</option>
                 <option value="pa">ਪੰਜਾਬੀ</option><option value="or">ଓଡ଼ିଆ</option><option value="ur">اردو</option>
             </select>
-            <select id="watchCadence" style="flex:1;min-width:110px;padding:.5rem .6rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.85rem;font-family:'Inter',sans-serif;">
+            <select id="watchCadence" style="flex:1;min-width:110px;padding:.5rem .6rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.85rem;font-family:'Inter',system-ui,sans-serif;">
                 <option value="daily">Daily</option><option value="weekly" selected>Weekly</option><option value="monthly">Monthly</option>
             </select>
             <button class="modal-btn" style="background:var(--primary);color:#fff;border-color:var(--primary)" onclick="createWatch()">+ Watch</button>
@@ -697,8 +1122,8 @@
         <p>Generate a sectioned, cited review of a topic from your corpus. Runs as a background job; download the Markdown when it's done.</p>
         <div style="display:flex;gap:.5rem;flex-wrap:wrap;margin-top:1rem">
             <input id="reportTopic" maxlength="500" placeholder="Topic — e.g. terahertz antenna miniaturization"
-                style="flex:1 1 100%;padding:.5rem .6rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.85rem;font-family:'Inter',sans-serif;">
-            <select id="reportLang" style="flex:1;min-width:120px;padding:.5rem .6rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.85rem;font-family:'Inter',sans-serif;">
+                style="flex:1 1 100%;padding:.5rem .6rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.85rem;font-family:'Inter',system-ui,sans-serif;">
+            <select id="reportLang" style="flex:1;min-width:120px;padding:.5rem .6rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.85rem;font-family:'Inter',system-ui,sans-serif;">
                 <option value="en">English</option><option value="hi">हिंदी</option><option value="te">తెలుగు</option>
                 <option value="ta">தமிழ்</option><option value="bn">বাংলা</option><option value="mr">मराठी</option>
                 <option value="gu">ગુજરાતી</option><option value="kn">ಕನ್ನಡ</option><option value="ml">മലയാളം</option>
@@ -722,6 +1147,25 @@
         <div class="modal-actions">
             <button class="modal-btn" onclick="loadIngestHealth()">Refresh</button>
             <button class="modal-btn" onclick="hideHealthModal()">Close</button>
+        </div>
+    </div>
+</div>
+
+<div class="overlay" id="compareOverlay">
+    <div class="modal" style="max-width:720px">
+        <h3>🔀 Compare Papers</h3>
+        <p>Comma-separated paper IDs (2+) and dimensions to compare them on.</p>
+        <div style="display:flex;flex-direction:column;gap:.5rem;margin-top:.8rem">
+            <input id="comparePaperIds" placeholder="paper_id_1, paper_id_2, ..."
+                style="padding:.5rem .6rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.85rem;font-family:'Inter',system-ui,sans-serif;">
+            <input id="compareDimensions" placeholder="methodology, dataset, results, ..."
+                style="padding:.5rem .6rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.85rem;font-family:'Inter',system-ui,sans-serif;">
+            <button id="compareBtn" class="modal-btn" style="background:var(--primary);color:#fff;border-color:var(--primary);align-self:flex-start" onclick="runCompare()">Compare</button>
+        </div>
+        <div id="compareStatus" style="margin-top:.8rem;font-size:.8rem;color:var(--text-3)"></div>
+        <div id="compareTableWrap" style="margin-top:.8rem;max-height:55vh;overflow:auto"></div>
+        <div class="modal-actions">
+            <button class="modal-btn" onclick="hideCompareModal()">Close</button>
         </div>
     </div>
 </div>
@@ -1244,10 +1688,12 @@ async function refreshKB() {
         list.innerHTML='<div class="scope-hint" style="font-size:11px;opacity:.7;padding:4px 6px">☑ Check papers to answer <b>only</b> from them. None checked = search all.</div>'+papers.map(p=>{
             const sid=p.filename.replace(/[^a-zA-Z0-9]/g,'_');
             const pid=p.filename.replace(/\.pdf$/i,'');
+            const copyId=_regCopy(pid);
             return `<div class="paper-item" id="pi-${sid}">
                 <input type="checkbox" class="paper-scope" data-pid="${esc(pid)}" title="Restrict answers to this paper">
                 <span class="paper-icon">📄</span>
                 <span class="paper-name" title="${esc(p.filename)}">${esc(p.filename)}</span>
+                <button class="paper-copy-btn" data-copy-id="${copyId}" title="Copy paper ID: ${esc(pid)}">ID</button>
                 <button class="paper-ingest-btn" id="ib-${sid}" onclick="ingestOne('${esc(p.filename).replace(/'/g,"\\'")}','${sid}')">Ingest</button>
             </div>`;
         }).join('');
@@ -1576,6 +2022,57 @@ async function reindexPaper(paperId,btn){
         showToast(`Re-ingested ${paperId}: ${d.chunks_ingested} chunks`,'success');
         loadIngestHealth();
     }catch(e){ showToast(e.message,'error'); btn.disabled=false; btn.textContent='Re-ingest'; }
+}
+
+// ── COMPARE PAPERS ─────────────────────────────────────────────
+function showCompareModal(){ document.getElementById('compareOverlay').classList.add('active'); }
+function hideCompareModal(){ document.getElementById('compareOverlay').classList.remove('active'); }
+
+async function runCompare(){
+    const paperIds=document.getElementById('comparePaperIds').value.split(',').map(s=>s.trim()).filter(Boolean);
+    const dimensions=document.getElementById('compareDimensions').value.split(',').map(s=>s.trim()).filter(Boolean);
+    const statusEl=document.getElementById('compareStatus');
+    const tableWrap=document.getElementById('compareTableWrap');
+    if(paperIds.length<2){ showToast('Enter at least 2 paper IDs','error'); return; }
+    if(!dimensions.length){ showToast('Enter at least 1 dimension','error'); return; }
+
+    const btn=document.getElementById('compareBtn');
+    btn.disabled=true; btn.textContent='Comparing…';
+    statusEl.textContent='Retrieving papers and extracting per-dimension answers…';
+    tableWrap.innerHTML='';
+
+    try{
+        const r=await fetch(`${API}/compare`,{method:'POST',headers:authHeaders({'Content-Type':'application/json'}),body:JSON.stringify({paper_ids:paperIds,dimensions})});
+        const d=await r.json();
+        if(!r.ok) throw new Error(formatError(d)||'Failed to start comparison');
+
+        let attempts=0;
+        const poll=setInterval(async()=>{
+            if(++attempts>150){clearInterval(poll);statusEl.textContent='Timed out.';btn.disabled=false;btn.textContent='Compare';return;}
+            try{
+                const s=await fetch(`${API}/compare/status/${d.job_id}`,{headers:authHeaders()}); if(!s.ok)return;
+                const job=await s.json();
+                if(job.status==='success'){
+                    clearInterval(poll); btn.disabled=false; btn.textContent='Compare';
+                    statusEl.textContent='';
+                    renderCompareTable(paperIds, job.dimensions, job.matrix);
+                }else if(job.status==='failed'){
+                    clearInterval(poll); btn.disabled=false; btn.textContent='Compare';
+                    statusEl.textContent=`Failed: ${job.error||'unknown error'}`;
+                }
+            }catch(err){console.warn('Compare polling error:',err);}
+        },2000);
+    }catch(e){ showToast(e.message,'error'); btn.disabled=false; btn.textContent='Compare'; }
+}
+
+function renderCompareTable(paperIds, dimensions, matrix){
+    const tableWrap=document.getElementById('compareTableWrap');
+    const rows=dimensions.map(dim=>{
+        const cells=paperIds.map(pid=>`<td style="padding:.5rem .6rem;border:1px solid var(--border);vertical-align:top;font-size:.8rem">${esc((matrix[pid]||{})[dim]||'N/A')}</td>`).join('');
+        return `<tr><th style="padding:.5rem .6rem;border:1px solid var(--border);text-align:left;font-size:.8rem;white-space:nowrap">${esc(dim)}</th>${cells}</tr>`;
+    }).join('');
+    const header=paperIds.map(pid=>`<th style="padding:.5rem .6rem;border:1px solid var(--border);text-align:left;font-size:.8rem">${esc(pid)}</th>`).join('');
+    tableWrap.innerHTML=`<table style="border-collapse:collapse;width:100%"><thead><tr><th style="padding:.5rem .6rem;border:1px solid var(--border)"></th>${header}</tr></thead><tbody>${rows}</tbody></table>`;
 }
 
 async function generateReport(){

--- a/static/index.html
+++ b/static/index.html
@@ -534,6 +534,11 @@
             </div>
             <input type="file" id="fileInput" accept=".pdf" multiple onchange="handleFiles(event)">
             <button class="ingest-all-btn" id="ingestAllBtn" onclick="ingestAll()">⚡ Ingest All PDFs</button>
+            <div style="display:flex;gap:.4rem;margin-top:.5rem">
+                <input id="urlIngestInput" placeholder="arXiv ID, DOI, or PDF URL…"
+                    style="flex:1;min-width:0;padding:.45rem .55rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.8rem;font-family:'Inter',sans-serif;">
+                <button class="modal-btn" style="padding:.35rem .6rem;font-size:.78rem;flex-shrink:0" onclick="ingestFromUrl()">+ Add</button>
+            </div>
             <div id="papersList">
                 <div class="papers-empty" id="papersEmpty">No documents ingested yet.<br>ChromaDB is empty.</div>
             </div>
@@ -1269,6 +1274,40 @@ async function ingestAll() {
             }catch(err){console.warn('Polling error:',err);}
         },2000);
     }catch(e){showToast(`✗ ${e.message}`,'error');btn.disabled=false;btn.textContent='⚡ Ingest All PDFs';}
+}
+
+async function ingestFromUrl() {
+    const input=document.getElementById('urlIngestInput');
+    const raw=input.value.trim();
+    if(!raw){ showToast('Enter an arXiv ID, DOI, or PDF URL','error'); return; }
+
+    let body;
+    if(raw.includes('\n')) body={reading_list:raw};
+    else if(raw.startsWith('http')) body={url:raw};
+    else if(raw.startsWith('10.')||raw.includes('doi.org')) body={doi:raw};
+    else body={arxiv_id:raw};
+
+    try {
+        const r=await fetch(`${API}/ingest/from-url`,{method:'POST',headers:authHeaders({'Content-Type':'application/json'}),body:JSON.stringify(body)});
+        const d=await r.json();
+        if(!r.ok) throw new Error(formatError(d)||'Failed to resolve input');
+        input.value='';
+        showToast('Job started — polling for completion…','info');
+        let attempts=0;
+        const poll=setInterval(async()=>{
+            if(++attempts>300){clearInterval(poll);showToast('Ingest timed out.','error');return;}
+            try {
+                const s=await fetch(`${API}/ingest/status/${d.job_id}`,{headers:authHeaders()}); if(!s.ok)return;
+                const st=await s.json();
+                if(['success','partial','failed'].includes(st.status)){
+                    clearInterval(poll);
+                    if(st.status==='failed')showToast(`Ingest failed: ${st.error||'unknown'}`,'error');
+                    else showToast(`✓ ${st.chunks_ingested||0} chunks from ${st.successful||0}/${st.total_files||0} paper(s)`,'success');
+                    refreshKB();
+                }
+            }catch(err){console.warn('Polling error:',err);}
+        },2000);
+    }catch(e){ showToast(`✗ ${e.message}`,'error'); }
 }
 
 // ── PURGE ──────────────────────────────────────────────────────

--- a/static/index.html
+++ b/static/index.html
@@ -983,6 +983,8 @@
         <button class="sfooter-btn" onclick="showHealthModal()">🩺 Ingestion Health</button>
         <button class="sfooter-btn" onclick="showCompareModal()">🔀 Compare Papers</button>
         <button class="sfooter-btn" onclick="showMapModal()">🗺 Library Map</button>
+        <button class="sfooter-btn" id="userBadge" onclick="showLogin()">Not logged in</button>
+        <button class="sfooter-btn" onclick="logout()">🚪 Log out</button>
         <button class="sfooter-btn danger" onclick="showPurgeModal('papers')">🗑 Delete All Papers</button>
         <button class="sfooter-btn danger" onclick="showPurgeModal('database')">⚠ Clear Vector Database</button>
     </div>
@@ -1190,6 +1192,22 @@
     </div>
 </div>
 
+<div class="overlay" id="loginOverlay">
+    <div class="modal" style="max-width:380px">
+        <h3>🔐 Log in</h3>
+        <p>Enter your username and password to access your watches, reports, and history.</p>
+        <div style="display:flex;flex-direction:column;gap:.6rem;margin-top:.8rem">
+            <input id="loginUser" placeholder="Username" autocomplete="username"
+                style="padding:.55rem .7rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.9rem">
+            <input id="loginPass" type="password" placeholder="Password" autocomplete="current-password"
+                onkeydown="if(event.key==='Enter')doLogin()"
+                style="padding:.55rem .7rem;border-radius:7px;border:1px solid var(--border);background:var(--surface-up);color:var(--text-1);font-size:.9rem">
+            <div id="loginError" style="color:#ef4444;font-size:.8rem;min-height:1em"></div>
+            <button class="modal-btn" style="background:var(--primary);color:#fff;border-color:var(--primary)" onclick="doLogin()">Log in</button>
+        </div>
+    </div>
+</div>
+
 <div class="sidebar-overlay" id="sidebarOverlay" onclick="toggleSidebar()"></div>
 <div class="toast-wrap" id="toastWrap"></div>
 <script>
@@ -1249,6 +1267,7 @@ async function loadModels() {
         updateModelDisabled();
     } catch (e) { console.warn('model list unavailable', e); }
 }
+updateUserBadge();
 // In agent mode, tool-incapable models can't route tools — grey them out.
 function updateModelDisabled() {
     const agent = pipelineMode === 'agent';
@@ -1928,10 +1947,43 @@ function authHeaders(extra){
     const k=localStorage.getItem('indicrag-api-key'); if(k) h['X-API-Key']=k;
     return h;
 }
-function watchUserId(){
-    let u=localStorage.getItem('indicrag-user-id');
-    if(!u){ u='web-'+Math.random().toString(36).slice(2,10); localStorage.setItem('indicrag-user-id',u); }
-    return u;
+
+// ── LOGIN ──────────────────────────────────────────────────────
+// Name+password -> POST /login -> the user's api_key, stored and sent as
+// X-API-Key on every request (deps.get_current_user resolves it to the user).
+function showLogin(){ document.getElementById('loginOverlay').classList.add('active'); document.getElementById('loginError').textContent=''; }
+function hideLogin(){ document.getElementById('loginOverlay').classList.remove('active'); }
+function currentUser(){ return localStorage.getItem('indicrag-username') || ''; }
+
+async function doLogin(){
+    const username=document.getElementById('loginUser').value.trim();
+    const password=document.getElementById('loginPass').value;
+    const err=document.getElementById('loginError');
+    if(!username||!password){ err.textContent='Enter username and password.'; return; }
+    try{
+        const r=await fetch(`${API}/login`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({username,password})});
+        if(!r.ok){ err.textContent = r.status===401 ? 'Invalid username or password.' : 'Login failed.'; return; }
+        const d=await r.json();
+        localStorage.setItem('indicrag-api-key',d.api_key);
+        localStorage.setItem('indicrag-username',d.username);
+        document.getElementById('loginPass').value='';
+        hideLogin();
+        updateUserBadge();
+        showToast(`Logged in as ${d.username}`,'success');
+    }catch(e){ err.textContent='Network error.'; }
+}
+
+function logout(){
+    localStorage.removeItem('indicrag-api-key');
+    localStorage.removeItem('indicrag-username');
+    updateUserBadge();
+    showLogin();
+}
+
+function updateUserBadge(){
+    const b=document.getElementById('userBadge'); if(!b) return;
+    const u=currentUser();
+    b.textContent = u ? `👤 ${u}` : 'Not logged in';
 }
 function showWatchModal(){ document.getElementById('watchOverlay').classList.add('active'); loadWatches(); }
 function hideWatchModal(){ document.getElementById('watchOverlay').classList.remove('active'); }
@@ -1940,7 +1992,7 @@ async function loadWatches(){
     const list=document.getElementById('watchList');
     list.innerHTML='<div style="color:var(--text-3);font-size:.82rem;padding:.5rem 0">Loading…</div>';
     try{
-        const r=await fetch(`${API}/watch?user_id=${encodeURIComponent(watchUserId())}`,{headers:authHeaders()});
+        const r=await fetch(`${API}/watch`,{headers:authHeaders()});
         if(r.status===404){ list.innerHTML='<div style="color:var(--text-3);font-size:.82rem;padding:.5rem 0">Topic watches are disabled (set <code>WATCH_ENABLE=true</code>).</div>'; return; }
         const d=await r.json();
         if(!r.ok) throw new Error(formatError(d)||'Failed to load watches');
@@ -1970,7 +2022,7 @@ async function createWatch(){
         const r=await fetch(`${API}/watch`,{
             method:'POST', headers:authHeaders({'Content-Type':'application/json'}),
             body:JSON.stringify({
-                user_id:watchUserId(), topic,
+                topic,
                 language:document.getElementById('watchLang').value,
                 cadence:document.getElementById('watchCadence').value,
             })

--- a/static/index.html
+++ b/static/index.html
@@ -1009,6 +1009,12 @@
         </div>
     </header>
 
+    <div id="scopeIndicator" style="display:none;align-items:center;gap:.5rem;padding:.4rem .9rem;background:var(--primary-bg);border-bottom:1px solid var(--primary-border);color:var(--primary);font-size:.78rem">
+        <span>📌</span>
+        <span id="scopeIndicatorText" style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"></span>
+        <button onclick="clearPaperScope()" style="background:none;border:none;color:var(--primary);cursor:pointer;font-size:.9rem;line-height:1;padding:0" title="Clear scope">✕</button>
+    </div>
+
     <div class="chat-area" id="chatArea">
         <div class="welcome-row" id="welcomeMsg">
             <div class="bot-avatar">
@@ -1700,6 +1706,27 @@ async function refreshKB() {
         }).join('');
     } catch(e){ console.error('Failed to load knowledge base:', e); }
 }
+
+// "Chat with this paper": the paper-scope checkboxes already restrict retrieval
+// (paper_ids sent on /chat/stream) — this just makes the active scope visible.
+function updateScopeIndicator(){
+    const checked=[...document.querySelectorAll('.paper-scope:checked')];
+    const bar=document.getElementById('scopeIndicator');
+    const text=document.getElementById('scopeIndicatorText');
+    if(!checked.length){ bar.style.display='none'; return; }
+    text.textContent=checked.length===1
+        ? `Scoped to: ${checked[0].dataset.pid}`
+        : `Scoped to ${checked.length} papers: ${checked.map(c=>c.dataset.pid).join(', ')}`;
+    bar.style.display='flex';
+}
+function clearPaperScope(){
+    document.querySelectorAll('.paper-scope:checked').forEach(c=>{c.checked=false;});
+    updateScopeIndicator();
+}
+document.addEventListener('change', e=>{
+    if(e.target.classList && e.target.classList.contains('paper-scope')) updateScopeIndicator();
+});
+
 async function ingestOne(filename,sid) {
     const btn=document.getElementById(`ib-${sid}`); if(!btn)return;
     const orig=btn.textContent; btn.disabled=true; btn.textContent='…';

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -811,3 +811,78 @@ def test_tool_executor_tags_and_interleaves():
     assert all("retriever" in c for c in ctxs), "every passage must be tagged with its tool"
     first12 = ctxs[:12]
     assert sum(1 for c in first12 if c["retriever"] == "indicrag_retrieval") == 3
+
+
+# ── Task 2.6: Agent-invocable watches & reports ────────────────────
+
+def test_create_watch_and_generate_report_declared():
+    from agent.tool_declarations import FUNCTION_DECLARATIONS
+    names = {d.name for d in FUNCTION_DECLARATIONS}
+    assert "create_watch" in names
+    assert "generate_report" in names
+
+
+def test_execute_create_watch_persists_watch():
+    from agent import tool_executor
+    import persistence
+    saved = {}
+    with patch.object(persistence, "save_watch", lambda w: saved.update(w)):
+        res = tool_executor.execute_create_watch("terahertz antennas", cadence="daily", language="hi")
+    assert res["status"] == "created"
+    assert saved["topic"] == "terahertz antennas"
+    assert saved["cadence"] == "daily"
+    assert saved["language"] == "hi"
+    assert saved["next_run"] is not None  # scheduled to auto-run
+    assert res["watch_id"] == saved["id"]
+
+
+def test_execute_create_watch_bad_cadence_falls_back_to_weekly():
+    from agent import tool_executor
+    import persistence
+    saved = {}
+    with patch.object(persistence, "save_watch", lambda w: saved.update(w)):
+        tool_executor.execute_create_watch("x", cadence="hourly")
+    assert saved["cadence"] == "weekly"
+
+
+def test_execute_generate_report_returns_markdown():
+    from agent import tool_executor
+    fake = {"markdown": "# Review [1]", "citation_count": 1, "sections": ["intro"]}
+    with patch("report_runner.run_report", return_value=fake):
+        res = tool_executor.execute_generate_report("antennas", language="en")
+    assert res["status"] == "completed"
+    assert res["markdown"] == "# Review [1]"
+    assert res["citation_count"] == 1
+    assert res["section_count"] == 1
+
+
+def test_execute_generate_report_handles_failure():
+    from agent import tool_executor
+    with patch("report_runner.run_report", side_effect=RuntimeError("boom")):
+        res = tool_executor.execute_generate_report("antennas")
+    assert res["status"] == "error"
+    assert "boom" in res["message"]
+
+
+def test_dispatch_gated_by_config_flags():
+    import config
+    from agent.tool_executor import TOOL_DISPATCH
+    assert "create_watch" in TOOL_DISPATCH
+    assert "generate_report" in TOOL_DISPATCH
+    with patch.object(config, "WATCH_ENABLE", False):
+        r = TOOL_DISPATCH["create_watch"]({"topic": "x"})
+    assert r["status"] == "disabled"
+    with patch.object(config, "REPORT_ENABLE", False):
+        r = TOOL_DISPATCH["generate_report"]({"topic": "x"})
+    assert r["status"] == "disabled"
+
+
+def test_dispatch_create_watch_enabled(tmp_path):
+    import config, persistence
+    from agent.tool_executor import TOOL_DISPATCH
+    saved = {}
+    with patch.object(config, "WATCH_ENABLE", True), \
+         patch.object(persistence, "save_watch", lambda w: saved.update(w)):
+        r = TOOL_DISPATCH["create_watch"]({"topic": "graphene", "cadence": "monthly"})
+    assert r["status"] == "created"
+    assert saved["cadence"] == "monthly"

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -878,7 +878,8 @@ def test_dispatch_gated_by_config_flags():
 
 
 def test_dispatch_create_watch_enabled(tmp_path):
-    import config, persistence
+    import config
+    import persistence
     from agent.tool_executor import TOOL_DISPATCH
     saved = {}
     with patch.object(config, "WATCH_ENABLE", True), \

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -886,3 +886,21 @@ def test_dispatch_create_watch_enabled(tmp_path):
         r = TOOL_DISPATCH["create_watch"]({"topic": "graphene", "cadence": "monthly"})
     assert r["status"] == "created"
     assert saved["cadence"] == "monthly"
+
+
+def test_tool_executor_node_stamps_watch_owner():
+    """A create_watch call routed through the agent node inherits the run's owner."""
+    import config
+    from agent.nodes import tool_executor_node as ten
+    captured = {}
+    def _fake_create(topic, cadence="weekly", language="en", user_id="agent"):
+        captured["user_id"] = user_id
+        return {"status": "created", "watch_id": "w1"}
+    with patch.object(config, "WATCH_ENABLE", True), \
+         patch("agent.tool_executor.execute_create_watch", _fake_create):
+        state = {
+            "tool_calls_requested": [{"name": "create_watch", "args": {"topic": "x"}}],
+            "retrieved_contexts": [], "tool_calls_log": [], "user_id": "alice",
+        }
+        ten.tool_executor_node(state)
+    assert captured["user_id"] == "alice"

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -690,6 +690,42 @@ def test_indicrag_year_range_passed_as_filter():
     assert kwargs["filter_dict"] == {"year": {"$gte": "2020"}}
 
 
+def test_indicrag_tags_passed_as_post_filter_sentinel():
+    """execute_indicrag must forward tags as a rag post-filter sentinel, not a ChromaDB $in
+    clause — PATCH /papers stores tags as one unsplit string, so $in would never match."""
+    import agent.tool_executor as te
+    import rag
+
+    with patch("rag.retrieve_context", return_value={"chunks": [], "metadatas": []}) as rc:
+        te.execute_indicrag("deep learning antennas", tags="transformer, efficiency")
+
+    _, kwargs = rc.call_args
+    assert kwargs["filter_dict"] == {rag._TAGS_SENTINEL: ["transformer", "efficiency"]}
+
+
+def test_indicrag_tags_and_year_combined_with_and():
+    import agent.tool_executor as te
+    import rag
+
+    with patch("rag.retrieve_context", return_value={"chunks": [], "metadatas": []}) as rc:
+        te.execute_indicrag("deep learning antennas", year_from=2020, tags="transformer")
+
+    _, kwargs = rc.call_args
+    assert kwargs["filter_dict"] == {
+        "$and": [{"year": {"$gte": "2020"}}, {rag._TAGS_SENTINEL: ["transformer"]}]
+    }
+
+
+def test_indicrag_blank_tags_no_filter():
+    import agent.tool_executor as te
+
+    with patch("rag.retrieve_context", return_value={"chunks": [], "metadatas": []}) as rc:
+        te.execute_indicrag("deep learning antennas", tags="  ,  ")
+
+    _, kwargs = rc.call_args
+    assert kwargs["filter_dict"] is None
+
+
 def test_reflexion_time_budget_finalises_draft():
     """Over the wall-clock budget, the loop finalises the current draft instead of
     starting another retrieve→generate→verify cycle (returns before any LLM/NLI call)."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,6 +42,23 @@ def test_health_returns_healthy(client):
 
 
 # ---------------------------------------------------------------------------
+# POST /ingest/from-url
+# ---------------------------------------------------------------------------
+
+def test_ingest_from_url_rejects_unresolvable_input(client):
+    resp = client.post("/ingest/from-url", json={})
+    assert resp.status_code == 400
+
+
+def test_ingest_from_url_accepts_direct_url(client):
+    resp = client.post("/ingest/from-url", json={"url": "http://example.com/paper.pdf"})
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["status"] == "pending"
+    assert body["job_id"]
+
+
+# ---------------------------------------------------------------------------
 # DELETE /papers/{paper_id}
 # ---------------------------------------------------------------------------
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,6 +42,25 @@ def test_health_returns_healthy(client):
 
 
 # ---------------------------------------------------------------------------
+# GET /papers
+# ---------------------------------------------------------------------------
+
+def test_list_papers_includes_paper_id(client, tmp_path, monkeypatch):
+    """paper_id (the value /compare, /ingest/reindex, etc. actually need) must
+    be in the response — filename alone doesn't tell the UI what to send."""
+    (tmp_path / "smith_2020_transformer.pdf").write_bytes(b"%PDF-1.4 fake")
+    monkeypatch.setattr("config.PAPERS_DIR", tmp_path)
+
+    resp = client.get("/papers")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["paper_id"] == "smith_2020_transformer"
+    assert body[0]["filename"] == "smith_2020_transformer.pdf"
+
+
+# ---------------------------------------------------------------------------
 # POST /compare
 # ---------------------------------------------------------------------------
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,7 +6,7 @@ that BGE-M3 / ChromaDB are never initialised during tests.
 """
 import pytest
 from contextlib import asynccontextmanager
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 
 @asynccontextmanager
@@ -208,6 +208,68 @@ def test_quality_returns_error_when_absent(client, tmp_path, monkeypatch):
 
     assert resp.status_code == 200
     assert resp.json() == {"error": "No eval report available"}
+
+
+# ---------------------------------------------------------------------------
+# GET /corpus/map
+# ---------------------------------------------------------------------------
+
+def test_kmeans_separates_two_clear_clusters():
+    import numpy as np
+    from routes.management import _kmeans
+
+    X = np.array([
+        [0.0, 0.0], [0.1, 0.0], [0.0, 0.1],
+        [10.0, 10.0], [10.1, 10.0], [10.0, 10.1],
+    ], dtype=np.float32)
+    labels = _kmeans(X, k=2)
+
+    assert labels[0] == labels[1] == labels[2]
+    assert labels[3] == labels[4] == labels[5]
+    assert labels[0] != labels[3]
+
+
+def test_kmeans_k_greater_than_n_does_not_crash():
+    import numpy as np
+    from routes.management import _kmeans
+
+    X = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]], dtype=np.float32)
+    labels = _kmeans(X, k=10)
+    assert len(labels) == 3
+    assert len(set(labels.tolist())) <= 3
+
+
+def test_corpus_map_returns_clusters_and_timeline(client):
+    metadatas = [
+        {"title": "Paper A", "year": "2020"}, {"title": "Paper A", "year": "2020"},
+        {"title": "Paper B", "year": "2021"},
+        {"title": "Paper C", "year": "2021"}, {"title": "Paper C", "year": "2021"},
+    ]
+    embeddings = [[0.0, 0.0], [0.1, 0.0], [0.0, 0.1], [10.0, 10.0], [10.1, 10.0]]
+    fake_collection = MagicMock()
+    with patch("vector_store.get_or_create_collection", return_value=fake_collection), \
+         patch("vector_store._chroma_call", return_value={"embeddings": embeddings, "metadatas": metadatas}):
+        resp = client.get("/corpus/map")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["clusters"]) >= 1
+    total_chunks = sum(c["chunk_count"] for c in body["clusters"])
+    assert total_chunks == 5
+    # 5 chunks but only 3 distinct papers -> at least one cluster must dedupe
+    # a repeated title down to a smaller paper_count than its raw chunk_count.
+    assert any(c["chunk_count"] > c["paper_count"] for c in body["clusters"])
+    years = {t["year"]: t["count"] for t in body["timeline"]}
+    assert years == {"2020": 2, "2021": 3}
+
+
+def test_corpus_map_empty_collection(client):
+    with patch("vector_store.get_or_create_collection", return_value=MagicMock()), \
+         patch("vector_store._chroma_call", return_value={"embeddings": [], "metadatas": []}):
+        resp = client.get("/corpus/map")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"clusters": [], "timeline": []}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -356,3 +356,24 @@ def test_rate_limit_headers_present(client):
 
         # Verify that we did hit the rate limit (at least on the 31st request)
         assert rate_limit_exceeded, "Expected to hit rate limit after 31 requests"
+
+
+# ---------------------------------------------------------------------------
+# GET /graph  (Task 3.3 — knowledge/citation graph)
+# ---------------------------------------------------------------------------
+
+def test_graph_returns_all_edges(client):
+    fake = [{"source": "A", "target": "B", "type": "co_citation", "score": 2.0}]
+    with patch("persistence.get_all_edges", return_value=fake):
+        resp = client.get("/graph")
+    assert resp.status_code == 200
+    assert resp.json()["edges"] == fake
+
+
+def test_graph_filters_by_paper_id(client):
+    fake = [{"source": "A", "target": "B", "type": "co_citation", "score": 2.0, "metadata": {}}]
+    with patch("persistence.get_paper_edges", return_value=fake) as m:
+        resp = client.get("/graph", params={"paper_id": "A"})
+    assert resp.status_code == 200
+    m.assert_called_once_with("A")
+    assert resp.json()["edges"] == fake

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,6 +42,43 @@ def test_health_returns_healthy(client):
 
 
 # ---------------------------------------------------------------------------
+# GET /ingest/health
+# ---------------------------------------------------------------------------
+
+def test_ingest_health_reports_indexed_and_failed_papers(client, tmp_path, monkeypatch):
+    """A PDF with 0 indexed chunks (extraction failed, corrupted figure, etc.)
+    must show up as failed rather than silently vanishing from the count."""
+    (tmp_path / "good_paper.pdf").write_bytes(b"%PDF-1.4 fake")
+    (tmp_path / "failed_paper.pdf").write_bytes(b"%PDF-1.4 fake")
+    monkeypatch.setattr("config.PAPERS_DIR", tmp_path)
+
+    with patch("vector_store.get_paper_chunk_counts", return_value={"good_paper": 5}):
+        resp = client.get("/ingest/health")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["paper_count"] == 2
+    assert body["chunk_count"] == 5
+    assert body["failed_count"] == 1
+    by_id = {p["paper_id"]: p for p in body["papers"]}
+    assert by_id["good_paper"]["status"] == "indexed"
+    assert by_id["good_paper"]["chunks"] == 5
+    assert by_id["failed_paper"]["status"] == "failed"
+    assert by_id["failed_paper"]["chunks"] == 0
+
+
+def test_ingest_health_empty_papers_dir(client, tmp_path, monkeypatch):
+    monkeypatch.setattr("config.PAPERS_DIR", tmp_path)
+
+    with patch("vector_store.get_paper_chunk_counts", return_value={}):
+        resp = client.get("/ingest/health")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"paper_count": 0, "chunk_count": 0, "failed_count": 0, "papers": []}
+
+
+# ---------------------------------------------------------------------------
 # DELETE /papers/{paper_id}
 # ---------------------------------------------------------------------------
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -186,6 +186,31 @@ def test_delete_paper_not_found(client):
 
 
 # ---------------------------------------------------------------------------
+# GET /quality
+# ---------------------------------------------------------------------------
+
+def test_quality_returns_report_when_present(client, tmp_path, monkeypatch):
+    report = {"overall": 0.94, "num_queries": 3}
+    report_path = tmp_path / "eval_report.json"
+    report_path.write_text(__import__("json").dumps(report), encoding="utf-8")
+    monkeypatch.setattr("routes.management._EVAL_REPORT_PATH", report_path)
+
+    resp = client.get("/quality")
+
+    assert resp.status_code == 200
+    assert resp.json() == report
+
+
+def test_quality_returns_error_when_absent(client, tmp_path, monkeypatch):
+    monkeypatch.setattr("routes.management._EVAL_REPORT_PATH", tmp_path / "does_not_exist.json")
+
+    resp = client.get("/quality")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"error": "No eval report available"}
+
+
+# ---------------------------------------------------------------------------
 # PATCH /papers/{paper_id}
 # ---------------------------------------------------------------------------
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,6 +42,36 @@ def test_health_returns_healthy(client):
 
 
 # ---------------------------------------------------------------------------
+# POST /compare
+# ---------------------------------------------------------------------------
+
+def test_compare_rejects_single_paper(client):
+    resp = client.post("/compare", json={"paper_ids": ["p1"], "dimensions": ["methodology"]})
+    assert resp.status_code == 422
+
+
+def test_compare_runs_job_and_status_returns_matrix(client):
+    fake_matrix = {"dimensions": ["methodology"], "matrix": {"p1": {"methodology": "x"}, "p2": {"methodology": "y"}}}
+    with patch("rag.compare_papers", return_value=fake_matrix) as mock_compare:
+        resp = client.post("/compare", json={"paper_ids": ["p1", "p2"], "dimensions": ["methodology"]})
+        assert resp.status_code == 202
+        job_id = resp.json()["job_id"]
+
+        status_resp = client.get(f"/compare/status/{job_id}")
+
+    mock_compare.assert_called_once_with(["p1", "p2"], ["methodology"], None)
+    assert status_resp.status_code == 200
+    body = status_resp.json()
+    assert body["status"] == "success"
+    assert body["matrix"] == fake_matrix["matrix"]
+
+
+def test_compare_status_404_for_unknown_job(client):
+    resp = client.get("/compare/status/does-not-exist")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
 # POST /chat — paper_ids + tags filter combination
 # ---------------------------------------------------------------------------
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,6 +42,36 @@ def test_health_returns_healthy(client):
 
 
 # ---------------------------------------------------------------------------
+# POST /chat — paper_ids + tags filter combination
+# ---------------------------------------------------------------------------
+
+def test_chat_combines_paper_and_tags_filter(client):
+    """routes/chat.py must reach rag.answer_with_history with the same
+    combine_filters(paper_filter, tags_filter) wiring routes/query.py uses."""
+    import rag
+
+    with patch("rag.answer_with_history") as mock_chat:
+        mock_chat.return_value = {
+            "answer": "Test answer", "language": "en", "language_name": "English",
+            "chunks_used": 1, "citations": [],
+        }
+        resp = client.post("/chat", json={
+            "message": "What is IndicRAG?",
+            "paper_ids": ["p1"],
+            "tags": "transformer, efficiency",
+        })
+
+    assert resp.status_code == 200
+    _, kwargs = mock_chat.call_args
+    assert kwargs["filter_dict"] == {
+        "$and": [
+            {"paper_id": {"$in": ["p1"]}},
+            {rag._TAGS_SENTINEL: ["transformer", "efficiency"]},
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
 # DELETE /papers/{paper_id}
 # ---------------------------------------------------------------------------
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -65,6 +65,48 @@ def test_patch_paper_invalid_field(client):
     assert resp.status_code == 400
 
 
+def test_query_response_includes_confidence_and_evidence(client):
+    claim = {"claim": "x", "support": 0.82, "grounded": True,
+              "supporting_chunk": "chunk text", "supporting_chunk_index": 0}
+    with patch("rag.answer_question") as mock_query:
+        mock_query.return_value = {
+            "answer": "Test answer",
+            "language": "en",
+            "language_name": "English",
+            "chunks_used": 1,
+            "citations": [],
+            "processing_time": 0.1,
+            "timestamp": "2026-06-30T00:00:00Z",
+            "answer_confidence": 0.82,
+            "faithfulness": [claim],
+        }
+        resp = client.post("/query", json={"question": "What is IndicRAG?"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["confidence"] == 0.82
+    assert body["evidence"] == [claim]
+
+
+def test_query_response_defaults_confidence_and_evidence_when_absent(client):
+    with patch("rag.answer_question") as mock_query:
+        mock_query.return_value = {
+            "answer": "Test answer",
+            "language": "en",
+            "language_name": "English",
+            "chunks_used": 1,
+            "citations": [],
+            "processing_time": 0.1,
+            "timestamp": "2026-06-30T00:00:00Z",
+        }
+        resp = client.post("/query", json={"question": "What is IndicRAG?"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["confidence"] == 0.0
+    assert body["evidence"] == []
+
+
 # ---------------------------------------------------------------------------
 # Rate limiting wired up
 # ---------------------------------------------------------------------------

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,97 @@
+"""Multi-user login + identity resolution."""
+
+import asyncio
+from contextlib import asynccontextmanager
+
+import pytest
+
+import auth_utils
+import deps
+import persistence
+
+
+@pytest.fixture(autouse=True)
+def _clean_users():
+    with persistence._db_lock:
+        persistence._conn.execute("DELETE FROM users")
+        persistence._conn.commit()
+    deps._refresh_key_map()
+    yield
+    with persistence._db_lock:
+        persistence._conn.execute("DELETE FROM users")
+        persistence._conn.commit()
+    deps._refresh_key_map()
+
+
+def _seed(name, pw, key):
+    s, h = auth_utils.hash_password(pw)
+    persistence.save_user(name, s, h, key, "2026-07-23T00:00:00+00:00")
+    deps._refresh_key_map()
+
+
+# -- password hashing ------------------------------------------------
+def test_hash_roundtrip_and_reject():
+    s, h = auth_utils.hash_password("hunter2")
+    assert auth_utils.verify_password("hunter2", s, h)
+    assert not auth_utils.verify_password("nope", s, h)
+
+
+def test_hash_is_salted():
+    s1, h1 = auth_utils.hash_password("same")
+    s2, h2 = auth_utils.hash_password("same")
+    assert s1 != s2 and h1 != h2  # per-user salt -> different hashes
+
+
+# -- get_current_user ------------------------------------------------
+def test_current_user_default_when_auth_disabled():
+    # no users seeded, no env keys -> auth off -> everyone is the default user
+    assert asyncio.run(deps.get_current_user(None)) == "default"
+
+
+def test_current_user_maps_key_to_username():
+    _seed("alice", "pw", "k_alice")
+    assert asyncio.run(deps.get_current_user("k_alice")) == "alice"
+
+
+def test_current_user_rejects_unknown_key():
+    _seed("alice", "pw", "k_alice")
+    with pytest.raises(Exception):  # HTTPException 401
+        asyncio.run(deps.get_current_user("wrong"))
+
+
+# -- POST /login -----------------------------------------------------
+@asynccontextmanager
+async def _noop_lifespan(app):
+    yield
+
+
+@pytest.fixture(scope="module")
+def client():
+    import api_server
+    from starlette.testclient import TestClient
+    original = api_server.app.router.lifespan_context
+    api_server.app.router.lifespan_context = _noop_lifespan
+    try:
+        with TestClient(api_server.app, raise_server_exceptions=True) as c:
+            yield c
+    finally:
+        api_server.app.router.lifespan_context = original
+
+
+def test_login_returns_key_on_correct_password(client):
+    _seed("alice", "s3cret", "k_alice")
+    r = client.post("/login", json={"username": "alice", "password": "s3cret"})
+    assert r.status_code == 200
+    assert r.json() == {"username": "alice", "api_key": "k_alice"}
+
+
+def test_login_wrong_password_is_401(client):
+    _seed("alice", "s3cret", "k_alice")
+    r = client.post("/login", json={"username": "alice", "password": "wrong"})
+    assert r.status_code == 401
+    assert "k_alice" not in r.text  # never leak the key on failure
+
+
+def test_login_unknown_user_is_401(client):
+    r = client.post("/login", json={"username": "ghost", "password": "x"})
+    assert r.status_code == 401

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -1,0 +1,155 @@
+"""Unit tests for download_utils.py — SSRF guards and size-capped streaming download.
+
+Regression coverage for the SSRF gap watch_runner._download_pdf had: it only
+checked the URL scheme (http/https), never the DNS-resolved IP, so a URL whose
+hostname resolves to a loopback/private/link-local address (e.g. an attacker
+pointing at http://169.254.169.254/ or a rebound DNS name) would be fetched
+by the server. download_utils adds that check.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+def test_is_private_ip_rejects_loopback():
+    from download_utils import _is_private_ip
+
+    with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("127.0.0.1", 0))]):
+        assert _is_private_ip("localhost") is True
+
+
+def test_is_private_ip_rejects_private_range():
+    from download_utils import _is_private_ip
+
+    with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("10.0.0.5", 0))]):
+        assert _is_private_ip("internal.example") is True
+
+
+def test_is_private_ip_rejects_link_local():
+    """Covers the metadata-service SSRF class (169.254.169.254)."""
+    from download_utils import _is_private_ip
+
+    with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("169.254.169.254", 0))]):
+        assert _is_private_ip("metadata.internal") is True
+
+
+def test_is_private_ip_allows_public():
+    from download_utils import _is_private_ip
+
+    with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 0))]):
+        assert _is_private_ip("example.com") is False
+
+
+def test_is_private_ip_dns_failure_treated_as_safe_to_skip():
+    """A hostname that fails to resolve isn't itself an SSRF vector — download_pdf's
+    own urlopen() will fail on it separately; _is_private_ip shouldn't crash."""
+    import socket
+    from download_utils import _is_private_ip
+
+    with patch("socket.getaddrinfo", side_effect=socket.gaierror("no such host")):
+        assert _is_private_ip("nonexistent.invalid") is False
+
+
+def test_download_pdf_rejects_non_http_scheme():
+    from download_utils import download_pdf
+
+    assert download_pdf("file:///etc/passwd") is None
+    assert download_pdf("ftp://example.com/x.pdf") is None
+
+
+def test_download_pdf_rejects_private_ip_target():
+    from download_utils import download_pdf
+    import download_utils
+
+    with patch("download_utils._is_private_ip", return_value=True), \
+         patch.object(download_utils._NoRedirectOpener, "open") as mock_open:
+        result = download_pdf("http://169.254.169.254/x.pdf")
+
+    assert result is None
+    mock_open.assert_not_called()  # must reject before ever making the request
+
+
+def test_download_pdf_streams_public_url(tmp_path):
+    from download_utils import download_pdf
+    import download_utils
+
+    mock_resp = MagicMock()
+    mock_resp.read.side_effect = [b"PDF-bytes", b""]
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=False)
+
+    with patch("download_utils._is_private_ip", return_value=False), \
+         patch.object(download_utils._NoRedirectOpener, "open", return_value=mock_resp):
+        path = download_pdf("http://example.com/paper.pdf")
+
+    assert path is not None
+    with open(path, "rb") as f:
+        assert f.read() == b"PDF-bytes"
+
+
+def test_download_pdf_rejects_redirect_to_private_ip():
+    """Regression: urlopen follows redirects by default, so a public URL that
+    302s to an internal address (cloud metadata service, localhost, ...) must
+    not be silently followed — that fully defeats the private-IP guard."""
+    import urllib.error
+    import download_utils
+
+    def fake_open(req, timeout=30):
+        raise urllib.error.HTTPError(
+            req.full_url, 302, "Found", {"Location": "http://169.254.169.254/latest/meta-data/"}, None
+        )
+
+    # Original host looks public and passes; the redirect target is a real
+    # link-local literal, so the real (unmocked) check correctly rejects it —
+    # only the original hostname's lookup needs faking here.
+    def fake_is_private(hostname):
+        return hostname == "169.254.169.254"
+
+    with patch("download_utils._is_private_ip", side_effect=fake_is_private), \
+         patch.object(download_utils._NoRedirectOpener, "open", side_effect=fake_open):
+        result = download_utils.download_pdf("http://public-looking.example.com/redirect")
+
+    assert result is None
+
+
+def test_download_pdf_follows_redirect_to_public_url(tmp_path):
+    """A redirect to another public URL is fine — only the private-IP hop is blocked."""
+    import urllib.error
+    import download_utils
+
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+    mock_resp.read.side_effect = [b"PDF-bytes", b""]
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=False)
+
+    calls = {"n": 0}
+    def fake_open(req, timeout=30):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise urllib.error.HTTPError(
+                req.full_url, 302, "Found", {"Location": "http://public2.example.com/paper.pdf"}, None
+            )
+        return mock_resp
+
+    with patch("download_utils._is_private_ip", return_value=False), \
+         patch.object(download_utils._NoRedirectOpener, "open", side_effect=fake_open):
+        path = download_utils.download_pdf("http://public1.example.com/redirect")
+
+    assert path is not None
+    assert calls["n"] == 2  # followed exactly one redirect, re-validated the new host
+
+
+def test_download_pdf_size_cap_aborts_oversized_response():
+    import download_utils
+
+    big_chunk = b"x" * (download_utils._MAX_PDF_BYTES + 1)
+    mock_resp = MagicMock()
+    mock_resp.read.side_effect = [big_chunk, b""]
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=False)
+
+    with patch("download_utils._is_private_ip", return_value=False), \
+         patch.object(download_utils._NoRedirectOpener, "open", return_value=mock_resp):
+        result = download_utils.download_pdf("http://example.com/huge.pdf")
+
+    assert result is None

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -40,17 +40,18 @@ def test_submit_feedback_rejects_invalid_rating(client):
 
 def test_get_prefs_404_when_disabled(client):
     with patch("config.ENABLE_USER_PREFS", False):
-        resp = client.get("/prefs/user-1")
+        resp = client.get("/prefs")
     assert resp.status_code == 404
 
 
 def test_put_and_get_prefs_when_enabled(client):
+    # Owner comes from auth; with auth disabled the caller is the default user.
     with patch("config.ENABLE_USER_PREFS", True):
-        put_resp = client.put("/prefs/user-1", json={"prefs": {"language": "hi"}})
+        put_resp = client.put("/prefs", json={"prefs": {"language": "hi"}})
         assert put_resp.status_code == 200
         assert put_resp.json()["prefs"] == {"language": "hi"}
 
-        get_resp = client.get("/prefs/user-1")
+        get_resp = client.get("/prefs")
         assert get_resp.status_code == 200
         assert get_resp.json()["prefs"] == {"language": "hi"}
 

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -60,6 +60,45 @@ def test_search_export_rejects_unknown_format(client):
     assert resp.status_code == 400
 
 
+def test_list_feedback_returns_query_context(client):
+    import persistence
+    persistence.log_query(
+        query_id="q-ctx-1", question="What is BERT?", answer="A transformer model.",
+        mode="standard_A", model="default", language="en", confidence=0.8, coverage=0.5,
+        created_at="2026-07-20T00:00:00+00:00",
+    )
+    client.post("/feedback", json={"query_id": "q-ctx-1", "rating": "up"})
+
+    resp = client.get("/feedback")
+    assert resp.status_code == 200
+    entry = next(e for e in resp.json() if e["query_id"] == "q-ctx-1")
+    assert entry["question"] == "What is BERT?"
+    assert entry["answer"] == "A transformer model."
+    assert entry["rating"] == "up"
+
+
+def test_feedback_stats_aggregates_by_language(client):
+    import persistence
+    persistence.log_query(
+        query_id="q-stats-en", question="q", answer="a", mode="standard_A",
+        model="default", language="en", confidence=0.9, coverage=0.5,
+        created_at="2026-07-20T00:00:00+00:00",
+    )
+    persistence.log_query(
+        query_id="q-stats-hi", question="q", answer="a", mode="standard_A",
+        model="default", language="hi", confidence=0.9, coverage=0.5,
+        created_at="2026-07-20T00:00:00+00:00",
+    )
+    client.post("/feedback", json={"query_id": "q-stats-en", "rating": "up"})
+    client.post("/feedback", json={"query_id": "q-stats-hi", "rating": "down"})
+
+    resp = client.get("/feedback/stats")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["by_language"]["en"]["approval_rate"] == 1.0
+    assert body["by_language"]["hi"]["approval_rate"] == 0.0
+
+
 def test_search_export_returns_bibtex(client):
     fake_context = {
         "chunks": ["chunk text"],

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -60,6 +60,56 @@ def test_search_export_rejects_unknown_format(client):
     assert resp.status_code == 400
 
 
+def test_export_bibtex_from_answer_sources(client):
+    resp = client.post("/export/bibtex", json={
+        "sources": [
+            {"title": "A {Great} Paper", "authors": "John Smith, Jane Doe", "year": "2020"},
+            {"title": "Another Paper", "authors": "", "year": ""},
+        ]
+    })
+    assert resp.status_code == 200
+    assert "@article{Smith2020," in resp.text
+    assert "title = {A Great Paper}" in resp.text
+    assert "author = {John Smith, Jane Doe}" in resp.text
+    assert "year = {2020}" in resp.text
+    # No authors/year → falls back to a ref-style key, no dangling empty fields
+    assert "@article{ref2," in resp.text
+    assert "author = {}" not in resp.text
+    assert "year = {}" not in resp.text
+
+
+def test_export_bibtex_leading_comma_authors_no_crash(client):
+    """Regression: authors=', John Smith' must not IndexError inside _cite_key."""
+    resp = client.post("/export/bibtex", json={
+        "sources": [{"title": "Solo Title", "authors": ", John Smith", "year": "2021"}]
+    })
+    assert resp.status_code == 200
+    assert "@article{ref1," in resp.text
+
+
+def test_export_bibtex_no_authors_or_year_at_index_zero(client):
+    resp = client.post("/export/bibtex", json={"sources": [{"title": "Only A Title"}]})
+    assert resp.status_code == 200
+    assert "@article{ref1," in resp.text
+
+
+def test_export_bibtex_dedupes_colliding_keys(client):
+    resp = client.post("/export/bibtex", json={
+        "sources": [
+            {"title": "Paper One", "authors": "John Smith", "year": "2020"},
+            {"title": "Paper Two", "authors": "John Smith", "year": "2020"},
+        ]
+    })
+    assert resp.status_code == 200
+    assert "@article{Smith2020," in resp.text
+    assert "@article{Smith2020a," in resp.text
+
+
+def test_export_bibtex_rejects_empty_sources(client):
+    resp = client.post("/export/bibtex", json={"sources": []})
+    assert resp.status_code == 422
+
+
 def test_search_export_returns_bibtex(client):
     fake_context = {
         "chunks": ["chunk text"],

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,84 @@
+"""Task 3.3 — knowledge/citation graph (Phase 1): edge persistence + co-citation."""
+
+import pytest
+
+import persistence
+
+
+@pytest.fixture(autouse=True)
+def _clear_edges():
+    with persistence._db_lock:
+        persistence._conn.execute("DELETE FROM graph_edges")
+        persistence._conn.commit()
+    yield
+
+
+def test_save_and_get_all_edges():
+    persistence.save_graph_edge("Paper A", "Paper B", "co_citation", 1.0)
+    edges = persistence.get_all_edges()
+    assert len(edges) == 1
+    e = edges[0]
+    assert {e["source"], e["target"]} == {"Paper A", "Paper B"}
+    assert e["type"] == "co_citation"
+    assert e["score"] == 1.0
+
+
+def test_repeated_edge_accumulates_score_not_duplicates():
+    """Same query cited twice must not create two rows — score accumulates."""
+    for _ in range(3):
+        persistence.save_graph_edge("Paper A", "Paper B", "co_citation", 1.0)
+    edges = persistence.get_all_edges()
+    assert len(edges) == 1
+    assert edges[0]["score"] == 3.0
+
+
+def test_edges_are_undirected():
+    """(A,B) and (B,A) are the same edge."""
+    persistence.save_graph_edge("Paper B", "Paper A", "co_citation", 1.0)
+    persistence.save_graph_edge("Paper A", "Paper B", "co_citation", 1.0)
+    assert len(persistence.get_all_edges()) == 1
+
+
+def test_different_edge_types_are_distinct():
+    persistence.save_graph_edge("Paper A", "Paper B", "co_citation", 1.0)
+    persistence.save_graph_edge("Paper A", "Paper B", "contradiction", 0.9)
+    assert len(persistence.get_all_edges()) == 2
+
+
+def test_get_paper_edges_filters_by_paper():
+    persistence.save_graph_edge("Paper A", "Paper B", "co_citation", 1.0)
+    persistence.save_graph_edge("Paper C", "Paper D", "co_citation", 1.0)
+    a_edges = persistence.get_paper_edges("Paper A")
+    assert len(a_edges) == 1
+    assert {a_edges[0]["source"], a_edges[0]["target"]} == {"Paper A", "Paper B"}
+    assert a_edges[0]["metadata"] == {}
+
+
+def test_save_graph_edges_batch():
+    persistence.save_graph_edges([
+        ("A", "B", "co_citation", 1.0, None),
+        ("B", "C", "co_citation", 1.0, {"note": "x"}),
+    ])
+    assert len(persistence.get_all_edges()) == 2
+
+
+def test_extract_co_citations_pairs_cited_papers():
+    import rag
+    citations = [{"title": "Paper A"}, {"title": "Paper B"}, {"title": "Paper C"}]
+    pairs = rag.extract_co_citations(citations)
+    assert set(map(frozenset, pairs)) == {
+        frozenset({"Paper A", "Paper B"}),
+        frozenset({"Paper A", "Paper C"}),
+        frozenset({"Paper B", "Paper C"}),
+    }
+
+
+def test_extract_co_citations_single_paper_has_no_pairs():
+    import rag
+    assert rag.extract_co_citations([{"title": "Only One"}]) == []
+
+
+def test_extract_co_citations_dedups_repeat_titles():
+    import rag
+    pairs = rag.extract_co_citations([{"title": "A"}, {"title": "A"}, {"title": "B"}])
+    assert set(map(frozenset, pairs)) == {frozenset({"A", "B"})}

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -25,6 +25,110 @@ class FakeCollection:
         return len(self._docs)
 
 
+def test_resolve_urls_direct_url():
+    from routes.ingest import _resolve_urls_to_ingest
+
+    result = _resolve_urls_to_ingest(url="http://example.com/paper.pdf")
+    assert result == [{"url": "http://example.com/paper.pdf", "id": "http://example.com/paper.pdf", "title": ""}]
+
+
+def test_resolve_urls_arxiv_id(monkeypatch):
+    import routes.ingest as ingest_routes
+
+    monkeypatch.setattr(ingest_routes, "execute_arxiv_search", lambda q, max_results: {
+        "passages": [{"pdf_url": "http://arxiv.org/pdf/2301.07041", "title": "A Paper"}]
+    })
+
+    result = ingest_routes._resolve_urls_to_ingest(arxiv_id="2301.07041")
+    assert result == [{"url": "http://arxiv.org/pdf/2301.07041", "id": "2301.07041", "title": "A Paper"}]
+
+
+def test_resolve_urls_doi(monkeypatch):
+    import routes.ingest as ingest_routes
+
+    monkeypatch.setattr(ingest_routes, "execute_open_access_search", lambda q, max_results: {
+        "passages": [{"pdf_url": "http://oa.example.com/x.pdf", "title": "OA Paper"}]
+    })
+
+    result = ingest_routes._resolve_urls_to_ingest(doi="10.1234/abcd")
+    assert result == [{"url": "http://oa.example.com/x.pdf", "id": "10.1234/abcd", "title": "OA Paper"}]
+
+
+def test_resolve_urls_arxiv_no_pdf_found_skips(monkeypatch):
+    import routes.ingest as ingest_routes
+
+    monkeypatch.setattr(ingest_routes, "execute_arxiv_search", lambda q, max_results: {"passages": []})
+
+    assert ingest_routes._resolve_urls_to_ingest(arxiv_id="nope") == []
+
+
+def test_resolve_urls_reading_list_mixed(monkeypatch):
+    import routes.ingest as ingest_routes
+
+    def fake_arxiv(q, max_results):
+        return {"passages": [{"pdf_url": f"http://arxiv.org/pdf/{q}", "title": f"Paper {q}"}]}
+
+    def fake_oa(q, max_results):
+        return {"passages": [{"pdf_url": f"http://oa.example.com/{q}.pdf", "title": f"DOI {q}"}]}
+
+    monkeypatch.setattr(ingest_routes, "execute_arxiv_search", fake_arxiv)
+    monkeypatch.setattr(ingest_routes, "execute_open_access_search", fake_oa)
+
+    reading_list = "2301.07041\nhttps://direct.example.com/y.pdf\n10.1234/abcd\n\n  \n"
+    result = ingest_routes._resolve_urls_to_ingest(reading_list=reading_list)
+
+    assert result == [
+        {"url": "http://arxiv.org/pdf/2301.07041", "id": "2301.07041", "title": "Paper 2301.07041"},
+        {"url": "https://direct.example.com/y.pdf", "id": "https://direct.example.com/y.pdf", "title": ""},
+        {"url": "http://oa.example.com/10.1234/abcd.pdf", "id": "10.1234/abcd", "title": "DOI 10.1234/abcd"},
+    ]
+
+
+def test_resolve_urls_nothing_provided_returns_empty():
+    from routes.ingest import _resolve_urls_to_ingest
+
+    assert _resolve_urls_to_ingest() == []
+
+
+def test_batch_url_ingest_skips_existing_paper_id(monkeypatch):
+    """Regression: an attacker (or an honest duplicate) whose sanitized id
+    collides with an already-ingested paper_id must not silently overwrite
+    that paper's chunks — /ingest/from-url has no confirmation step, unlike
+    /upload (409s on collision) or /reindex (explicit, intentional overwrite)."""
+    import routes.ingest as ingest_routes
+    import vector_store
+
+    calls = []
+
+    class _FakeCollection:
+        def get(self, include=None):
+            return {"metadatas": [{"paper_id": "existing_paper"}]}
+
+    monkeypatch.setattr(vector_store, "get_or_create_collection", lambda: _FakeCollection())
+    monkeypatch.setattr(vector_store, "_chroma_call", lambda fn, **kw: fn(**kw))
+    monkeypatch.setattr(ingest_routes, "_update_job", lambda *a, **k: None)
+    monkeypatch.setattr("download_utils.download_pdf", lambda url: "/tmp/fake.pdf")
+
+    class _FakeIngestModule:
+        @staticmethod
+        def ingest_pdf(path, paper_id, metadata):
+            calls.append(paper_id)
+            return (3, "Title")
+
+    import sys
+    monkeypatch.setitem(sys.modules, "ingest", _FakeIngestModule())
+    monkeypatch.setattr("pathlib.Path.unlink", lambda self: None)
+    monkeypatch.setattr(ingest_routes, "_post_ingest_refresh", lambda: None)
+
+    urls = [
+        {"url": "http://example.com/a.pdf", "id": "existing_paper", "title": "Colliding"},
+        {"url": "http://example.com/b.pdf", "id": "new_paper", "title": "New"},
+    ]
+    ingest_routes._run_batch_url_ingest("job-1", urls)
+
+    assert calls == ["new_paper"]  # existing_paper was skipped, never ingested
+
+
 def test_per_section_chunk_size():
     """Dense sections (abstract) chunk smaller than narrative sections (results)."""
     import ingest

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,5 +1,30 @@
 """Unit tests for rag.py — citation parsing, prompt building, context formatting."""
 
+from unittest.mock import patch
+
+
+def test_run_faithfulness_returns_mean_confidence():
+    from rag import _run_faithfulness
+
+    claims = [
+        {"claim": "a", "support": 0.9, "grounded": True},
+        {"claim": "b", "support": 0.3, "grounded": False},
+    ]
+    with patch("verify.check_claims", return_value=claims):
+        result = _run_faithfulness("answer text", ["chunk"], [{"title": "P"}])
+
+    assert result["claims"] == claims
+    assert result["confidence"] == 0.6
+
+
+def test_run_faithfulness_zero_confidence_when_no_claims():
+    from rag import _run_faithfulness
+
+    with patch("verify.check_claims", return_value=[]):
+        result = _run_faithfulness("answer text", ["chunk"], [{"title": "P"}])
+
+    assert result == {"claims": [], "confidence": 0.0}
+
 
 def test_extract_citations_cite_format():
     from rag import extract_citations

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -26,6 +26,53 @@ def test_run_faithfulness_zero_confidence_when_no_claims():
     assert result == {"claims": [], "confidence": 0.0}
 
 
+def test_compare_papers_builds_matrix():
+    """compare_papers must scope retrieval per paper and ask one extraction
+    per dimension, keyed matrix[paper_id][dimension]."""
+    from rag import compare_papers
+
+    scoped_by_paper = {
+        "p1": {"chunks": ["p1 text"], "metadatas": [{"paper_id": "p1"}],
+               "formatted_context": "[1] Paper One - body:\np1 text\n", "chunks_used": 1},
+        "p2": {"chunks": ["p2 text"], "metadatas": [{"paper_id": "p2"}],
+               "formatted_context": "[1] Paper Two - body:\np2 text\n", "chunks_used": 1},
+    }
+
+    def fake_retrieve_scoped(filter_dict, collection):
+        pid = filter_dict["paper_id"]["$in"][0]
+        return scoped_by_paper[pid]
+
+    def fake_llm_generate(prompt, max_tokens=None, model=None):
+        # Echo back which paper/dimension the prompt was built for, so the
+        # test can assert the matrix cell actually came from the right call.
+        return f"answer for {prompt.splitlines()[-1]}"
+
+    with patch("rag._retrieve_scoped", side_effect=fake_retrieve_scoped), \
+         patch("rag.llm_generate", side_effect=fake_llm_generate), \
+         patch("vector_store.get_or_create_collection", return_value=object()):
+        result = compare_papers(["p1", "p2"], ["methodology", "dataset"])
+
+    assert result["dimensions"] == ["methodology", "dataset"]
+    assert set(result["matrix"].keys()) == {"p1", "p2"}
+    assert "p1 text" in result["matrix"]["p1"]["methodology"]
+    assert "p2 text" in result["matrix"]["p2"]["dataset"]
+
+
+def test_compare_papers_missing_paper_marks_na_without_llm_call():
+    """A paper_id with no chunks in the corpus must not burn an LLM call per
+    dimension — every cell for it is N/A."""
+    from rag import compare_papers
+
+    with patch("rag._retrieve_scoped", return_value={"chunks": [], "metadatas": [],
+                                                       "formatted_context": "", "chunks_used": 0}), \
+         patch("rag.llm_generate") as mock_llm, \
+         patch("vector_store.get_or_create_collection", return_value=object()):
+        result = compare_papers(["missing_paper"], ["methodology"])
+
+    assert result["matrix"]["missing_paper"]["methodology"] == "N/A — paper not found in corpus"
+    mock_llm.assert_not_called()
+
+
 def test_extract_citations_cite_format():
     from rag import extract_citations
 

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -49,6 +49,86 @@ def test_build_paper_filter_none_when_empty():
     assert build_paper_filter(["", "   "]) is None
 
 
+def test_build_tags_filter_parses_comma_separated():
+    from routes.query import build_tags_filter
+    import rag
+
+    assert build_tags_filter("transformer, efficiency") == {
+        rag._TAGS_SENTINEL: ["transformer", "efficiency"]
+    }
+
+
+def test_build_tags_filter_none_when_blank():
+    from routes.query import build_tags_filter
+
+    assert build_tags_filter(None) is None
+    assert build_tags_filter("") is None
+    assert build_tags_filter("  ,  ") is None
+
+
+def test_combine_filters_ands_multiple_present():
+    from routes.query import combine_filters
+
+    assert combine_filters({"paper_id": {"$in": ["p1"]}}, {"tags": {"$in": ["t1"]}}) == {
+        "$and": [{"paper_id": {"$in": ["p1"]}}, {"tags": {"$in": ["t1"]}}]
+    }
+    assert combine_filters({"paper_id": {"$in": ["p1"]}}, None) == {"paper_id": {"$in": ["p1"]}}
+    assert combine_filters(None, None) is None
+
+
+def test_extract_tags_post_filter_sentinel_only():
+    from rag import _extract_tags_post_filter, _TAGS_SENTINEL
+
+    chroma_safe, tags = _extract_tags_post_filter({_TAGS_SENTINEL: ["a", "b"]})
+    assert chroma_safe is None
+    assert tags == ["a", "b"]
+
+
+def test_extract_tags_post_filter_combined_with_and():
+    """paper_id must resurface as a top-level key after extraction, so the
+    paper-scoped retrieval branch (`'paper_id' in filter_dict`) still fires."""
+    from rag import _extract_tags_post_filter, _TAGS_SENTINEL
+
+    combined = {"$and": [{"paper_id": {"$in": ["p1"]}}, {_TAGS_SENTINEL: ["a"]}]}
+    chroma_safe, tags = _extract_tags_post_filter(combined)
+    assert chroma_safe == {"paper_id": {"$in": ["p1"]}}
+    assert tags == ["a"]
+
+
+def test_extract_tags_post_filter_no_sentinel_passthrough():
+    from rag import _extract_tags_post_filter
+
+    original = {"year": {"$gte": "2020"}}
+    chroma_safe, tags = _extract_tags_post_filter(original)
+    assert chroma_safe == original
+    assert tags is None
+
+
+def test_apply_tags_post_filter_matches_multi_tag_comma_joined_paper():
+    """The actual regression this card exists to fix: PATCH /papers stores tags
+    as one unsplit string (e.g. 'transformer,efficiency'), so a paper tagged with
+    2+ tags must still match a filter for just one of them."""
+    from rag import _apply_tags_post_filter
+
+    results = {
+        "chunks": ["c1", "c2"],
+        "metadatas": [{"tags": "transformer,efficiency"}, {"tags": "unrelated"}],
+        "distances": [0.1, 0.2],
+    }
+    filtered = _apply_tags_post_filter(results, ["transformer"])
+    assert filtered["chunks"] == ["c1"]
+    assert filtered["metadatas"] == [{"tags": "transformer,efficiency"}]
+    assert filtered["distances"] == [0.1]
+
+
+def test_apply_tags_post_filter_no_match_returns_empty():
+    from rag import _apply_tags_post_filter
+
+    results = {"chunks": ["c1"], "metadatas": [{"tags": "unrelated"}], "distances": [0.1]}
+    filtered = _apply_tags_post_filter(results, ["transformer"])
+    assert filtered["chunks"] == []
+
+
 class _ScopedFakeCollection:
     """Returns all stored chunks for a where-filter; ignores include details."""
     def __init__(self, rows):

--- a/tests/test_report_routes.py
+++ b/tests/test_report_routes.py
@@ -79,3 +79,75 @@ def test_download_before_ready_409(client):
         job_id = client.post("/report", json={"topic": "x"}).json()["job_id"]
         assert client.get(f"/report/status/{job_id}").json()["status"] == "failed"
         assert client.get(f"/report/{job_id}/download").status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# Report persistence (survives restart, unlike the job store's 24h prune)
+# ---------------------------------------------------------------------------
+
+def test_save_get_list_report_roundtrip():
+    import persistence
+
+    persistence.save_report(
+        report_id="r1", watch_id="w1", topic="graphene sensors", language="en",
+        markdown="# Review\n\ntext [1]\n", citation_count=3,
+        created_at="2026-07-20T00:00:00+00:00",
+    )
+
+    got = persistence.get_report("r1")
+    assert got["topic"] == "graphene sensors"
+    assert got["markdown"] == "# Review\n\ntext [1]\n"
+    assert got["citation_count"] == 3
+
+    listed = persistence.list_reports(watch_id="w1")
+    assert any(r["id"] == "r1" for r in listed)
+    assert "markdown" not in listed[0]  # list is summary-only, not the full body
+
+
+def test_save_report_upsert_overwrites_same_id():
+    import persistence
+
+    persistence.save_report(
+        report_id="r2", watch_id="", topic="t", language="en",
+        markdown="v1", citation_count=1, created_at="2026-07-20T00:00:00+00:00",
+    )
+    persistence.save_report(
+        report_id="r2", watch_id="", topic="t", language="en",
+        markdown="v2", citation_count=2, created_at="2026-07-21T00:00:00+00:00",
+    )
+    assert persistence.get_report("r2")["markdown"] == "v2"
+
+
+def test_get_report_missing_returns_none():
+    import persistence
+    assert persistence.get_report("does-not-exist") is None
+
+
+# ---------------------------------------------------------------------------
+# GET /reports, GET /reports/{report_id}
+# ---------------------------------------------------------------------------
+
+def test_list_reports_endpoint(client):
+    import persistence
+    persistence.save_report(
+        report_id="r3", watch_id="", topic="t3", language="en",
+        markdown="body", citation_count=1, created_at="2026-07-20T00:00:00+00:00",
+    )
+    resp = client.get("/reports")
+    assert resp.status_code == 200
+    assert any(r["id"] == "r3" for r in resp.json())
+
+
+def test_get_report_endpoint_404(client):
+    assert client.get("/reports/does-not-exist").status_code == 404
+
+
+def test_get_report_endpoint_returns_full_report(client):
+    import persistence
+    persistence.save_report(
+        report_id="r4", watch_id="", topic="t4", language="en",
+        markdown="full body [1]", citation_count=1, created_at="2026-07-20T00:00:00+00:00",
+    )
+    resp = client.get("/reports/r4")
+    assert resp.status_code == 200
+    assert resp.json()["markdown"] == "full body [1]"

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -17,6 +17,19 @@ def test_delete_returns_count():
     coll.delete.assert_called_once()
 
 
+def test_get_paper_chunk_counts_groups_by_paper_id():
+    import vector_store
+
+    coll = MagicMock()
+    coll.get.return_value = {"metadatas": [
+        {"paper_id": "p1"}, {"paper_id": "p1"}, {"paper_id": "p2"}, {},
+    ]}
+
+    counts = vector_store.get_paper_chunk_counts(collection=coll)
+
+    assert counts == {"p1": 2, "p2": 1}
+
+
 def test_timeout_wrapper():
     """_chroma_call raises TimeoutError when the ChromaDB operation exceeds the timeout."""
     from vector_store import _chroma_call

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -120,6 +120,40 @@ def test_metadatas_none_falls_back_to_chunk_index():
     assert premises == ["second"]
 
 
+def _fake_model_per_pair(rows):
+    """CrossEncoder stand-in returning a distinct logit row per input pair, in order."""
+    m = MagicMock()
+    m.predict = MagicMock(side_effect=lambda pairs: np.array(rows[:len(pairs)]))
+    return m
+
+
+def test_check_claims_returns_argmax_supporting_chunk():
+    """The winning (highest-entailment) chunk must be surfaced, not just its score."""
+    chunks = ["chunk with weak overlap", "chunk that strongly supports the claim"]
+    metadatas = [{"title": "PaperA"}, {"title": "PaperA"}]
+    answer = "The claim is well supported. [1]"
+
+    fake_model = _fake_model_per_pair([
+        [-2.0, 0.0, 1.0],   # low entailment for chunk 0
+        [5.0, -2.0, -3.0],  # high entailment for chunk 1
+    ])
+    with patch("verify._load", return_value=fake_model):
+        results = verify.check_claims(answer, chunks, metadatas)
+
+    assert results[0]["supporting_chunk_index"] == 1
+    assert results[0]["supporting_chunk"] == chunks[1]
+
+
+def test_supporting_chunk_truncated_for_payload_size():
+    chunks = ["x" * 1000]
+    answer = "Claim. [1]"
+
+    with patch("verify._load", return_value=_fake_model()):
+        results = verify.check_claims(answer, chunks)
+
+    assert len(results[0]["supporting_chunk"]) == 500
+
+
 def test_not_found_marker_also_merges_as_citation_only_fragment():
     answer = "No information was available on this topic. [NOT FOUND: topic] Second sentence. [1]"
     chunks = ["relevant chunk"]

--- a/tests/test_watch_routes.py
+++ b/tests/test_watch_routes.py
@@ -83,7 +83,9 @@ def test_create_watch_rejects_empty_topic(client):
 def test_list_watches_scoped_to_authenticated_user(client):
     """Each user sees only their own watches; owner comes from the API key,
     not a client-supplied field (multi-user support)."""
-    import persistence, deps, auth_utils
+    import persistence
+    import deps
+    import auth_utils
     for name, key in (("alice", "k_alice"), ("bob", "k_bob")):
         s, h = auth_utils.hash_password("pw")
         persistence.save_user(name, s, h, key, "2026-07-23T00:00:00+00:00")

--- a/tests/test_watch_routes.py
+++ b/tests/test_watch_routes.py
@@ -80,15 +80,34 @@ def test_create_watch_rejects_empty_topic(client):
         assert resp.status_code == 422
 
 
-def test_list_watches_all_and_by_user(client):
-    with patch("config.WATCH_ENABLE", True):
-        client.post("/watch", json={"user_id": "u1", "topic": "a"})
-        client.post("/watch", json={"user_id": "u1", "topic": "b"})
-        client.post("/watch", json={"user_id": "u2", "topic": "c"})
+def test_list_watches_scoped_to_authenticated_user(client):
+    """Each user sees only their own watches; owner comes from the API key,
+    not a client-supplied field (multi-user support)."""
+    import persistence, deps, auth_utils
+    for name, key in (("alice", "k_alice"), ("bob", "k_bob")):
+        s, h = auth_utils.hash_password("pw")
+        persistence.save_user(name, s, h, key, "2026-07-23T00:00:00+00:00")
+    deps._refresh_key_map()
+    try:
+        with patch("config.WATCH_ENABLE", True):
+            client.post("/watch", json={"topic": "a"}, headers={"X-API-Key": "k_alice"})
+            client.post("/watch", json={"topic": "b"}, headers={"X-API-Key": "k_alice"})
+            client.post("/watch", json={"topic": "c"}, headers={"X-API-Key": "k_bob"})
 
-        assert len(client.get("/watch").json()) == 3
-        u1 = client.get("/watch", params={"user_id": "u1"}).json()
-        assert len(u1) == 2 and all(w["user_id"] == "u1" for w in u1)
+            alice = client.get("/watch", headers={"X-API-Key": "k_alice"}).json()
+            bob = client.get("/watch", headers={"X-API-Key": "k_bob"}).json()
+            assert len(alice) == 2 and all(w["user_id"] == "alice" for w in alice)
+            assert len(bob) == 1 and bob[0]["user_id"] == "bob"
+
+            # bob cannot see or delete alice's watch — 404, not 403 (no existence leak)
+            a_id = alice[0]["id"]
+            assert client.get(f"/watch/{a_id}", headers={"X-API-Key": "k_bob"}).status_code == 404
+            assert client.delete(f"/watch/{a_id}", headers={"X-API-Key": "k_bob"}).status_code == 404
+            assert client.get(f"/watch/{a_id}", headers={"X-API-Key": "k_alice"}).status_code == 200
+    finally:
+        for name in ("alice", "bob"):
+            persistence.delete_user(name)
+        deps._refresh_key_map()
 
 
 def test_get_watch_roundtrip_and_404(client):

--- a/tests/test_watch_run.py
+++ b/tests/test_watch_run.py
@@ -144,6 +144,58 @@ def test_abstract_only_does_not_trigger_cache_refresh(monkeypatch):
     assert calls == []  # nothing was actually indexed, no refresh needed
 
 
+def test_owned_report_regenerated_when_new_papers_ingested(monkeypatch):
+    """A watch with report_id set owns a 'living review': every time it
+    actually indexes a new paper, the report regenerates in place under
+    the same report_id (no confirmation button a user would forget to click)."""
+    import persistence as persistence_module
+
+    _save("w1", report_id="rep-1")
+    _patch(monkeypatch, [_hit("2401.001")])  # has a pdf_url -> real ingest, indexed=True
+
+    saved = []
+    monkeypatch.setattr(
+        "report_runner.run_report",
+        lambda topic, language: {"markdown": "regenerated [1]", "citation_count": 1,
+                                  "sections": ["s"], "topic": topic, "language": language},
+    )
+    monkeypatch.setattr(persistence_module, "save_report",
+                        lambda **kw: saved.append(kw))
+
+    watch_runner.run_watch("w1")
+
+    assert len(saved) == 1
+    assert saved[0]["report_id"] == "rep-1"
+    assert saved[0]["markdown"] == "regenerated [1]"
+
+
+def test_owned_report_not_regenerated_when_nothing_indexed(monkeypatch):
+    import persistence as persistence_module
+
+    _save("w1", report_id="rep-1")
+    _patch(monkeypatch, [_hit("2401.003", pdf=False)])  # abstract-only, indexed=False
+
+    saved = []
+    monkeypatch.setattr("report_runner.run_report", lambda *a, **k: {"markdown": "x", "citation_count": 0})
+    monkeypatch.setattr(persistence_module, "save_report", lambda **kw: saved.append(kw))
+
+    watch_runner.run_watch("w1")
+
+    assert saved == []
+
+
+def test_watch_without_report_id_never_calls_run_report(monkeypatch):
+    _save("w1")  # no report_id
+    _patch(monkeypatch, [_hit("2401.001")])
+
+    with_call = []
+    monkeypatch.setattr("report_runner.run_report", lambda *a, **k: with_call.append(1) or {"markdown": "", "citation_count": 0})
+
+    watch_runner.run_watch("w1")
+
+    assert with_call == []
+
+
 def test_run_due_watches_runs_each_due_and_survives_failures(monkeypatch):
     ran = []
     monkeypatch.setattr(watch_runner.persistence, "due_watches",

--- a/tests/test_watch_run.py
+++ b/tests/test_watch_run.py
@@ -110,6 +110,40 @@ def test_no_new_papers_keeps_prior_digest(monkeypatch):
     assert persistence.get_watch("w1")["latest_digest"] == "OLD"  # unchanged
 
 
+def test_pdf_ingest_triggers_cache_refresh(monkeypatch):
+    _save("w1")
+    _patch(monkeypatch, [_hit("2401.001")])
+    calls = []
+    monkeypatch.setattr(watch_runner, "_post_ingest_refresh", lambda: calls.append(1))
+
+    watch_runner.run_watch("w1")
+
+    assert calls == [1]  # BM25/cache must be invalidated so the paper is searchable
+
+
+def test_corpus_duplicate_does_not_trigger_cache_refresh(monkeypatch):
+    _save("w1")
+    # ingest_pdf returns 0 chunks → duplicate/unchanged in corpus, nothing indexed
+    _patch(monkeypatch, [_hit("2401.001")], ingest=lambda *a, **k: (0, "Dup"))
+    calls = []
+    monkeypatch.setattr(watch_runner, "_post_ingest_refresh", lambda: calls.append(1))
+
+    watch_runner.run_watch("w1")
+
+    assert calls == []  # duplicate content, nothing new to make searchable
+
+
+def test_abstract_only_does_not_trigger_cache_refresh(monkeypatch):
+    _save("w1")
+    _patch(monkeypatch, [_hit("2401.003", pdf=False)])
+    calls = []
+    monkeypatch.setattr(watch_runner, "_post_ingest_refresh", lambda: calls.append(1))
+
+    watch_runner.run_watch("w1")
+
+    assert calls == []  # nothing was actually indexed, no refresh needed
+
+
 def test_run_due_watches_runs_each_due_and_survives_failures(monkeypatch):
     ran = []
     monkeypatch.setattr(watch_runner.persistence, "due_watches",

--- a/vector_store.py
+++ b/vector_store.py
@@ -251,6 +251,19 @@ def get_collection_stats(collection: chromadb.Collection = None) -> Dict[str, An
     
     return stats
 
+def get_paper_chunk_counts(collection: chromadb.Collection = None) -> Dict[str, int]:
+    """Chunk count per paper_id, for ingestion health / re-ingest tooling."""
+    if collection is None:
+        collection = get_or_create_collection()
+    got = _chroma_call(collection.get, include=['metadatas'])
+    counts: Dict[str, int] = {}
+    for meta in got.get('metadatas', []):
+        pid = (meta or {}).get('paper_id', '')
+        if pid:
+            counts[pid] = counts.get(pid, 0) + 1
+    return counts
+
+
 def delete_by_paper_id(paper_id: str, collection: chromadb.Collection = None) -> int:
     """
     Delete all chunks for a specific paper.

--- a/verify.py
+++ b/verify.py
@@ -112,7 +112,13 @@ def check_claims(answer: str, chunks: List[str], metadatas=None) -> List[dict]:
         # (config.NLI_ENTAILMENT_INDEX), since label order differs across NLI models.
         e = np.exp(raw - raw.max(axis=1, keepdims=True))
         probs = e / e.sum(axis=1, keepdims=True)
-        score = float(probs[:, config.NLI_ENTAILMENT_INDEX].max())
-        results.append({"claim": sent, "support": score,
-                        "grounded": score >= config.FAITHFULNESS_THRESHOLD})
+        entail_probs = probs[:, config.NLI_ENTAILMENT_INDEX]
+        best_idx = int(entail_probs.argmax())
+        score = float(entail_probs[best_idx])
+        results.append({
+            "claim": sent, "support": score,
+            "grounded": score >= config.FAITHFULNESS_THRESHOLD,
+            "supporting_chunk": cited_chunks[best_idx][:500],  # truncate for payload size
+            "supporting_chunk_index": best_idx,
+        })
     return results

--- a/watch_runner.py
+++ b/watch_runner.py
@@ -103,6 +103,7 @@ def run_watch(watch_id: str) -> dict:
                     markdown=new_report["markdown"],
                     citation_count=new_report["citation_count"],
                     created_at=datetime.now(timezone.utc).isoformat(),
+                    user_id=w.get("user_id"),
                 )
             except Exception as e:
                 logger.error(f"[Watch] living-review regeneration failed for {watch_id}: {e}")

--- a/watch_runner.py
+++ b/watch_runner.py
@@ -9,54 +9,19 @@ from datetime import datetime, timedelta, timezone
 import asyncio
 import logging
 import os
-import tempfile
-import urllib.request
 
 import config
 import persistence
 import rag
 from agent.tool_executor import execute_arxiv_search, execute_open_access_search
 from cache_refresh import _post_ingest_refresh
+from download_utils import download_pdf as _download_pdf
 from ingest import ingest_pdf
 
 logger = logging.getLogger(__name__)
 
 _CADENCES = {"daily": timedelta(days=1), "weekly": timedelta(days=7), "monthly": timedelta(days=30)}
 _DIGEST_MAX_TOKENS = 1200
-_MAX_PDF_BYTES = 50 * 1024 * 1024  # 50 MB cap — guards against OOM on hostile URLs
-
-
-def _download_pdf(url: str) -> str | None:
-    """Fetch a PDF to a temp file; return its path, or None on failure.
-
-    Rejects non-HTTP(S) URLs (blocks file://, ftp://, gopher:// SSRF vectors)
-    and streams with a hard size cap so a huge response can't OOM the process.
-    """
-    from urllib.parse import urlparse
-
-    if urlparse(url).scheme not in ("http", "https"):
-        logger.warning(f"[Watch] Rejected non-HTTP(S) URL: {url}")
-        return None
-    try:
-        req = urllib.request.Request(url, headers={"User-Agent": "IndicRAG/2.0"})
-        fd, path = tempfile.mkstemp(suffix=".pdf")
-        with urllib.request.urlopen(req, timeout=30) as resp, os.fdopen(fd, "wb") as f:
-            total = 0
-            while True:
-                chunk = resp.read(8192)
-                if not chunk:
-                    break
-                total += len(chunk)
-                if total > _MAX_PDF_BYTES:
-                    logger.warning(f"[Watch] PDF too large (>{_MAX_PDF_BYTES} bytes), aborting: {url}")
-                    f.close()
-                    os.unlink(path)
-                    return None
-                f.write(chunk)
-        return path
-    except Exception as e:
-        logger.warning(f"[Watch] PDF download failed {url}: {e}")
-        return None
 
 
 def _summarize(topic: str, papers: list[dict], language: str) -> str:

--- a/watch_runner.py
+++ b/watch_runner.py
@@ -16,6 +16,7 @@ import config
 import persistence
 import rag
 from agent.tool_executor import execute_arxiv_search, execute_open_access_search
+from cache_refresh import _post_ingest_refresh
 from ingest import ingest_pdf
 
 logger = logging.getLogger(__name__)
@@ -92,6 +93,7 @@ def run_watch(watch_id: str) -> dict:
 
     ingested: list[dict] = []
     new_ids: list[str] = []
+    indexed = False  # True once at least one paper was actually added to the vector store
     for p in passages:
         arxiv_id = p.get("arxiv_id")
         if not arxiv_id or arxiv_id in seen:
@@ -114,10 +116,15 @@ def run_watch(watch_id: str) -> dict:
                         pass
                 if n_chunks > 0:  # 0 = duplicate/unchanged in corpus → seen, but not "new"
                     ingested.append({"arxiv_id": arxiv_id, "title": title or p.get("title", ""), "text": p.get("text", "")})
+                    indexed = True
                 continue
         # ponytail: no PDF (or download failed) → abstract feeds the digest only;
         # indexing an abstract-only chunk is deferred to a later increment.
         ingested.append({"arxiv_id": arxiv_id, "title": p.get("title", ""), "text": p.get("text", "")})
+
+    if indexed:
+        # Invalidate caches so newly ingested papers are searchable
+        _post_ingest_refresh()
 
     digest = _summarize(topic, ingested, language) if ingested else w.get("latest_digest")
 

--- a/watch_runner.py
+++ b/watch_runner.py
@@ -91,6 +91,22 @@ def run_watch(watch_id: str) -> dict:
         # Invalidate caches so newly ingested papers are searchable
         _post_ingest_refresh()
 
+        # A watch that owns a "living review" regenerates it in place whenever
+        # it actually indexes something new — no button a user could forget to click.
+        if w.get("report_id"):
+            try:
+                import report_runner
+                new_report = report_runner.run_report(topic, language)
+                persistence.save_report(
+                    report_id=w["report_id"], watch_id=watch_id,
+                    topic=topic, language=language,
+                    markdown=new_report["markdown"],
+                    citation_count=new_report["citation_count"],
+                    created_at=datetime.now(timezone.utc).isoformat(),
+                )
+            except Exception as e:
+                logger.error(f"[Watch] living-review regeneration failed for {watch_id}: {e}")
+
     digest = _summarize(topic, ingested, language) if ingested else w.get("latest_digest")
 
     now = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary

The 2.4.0 line: feedback loop, frictionless ingestion, cross-paper comparison, corpus intelligence, an agent-invocable watch/report toolset, a citation graph, and multi-user support with per-user data isolation.

## Highlights

**Multi-user support (new)**
- Pre-provisioned users (`manage_users.py`); login by name+password (`POST /login`) returns the user's `api_key`, sent as `X-API-Key` thereafter. Passwords pbkdf2-hashed with a per-user salt (stdlib, no new dependency); login rate-limited with a generic 401.
- Personal data (watches, reports, chat sessions, prefs, feedback, query_log) is owner-stamped and ownership-enforced (404 on cross-user access), closing the old client-supplied `user_id` hole. The corpus (papers, chunks, citation graph) stays a shared library.
- Back-compat: no users seeded + `API_KEYS` unset → everyone is `default`; idempotent `ALTER TABLE` migration adds owner columns; legacy NULL rows resolve to `default`.

**Corpus intelligence & graph**
- `GET /corpus/map` — topic clusters (pure-numpy k-means) + publication-year timeline; "Library Map" UI.
- Knowledge/citation graph (Phase 1): co-citation + contradiction edges persisted (undirected, score-accumulating), `GET /graph`.

**Agent & retrieval**
- Agent-invocable `create_watch` / `generate_report` tools (config-gated).
- Frictionless ingestion by arXiv ID / DOI / URL with SSRF hardening; tags filtering; confidence/evidence; BibTeX export; ingestion health panel.

**Reports & eval**
- Durable reports; watch-owned living reviews regenerated in place.
- Versioned eval reports + CI eval gate; `GET /quality`.

## Testing
- `python -m pytest` — 261 passing (excluding live-network arxiv/open-access tests).
- New suites: `tests/test_auth.py`, `tests/test_graph.py`; expanded watch/feedback/agent/api coverage.

## Deferred
Key rotation/expiry, password reset, self-signup, per-user corpus isolation; citation-graph Phase 2 (embedding clusters/topic labels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)