### PR TITLE
v2.5 — security, reliability and retrieval performance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,17 +34,18 @@ LLM_API_KEY=your-gemini-api-key-here
 # LLM_API_KEYS=key-one,key-two,key-three
 
 # Model to use for answer generation.
-# Recommended: gemini-3.6-flash — latest Gemini Flash, fast, cost-effective.
+# Recommended: gemini-3.7-flash — current Gemini Flash, fast, cost-effective.
 # Alternatives:
-#   gemini-3.5-flash         Previous generation, stable and proven
-#   gemini-3-flash-preview   Preview alias (same model)
+#   gemini-3.6-flash         Previous generation, stable and proven
+#   gemini-3.5-flash-lite    Cheapest, for high-throughput routine calls
 #   gemini-2.5-pro           Higher reasoning quality, slower and more expensive
 LLM_MODEL_NAME=gemini-3.7-flash
 # Fallback model when primary is overloaded (503/429)
 LLM_FALLBACK_MODEL=gemma-4-26b-a4b-it
 
-# Response generation parameters
-LLM_TEMPERATURE=0.3
+# Response generation parameters. Low by default — citation-grounded answers
+# should not paraphrase creatively.
+LLM_TEMPERATURE=0.1
 LLM_MAX_TOKENS=8192
 AGENT_MAX_TOKENS=8192
 # Hard ceiling for one agentic run (seconds). Measured on a CPU-only box:
@@ -105,7 +106,8 @@ AGENT_MAX_CONTEXT_LENGTH=80000
 #   LLM_FALLBACK_PROVIDER cross-vendor fallback when the primary is exhausted
 LLM_PROVIDER=gemini
 LLM_FALLBACK_PROVIDER=openrouter
-# Get a key at https://openrouter.ai/keys . Paid, no free tier.
+# Get a key at https://openrouter.ai/keys . Pay-per-token, but the ":free"
+# slugs in the list below cost nothing beyond a shared rate limit.
 OPENROUTER_API_KEY=
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 # Models offered in the UI dropdown (comma-separated). Bare name -> Gemini;
@@ -117,6 +119,15 @@ OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 LLM_SELECTABLE_MODELS=gemini-3.7-flash,gemini-3.6-flash,gemini-3.5-flash-lite,nvidia/nemotron-3-ultra-550b-a55b:free,nvidia/nemotron-3-super-120b-a12b:free,google/gemma-4-31b-it:free,nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free,openai/gpt-oss-20b:free
 # How long the enriched OpenRouter model catalog is cached (seconds).
 MODELS_CACHE_TTL=3600
+
+
+# ==============================================================================
+# Runtime — CPU threads
+# ==============================================================================
+# Torch/ONNX default to one intra-op thread per core, which oversubscribes the box
+# once dozens of request threads are already runnable. 0 leaves the library default
+# alone; anything else caps intra-op parallelism. Read before torch is imported.
+TORCH_NUM_THREADS=4
 
 
 # ==============================================================================
@@ -139,6 +150,10 @@ ABSTAIN_COMPLETENESS_FLOOR=0.5
 # MULTIMODAL_MAX_FIGS_PER_DOC.
 ENABLE_MULTIMODAL_INGEST=false
 MULTIMODAL_MAX_FIGS_PER_DOC=12
+# Concurrent VLM caption calls per paper (1 = sequential). Keep small: this bounds
+# requests in flight at the provider, and too high just turns a slow ingest into
+# 429s that trip the LLM circuit breaker for every other caller.
+FIGURE_CAPTION_WORKERS=4
 
 
 # ==============================================================================
@@ -164,6 +179,10 @@ WATCH_ENABLE=false
 WATCH_DEFAULT_CADENCE=weekly
 WATCH_MAX_RESULTS=10
 WATCH_POLL_INTERVAL=3600
+# How long a claimed watch is parked before it becomes due again. Must comfortably
+# exceed a real run (search + ingest + digest), or a slow run could be claimed a
+# second time. Also bounds how long a watch stays stuck if the claimer dies.
+WATCH_LEASE_SECONDS=3600
 
 
 # ==============================================================================
@@ -179,7 +198,7 @@ REPORT_MAX_SECTIONS=6
 # ==============================================================================
 # Gemini Prompt Caching
 # ==============================================================================
-# gemini-3.6-flash already caches prefixes IMPLICITLY for free; this adds
+# Gemini 3.x Flash already caches prefixes IMPLICITLY for free; this adds
 # GUARANTEED caching but is billed per token-hour of storage. Leave false unless
 # your system prompts clear the model's min-token cache floor.
 GEMINI_CACHE_ENABLED=false
@@ -251,6 +270,18 @@ LOG_LEVEL=INFO
 # index — re-ingest everything after a change, or retrieval silently degrades.
 EMBEDDING_MODEL_NAME=BAAI/bge-m3
 
+# Quantized int8 ONNX embedding backend — faster on CPU, slightly different
+# vectors. Mixing backends in one collection makes vectors incomparable, so a
+# change means a reindex; every chunk records which backend produced it and a
+# mixed collection is reported at startup. Leave false on GPU (fp16 wins).
+EMBED_ONNX_INT8=false
+
+# Upserts are batched so each wait is bounded by batch size rather than corpus
+# size, and the write timeout only has to cover ONE batch. The general 5s call
+# timeout suits a query and is far too short for a corpus-sized write.
+CHROMA_UPSERT_BATCH=256
+CHROMA_WRITE_TIMEOUT_S=120
+
 # ChromaDB HNSW index parameters. ef_construction and max_neighbors (M) only
 # apply when the collection is FIRST created; ef_search applies per query and
 # can be retuned by recreating the collection.
@@ -273,6 +304,14 @@ USE_RERANKER=true
 # Hybrid retrieval: fuse dense (ChromaDB) with BM25 lexical search via
 # Reciprocal Rank Fusion. Catches exact terms/identifiers that embeddings miss.
 USE_HYBRID_SEARCH=true
+
+# Persist the BM25 index between runs. Rebuilding reads every document out of
+# ChromaDB, so without this a restart pays a full corpus scan on the first query.
+# The cache is validated against the live corpus on load and ignored when it
+# disagrees, so a stale file costs a rebuild rather than wrong results.
+BM25_PERSIST=true
+# Where that cache lives. Defaults to the chroma_db/ directory.
+# BM25_CACHE_DIR=
 
 # HyDE: draft a hypothetical answer with the LLM and embed THAT instead of the
 # bare question. Helps multi-hop/vocabulary-gap queries; costs one extra LLM
@@ -380,6 +419,12 @@ TOOL_CACHE_TTL=180
 # SQLite file holding sessions, jobs, feedback, watches, reports, query log.
 # Defaults to sessions.db in the project root.
 # SESSIONS_DB_PATH=
+
+# How long a background job's lease stays valid without a heartbeat. Every
+# progress update renews it, so this only has to exceed the longest gap BETWEEN
+# updates, not the job's total runtime. Leases that expire are reaped at startup
+# and the job is marked failed instead of sitting at "running" forever.
+JOB_LEASE_SECONDS=900
 
 # Comma-separated browser origins allowed to call the API. Unset defaults to
 # localhost:8000/8080 (dev). Set this for any real deployment — the Web UI is

--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ LLM_API_KEY=your-gemini-api-key-here
 #   gemini-3.5-flash         Previous generation, stable and proven
 #   gemini-3-flash-preview   Preview alias (same model)
 #   gemini-2.5-pro           Higher reasoning quality, slower and more expensive
-LLM_MODEL_NAME=gemini-3.6-flash
+LLM_MODEL_NAME=gemini-3.7-flash
 # Fallback model when primary is overloaded (503/429)
 LLM_FALLBACK_MODEL=gemma-4-26b-a4b-it
 
@@ -114,7 +114,7 @@ OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 # Keep at least one "/" slug in this list: cross-vendor failover picks the first
 # OpenRouter slug here. With a Gemini-only list there is no cross-vendor hop,
 # and a Google-wide outage takes every attempt down with it.
-LLM_SELECTABLE_MODELS=gemini-3.6-flash,gemini-3.5-flash,nvidia/nemotron-3-ultra-550b-a55b:free,nvidia/nemotron-3-super-120b-a12b:free,google/gemma-4-31b-it:free,nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free,openai/gpt-oss-20b:free
+LLM_SELECTABLE_MODELS=gemini-3.7-flash,gemini-3.6-flash,gemini-3.5-flash-lite,nvidia/nemotron-3-ultra-550b-a55b:free,nvidia/nemotron-3-super-120b-a12b:free,google/gemma-4-31b-it:free,nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free,openai/gpt-oss-20b:free
 # How long the enriched OpenRouter model catalog is cached (seconds).
 MODELS_CACHE_TTL=3600
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,15 @@ jobs:
         # Heavy model downloads and API keys aren't available in CI, so restrict
         # to the unit markers.
         run: pytest -q -m "not integration and not network"
+      - name: Integration tests (real ChromaDB, no model downloads)
+        # These exercise the seams BETWEEN stages — prompt assembly, citation
+        # compaction, cache population, delete consistency across both indexes —
+        # which the unit suite cannot reach because it mocks every boundary.
+        # Every v2.4 patch bug was a seam defect of exactly this kind.
+        # No API key and no model download: the embedder is stubbed at its real
+        # external boundary, and everything on our side of it is real.
+        run: pytest -q -m "integration and not network" tests/integration
+
       - name: Eval gate
         # --grounding-judge jaccard (the default) is CI-safe: it scores the
         # already-committed answers_and_citations.json, no LLM/API key needed.

--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,11 @@ graphify-out/
 # Local tool state
 .mimocode/
 .serena/
+.agents/
+.claude/
+.commandcode/
+skills-lock.json
+repo.md
 
 # Local test scratch output
 test_output.txt

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ test_output.txt
 # Generated eval artifacts — timestamped, noisy diffs; regenerate via docs/Eval/evaluate.py
 docs/Eval/eval_report.json
 docs/Eval/eval_history/
+.gstack/

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Two pipelines ship side-by-side: **Standard RAG** (single-pass hybrid retrieval)
 * **Per-stage Prometheus metrics** — `indicrag_stage_seconds` across dense retrieval, BM25, ColBERT, cross-encoder and NLI, plus counters for cache hits, LLM tokens, failover hops, breaker trips, reflexion iterations and answer outcomes. Route-level latency answers "is /query slow"; these answer "why". Timing is recorded on the error path too, since a stage that fails after 30s is the one worth seeing
 * API-key auth with per-key data isolation, env-driven CORS, Pydantic v2 validation, path-traversal + URL-scheme guards
 * **SSRF-hardened outbound fetches** — scheme allow-list, DNS resolved once with the connection pinned to that address (closing the rebinding window), per-hop redirect re-validation, and a 50 MB streaming cap. TLS still validates against the hostname, not the pinned IP
-* **int8 quantized ONNX** cross-encoders for CPU — lower memory, faster inference (~3x reranker, ~11x NLI). Optionally the embedding model too (`EMBED_ONNX_INT8`), though that one measured only 1.38x and shifts every vector, so it ships off
+* **int8 quantized ONNX** cross-encoders for CPU — lower memory, faster inference (~3x reranker, ~11x NLI). Optionally the embedding model too (`EMBED_ONNX_INT8`), though that one is more modest (see `EMBED_ONNX_INT8` in the configuration table) and shifts every vector, so it ships off
 * **Tested across the seams** — an integration suite runs a real ChromaDB through ingest, retrieval, citation compaction, caching and delete consistency. The unit suite mocks every boundary, and all three v2.4 correctness bugs lived in the seams between stages, where a mock cannot reach
 
 ### 📡 Topic Watches & Literature Reports

--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ Two pipelines ship side-by-side: **Standard RAG** (single-pass hybrid retrieval)
 * **Unbounded LLM spend closed.** `POST /report` and `POST /watch/{id}/run` each start a full LLM workload and had no rate limit; either could drain the shared quota for every other user.
 * **Concurrent turns no longer lose each other.** Two requests on one session both read history at length N and both appended, so each answer was blind to the other. A per-session lock now spans read → generate → append.
 
+### v2.5 patch — correctness fixes
+
+* **A timed-out upsert no longer escapes rollback.** The ChromaDB write timeout cannot cancel work already in flight, so a batch that timed out could still commit after the failure handler ran, leaving chunks searchable that no ingest-log record covers. Batch ids are now recorded *before* the call, so rollback covers the in-flight batch.
+* **Rollback stopped deleting pre-existing chunks.** A failed batch rolled back every id it had written, including ids that already held content from an earlier ingest — deleting rows the ingest log still records. A pre-flight probe now separates rows this call created (deleted) from rows it overwrote (kept, and logged loudly for re-ingest).
+* **A failed watch run no longer wedges the watch forever.** Scheduling read `next_run` from the JSON blob while claiming compared the column, so one failure left the two divergent and every later claim failed. Both are now updated in a single statement.
+* **BM25 index integrity.** Misaligned `ids`/`texts` raise instead of being silently truncated by `zip()`; `save_index` snapshots under the index lock; and `invalidate()` deletes the persisted caches, since chunk ids are positional and a reused id would otherwise resurrect stale text.
+* **Tags filtering works in degraded mode.** Sparse-only retrieval fetched exactly `top_k` ids and filtered afterwards, so a tag query could come back empty; it now over-fetches and pushes the filter into ChromaDB.
+* **The Gemini thinking-config ladder is bounded.** Retries classify the rejection before climbing and cannot loop.
+* **SSRF guard inspects every DNS answer**, not just the first.
+* **Agent streams hold the session turn lock** for the whole stream, and a disconnect stops the graph instead of letting it run on.
+
 ### v2.5 — breaking change
 
 `POST /watch` no longer treats `user_id` as an identity. It is a display label; authorization comes from the API key. Clients that relied on reading another user's watches by passing their `user_id` will now receive `[]` — that is the fix, not a regression.
@@ -491,7 +502,7 @@ Key settings (all overridable via environment variables):
 | `OPENROUTER_API_KEY` | (none) | OpenRouter API key for multi-provider mode |
 | `LLM_MODEL_NAME` | `gemini-3.7-flash` | Gemini model for generation |
 | `LLM_FALLBACK_MODEL` | `gemma-4-26b-a4b-it` | Fallback when primary is overloaded (503/429) |
-| `LLM_SELECTABLE_MODELS` | `gemini-3.7-flash,gemini-3.6-flash,gemini-3.5-flash-lite,anthropic/claude-haiku,openai/gpt-5.4-nano` | Curated model dropdown (comma-separated; first entry is the default). `.env.example` ships a wider free-tier list. Bare name → Gemini, `/` slug → OpenRouter — **keep at least one `/` slug**, since cross-vendor failover picks the first one here |
+| `LLM_SELECTABLE_MODELS` | `gemini-3.7-flash,gemini-3.6-flash,gemini-3.5-flash-lite,nvidia/nemotron-3-super-120b-a12b:free,google/gemma-4-31b-it:free` | Curated model dropdown (comma-separated; first entry is the default). `.env.example` ships a wider free-tier list. Bare name → Gemini, `/` slug → OpenRouter — **keep at least one `/` slug**, since cross-vendor failover picks the first one here |
 | `LLM_MAX_TOKENS` | `8192` | Max tokens for standard RAG (covers thinking + answer) |
 | `AGENT_MAX_TOKENS` | `8192` | Max tokens for agentic pipeline |
 | `AGENT_TIMEOUT` | `300` | Agent pipeline timeout (seconds) → 504. Must leave room for `AGENT_EVAL_RESERVE_S`, or verification is skipped on every run |
@@ -705,9 +716,12 @@ rather than a re-ingest:
 ```bash
 python reindex.py --check          # report drift between the log and current config
 python reindex.py --dry-run        # show what a rebuild would do
-python reindex.py                  # rebuild the live collection
+python reindex.py --yes            # rebuild the live collection (destructive)
 python reindex.py --into staging   # rebuild elsewhere, verify, then switch
 ```
+
+A rebuild resets the target collection before replaying, so rebuilding the *live*
+collection without `--yes` refuses and says so. `--into staging` needs no flag.
 
 Replay **re-embeds** recorded chunks; it does not re-chunk. So it implements an
 embedding-model change and **not** a chunker change — a chunker change needs a real

--- a/README.md
+++ b/README.md
@@ -5,15 +5,43 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.130+-00a393.svg)](https://fastapi.tiangolo.com/)
-[![Google Gemini](https://img.shields.io/badge/Google%20Gemini-3.6%20Flash-blueviolet.svg)](https://ai.google.dev/)
+[![Google Gemini](https://img.shields.io/badge/Google%20Gemini-3.7%20Flash-blueviolet.svg)](https://ai.google.dev/)
 [![LangGraph](https://img.shields.io/badge/LangGraph-agent--pipeline-orange.svg)](https://github.com/langchain-ai/langgraph)
-![Version](https://img.shields.io/badge/version-2.4-blue.svg)
+![Version](https://img.shields.io/badge/version-2.5-blue.svg)
 
 ![INDICRAG.png](https://cdn.jsdelivr.net/gh/free-whiteboard-online/Free-Erasorio-Alternative-for-Collaborative-Design@3a5f22554411d3d6df27ee788c2df99d583f2c91/uploads/2025-12-03T05-25-45-007Z-3i36rbzio.png)
 
 A **production-ready** Retrieval-Augmented Generation system with an **agentic pipeline**, multilingual support for 10+ Indian languages, and tools for searching arXiv, Semantic Scholar, OpenAlex, and the web — alongside your own indexed document corpus.
 
 Two pipelines ship side-by-side: **Standard RAG** (single-pass hybrid retrieval) and **Agentic RAG** (multi-tool planning with reflexion self-correction). Answers stream token-by-token over SSE, sessions survive restarts, and every retrieval knob is env-configurable. Now with **multi-provider LLM** support (Gemini + OpenRouter), **topic watches**, and **literature review reports**.
+
+---
+
+## What's New in v2.5
+
+| Area | v2.4 | v2.5 |
+|------|------|------|
+| **Default model** | gemini-3.6-flash | **gemini-3.7-flash** — current Flash generation, built for agentic multi-step work |
+| **Data isolation** | Advertised, but only jobs enforced it | **Actually enforced** — sessions, watches, feedback, reports and prefs are scoped by API-key fingerprint |
+| **BM25** | Linear scan, dropped on every ingest | **Inverted index** (9x faster), incremental add/remove, persisted to disk (8x faster cold start) |
+| **Failure modes** | A sick ChromaDB or embedder failed every request | **Circuit breaker + sparse-only degraded mode**, surfaced as a `degraded` response field |
+| **Background jobs** | Left `running` forever after a crash | **Leased and reaped** — abandoned jobs are failed at startup with an actionable error |
+| **Watch scheduler** | Every worker ran every due watch | **Claimed** via compare-and-set, so replicas cannot duplicate ingests or LLM spend |
+| **Index provenance** | Nothing recorded which model made a vector | **Stamped** with model, dimension, backend and chunker version; mismatches reported at startup |
+| **Reindexing** | Re-parse every PDF, re-caption every figure | **`reindex.py`** replays an ingest log — reproducible, and works without the source PDFs |
+| **Observability** | HTTP latency only | **Per-stage metrics** — retrieval, rerank, NLI, cache hits, tokens, breaker trips, failover hops |
+| **Tests** | Every boundary mocked | **+ integration suite** over a real ChromaDB, covering the seams between stages |
+
+### v2.5 — security fixes
+
+* **Cross-user data exposure closed.** `GET /chat` and `GET /chat/{id}` listed and returned *every* user's conversations, and `DELETE /chat/{id}` deleted any of them. `GET /watch` took `user_id` as a query parameter, so omitting it returned all users' watches and supplying someone else's returned theirs. Feedback and report listings had no owner column at all — and the feedback join exposes the original question and answer text. Ownership is now the API-key fingerprint, never client input, and another key's record reads as `404` rather than `403` (a 403 confirms the id exists).
+* **SSRF DNS rebinding closed.** The private-IP guard and `urlopen`'s own lookup were two separate DNS queries, so a rebinding resolver could answer public for the check and `169.254.169.254` for the fetch. Resolution now happens once and the connection is pinned to that address; TLS still validates against the hostname.
+* **Unbounded LLM spend closed.** `POST /report` and `POST /watch/{id}/run` each start a full LLM workload and had no rate limit; either could drain the shared quota for every other user.
+* **Concurrent turns no longer lose each other.** Two requests on one session both read history at length N and both appended, so each answer was blind to the other. A per-session lock now spans read → generate → append.
+
+### v2.5 — breaking change
+
+`POST /watch` no longer treats `user_id` as an identity. It is a display label; authorization comes from the API key. Clients that relied on reading another user's watches by passing their `user_id` will now receive `[]` — that is the fix, not a regression.
 
 ---
 
@@ -66,11 +94,12 @@ Two pipelines ship side-by-side: **Standard RAG** (single-pass hybrid retrieval)
 
 ### 🔍 Hybrid Retrieval Pipeline
 
-* **Dense + sparse** — BGE-M3 (1024d) fused with BM25 via Reciprocal Rank Fusion (RRF)
+* **Dense + sparse** — BGE-M3 (1024d) fused with a BM25 **inverted index** via Reciprocal Rank Fusion (RRF). Scoring touches only the documents containing a query term, so cost tracks term frequency rather than corpus size (measured on 20k chunks: 25.9 ms → 2.9 ms per query). Updates are incremental — an ingest folds new chunks in instead of dropping the index and making the next query rebuild it (2.93 s → 3.8 ms), and the index persists across restarts
 * **Two-stage reranking** — `BAAI/bge-reranker-v2-m3` cross-encoder, with optional **ColBERT** multi-vector MaxSim rerank on the narrowed candidate set
 * **Optional HyDE** — generate a hypothetical answer, embed it, and retrieve against it for recall on sparse queries
 * **Faithfulness verification** — a multilingual NLI cross-encoder (`NLI_MODEL_NAME`, int8 ONNX on CPU) scores entailment per claim against its cited chunks; unsupported assertions flagged, stripped, or regenerated (`FAITHFULNESS_ENFORCE`). The threshold is **model-specific and calibrated**, not a taste setting — see `FAITHFULNESS_THRESHOLD`
 * **Citation integrity** — the answer's `[N]` markers are renumbered to a dense `1..M` matching the cited-only source panel, and markers are resolved against **only the chunks that reached the prompt**. The context is truncated by chunk count and by length, so numbering against everything retrieved let a marker the model invented resolve to a real paper it was never shown — a phantom citation that reads as legitimate. Unresolvable markers are dropped rather than left dangling
+* **Graceful degradation** — ChromaDB sits behind a circuit breaker (3 consecutive timeouts → fail fast for 60s), so an unhealthy store cannot make every request pay the full timeout and exhaust the thread pool. An embedding failure degrades to BM25-only rather than failing the query, and the response carries `degraded: "sparse_only"` so a reduced answer is never presented as a normal one
 * **HNSW tuning knobs** — `ef_search`, `ef_construction`, `M` all env-configurable
 
 ### 📥 Smart Ingestion
@@ -80,6 +109,8 @@ Two pipelines ship side-by-side: **Standard RAG** (single-pass hybrid retrieval)
 * **Metadata enrichment** — auto-fetch authors, year, DOI from arXiv by fuzzy title match at ingest time
 * **Title dedup** — near-duplicate papers rejected by `SequenceMatcher` ratio (`DEDUP_TITLE_THRESHOLD`)
 * **MD5 content dedup** + parallel extraction, Indic-aware chunking
+* **Index provenance** — every chunk records the embedding model, dimension, backend (`fp32` / `fp16` / `onnx-int8`) and chunker version that produced it. Cosine distance between two embedding spaces is meaningless but never raises, so a model swap otherwise shows up only as retrieval quality quietly getting worse; mismatches are reported at startup instead
+* **Replayable ingest log** — each ingestion records the chunks it produced, making the vector and lexical indexes derived views. `reindex.py` rebuilds them from that log without re-parsing PDFs or re-captioning figures, which is what turns an embedding-model change from an unreproducible afternoon into a routine replay
 
 ### 🌍 True Multilingual Support
 
@@ -91,12 +122,17 @@ Two pipelines ship side-by-side: **Standard RAG** (single-pass hybrid retrieval)
 ### 🛡️ Production-Ready Infrastructure
 
 * **SQLite session/job persistence** — restarts don't drop in-flight state (`SESSIONS_DB_PATH`)
+* **Leased jobs, reaped on restart** — jobs heartbeat while running, and startup fails the ones whose lease expired. A crash used to leave the row saying `running` forever while clients polled a job that no longer existed in any process. Reaping on an expired lease (rather than "not started by me") keeps it safe with multiple workers: a live worker's jobs are never taken from under it
+* **Claimed watch scheduling** — the schedule loop runs in-process, so every worker sees the same watch as due. A compare-and-set claim means only one runs it, instead of each replica repeating the arXiv fetch, the ingest and the digest spend
 * **SSE streaming** — token-by-token answers and live ingest progress; the `done` event carries the citation-corrected answer, since chunks stream before numbering can be resolved
 * Thread-safe model init (double-checked locking on all singletons)
 * Startup warm-up via FastAPI lifespan (embeddings, vector store, reranker, BM25) — no cold first request
-* Request-ID correlation across log lines; Prometheus metrics
-* API-key auth, env-driven CORS, Pydantic v2 validation, path-traversal + URL-scheme guards
-* **int8 quantized ONNX** cross-encoders for CPU — lower memory, faster inference
+* Request-ID correlation across log lines
+* **Per-stage Prometheus metrics** — `indicrag_stage_seconds` across dense retrieval, BM25, ColBERT, cross-encoder and NLI, plus counters for cache hits, LLM tokens, failover hops, breaker trips, reflexion iterations and answer outcomes. Route-level latency answers "is /query slow"; these answer "why". Timing is recorded on the error path too, since a stage that fails after 30s is the one worth seeing
+* API-key auth with per-key data isolation, env-driven CORS, Pydantic v2 validation, path-traversal + URL-scheme guards
+* **SSRF-hardened outbound fetches** — scheme allow-list, DNS resolved once with the connection pinned to that address (closing the rebinding window), per-hop redirect re-validation, and a 50 MB streaming cap. TLS still validates against the hostname, not the pinned IP
+* **int8 quantized ONNX** cross-encoders for CPU — lower memory, faster inference (~3x reranker, ~11x NLI). Optionally the embedding model too (`EMBED_ONNX_INT8`), though that one measured only 1.38x and shifts every vector, so it ships off
+* **Tested across the seams** — an integration suite runs a real ChromaDB through ingest, retrieval, citation compaction, caching and delete consistency. The unit suite mocks every boundary, and all three v2.4 correctness bugs lived in the seams between stages, where a mock cannot reach
 
 ### 📡 Topic Watches & Literature Reports
 
@@ -163,7 +199,9 @@ TAVILY_API_KEY=your_tavily_key_here
 AGENT_MAX_TOKENS=8192
 
 # Optional — thinking level (Gemini 3.x): minimal|low|medium|high, empty = model default
-# Empty is not neutral: gemini-3.6-flash then thinks at medium, out of LLM_MAX_TOKENS
+# Empty is not neutral: the model then thinks at its own default (medium), out of
+# LLM_MAX_TOKENS. Not every model offers every level — gemini-3.7-flash rejects
+# minimal, and the backend escalates one level up rather than failing the call.
 LLM_THINKING_LEVEL=minimal
 AGENT_THINKING_LEVEL=minimal
 
@@ -289,9 +327,9 @@ for src in data['sources']:
 | `/query/stream` | POST | Same, streamed token-by-token (SSE) |
 | `/chat` | POST | Multi-turn chat with persisted session history |
 | `/chat/stream` | POST | Streamed multi-turn chat (SSE) |
-| `/chat/{session_id}` | DELETE | Clear a chat session |
-| `/chat` | GET | List persisted chat sessions |
-| `/chat/{session_id}` | GET | Fetch one session's history |
+| `/chat/{session_id}` | DELETE | Clear a chat session (owner only) |
+| `/chat` | GET | List **your own** persisted chat sessions |
+| `/chat/{session_id}` | GET | Fetch one session's history (owner only; other keys get 404) |
 | `/agent/query` | POST | Agentic pipeline with reflexion loops (timeout → 504) |
 | `/agent/stream` | POST | Agentic pipeline, streamed step-by-step (SSE) |
 | `/compare` | POST | Kick off a multi-model answer comparison (async, returns `job_id`) |
@@ -312,26 +350,43 @@ for src in data['sources']:
 | `/papers` | GET | List uploaded PDFs |
 | `/papers/{paper_id}` | PATCH | Edit paper metadata (title, authors, year, tags) |
 | `/papers/{paper_id}` | DELETE | Delete a single paper |
-| `/watch` | GET/POST | List or create topic watches |
-| `/watch/{id}` | GET/DELETE | Read or delete a watch |
-| `/watch/{id}/run` | POST | Trigger a watch run immediately |
+| `/watch` | GET/POST | List or create topic watches (scoped to your key; `user_id` is a label) |
+| `/watch/{id}` | GET/DELETE | Read or delete a watch (owner only) |
+| `/watch/{id}/run` | POST | Trigger a watch run immediately — **rate-limited 5/min** (spends LLM budget) |
 | `/watch/{id}/digest` | GET | Fetch persisted digest for a watch |
-| `/report` | POST | Kick off a literature review report |
+| `/report` | POST | Kick off a literature review report — **rate-limited 5/min** (spends LLM budget) |
 | `/report/status/{job_id}` | GET | Report generation status |
 | `/report/{job_id}/download` | GET | Download completed report (Markdown) |
-| `/reports` | GET | List saved reports |
-| `/reports/{report_id}` | GET | Fetch one saved report |
+| `/reports` | GET | List **your own** saved reports |
+| `/reports/{report_id}` | GET | Fetch one saved report (owner only) |
 | `/feedback` | POST | Submit answer feedback |
-| `/feedback` | GET | List submitted feedback |
-| `/feedback/stats` | GET | Aggregate feedback counts |
-| `/prefs/{user_id}` | GET / PUT | Read / update user preferences |
+| `/feedback` | GET | List **your own** feedback, joined with its query context |
+| `/feedback/stats` | GET | Aggregate feedback counts for your key |
+| `/prefs/{user_id}` | GET / PUT | Read / update preferences (stored against your key, not the path label) |
 | `/stats` | GET | Vector store statistics |
 | `/quality` | GET | Index quality signals (chunk/metadata coverage) |
 | `/cache/stats` | GET | Cache hit rates, sizes, TTL config |
 | `/cache` | DELETE | Clear all caches |
-| `/health` | GET | Health check |
+| `/health` | GET | Health check (`?deep=true` for component checks) |
+| `/metrics` | GET | Prometheus metrics incl. per-stage timings (API key required) |
 | `/purge/papers` | DELETE | Delete all PDFs (admin key) |
 | `/purge/database` | DELETE | Clear vector database (admin key) |
+
+### Ownership and scoping
+
+Every read and delete listed above is scoped by a SHA-256 fingerprint of the caller's
+`X-API-Key`. A record owned by another key responds `404`, never `403` — a 403 would
+confirm the id exists. Records written before scoping existed carry no owner and are
+not visible to ordinary keys.
+
+When `API_KEYS` is unset the server is single-tenant, there is nothing to scope
+against, and all records are visible to the anonymous caller.
+
+### Response fields added in v2.5
+
+| Field | Where | Meaning |
+|---|---|---|
+| `degraded` | `QueryResponse`, `ChatResponse`, SSE `done` event | `null` normally. `"sparse_only"` means the dense retrieval leg was unavailable and the answer came from BM25 alone — lower quality, and clients should say so rather than presenting it as a normal answer. |
 
 ---
 
@@ -375,7 +430,9 @@ IndicRAG/
 │   ├── cache.py                     # Thread-safe TTL LRU cache (LLM/retrieval/tool)
 │   ├── watch_runner.py              # Background topic-watch digest loop
 │   ├── report_runner.py             # Async literature-review report generation
-│   └── purge.py                     # CLI cleanup (papers, db, models)
+│   ├── purge.py                     # CLI cleanup (papers, db, models)
+│   ├── reindex.py                   # Rebuild indexes by replaying the ingest log
+│   └── metrics.py                   # Per-stage Prometheus timings and counters
 │
 ├── 🔌 providers/                     # LLM provider backends
 │   ├── base.py                      # LLMBackend interface
@@ -432,9 +489,9 @@ Key settings (all overridable via environment variables):
 | `LLM_PROVIDER` | `gemini` | Primary LLM provider: `gemini` or `openrouter` |
 | `LLM_FALLBACK_PROVIDER` | `openrouter` | Cross-provider failover when the primary is down |
 | `OPENROUTER_API_KEY` | (none) | OpenRouter API key for multi-provider mode |
-| `LLM_MODEL_NAME` | `gemini-3.6-flash` | Gemini model for generation |
+| `LLM_MODEL_NAME` | `gemini-3.7-flash` | Gemini model for generation |
 | `LLM_FALLBACK_MODEL` | `gemma-4-26b-a4b-it` | Fallback when primary is overloaded (503/429) |
-| `LLM_SELECTABLE_MODELS` | `gemini-3.6-flash,gemini-3.5-flash,anthropic/claude-haiku,openai/gpt-5.4-nano` | Curated model dropdown (comma-separated; first entry is the default). `.env.example` ships a wider free-tier list. Bare name → Gemini, `/` slug → OpenRouter — **keep at least one `/` slug**, since cross-vendor failover picks the first one here |
+| `LLM_SELECTABLE_MODELS` | `gemini-3.7-flash,gemini-3.6-flash,gemini-3.5-flash-lite,anthropic/claude-haiku,openai/gpt-5.4-nano` | Curated model dropdown (comma-separated; first entry is the default). `.env.example` ships a wider free-tier list. Bare name → Gemini, `/` slug → OpenRouter — **keep at least one `/` slug**, since cross-vendor failover picks the first one here |
 | `LLM_MAX_TOKENS` | `8192` | Max tokens for standard RAG (covers thinking + answer) |
 | `AGENT_MAX_TOKENS` | `8192` | Max tokens for agentic pipeline |
 | `AGENT_TIMEOUT` | `300` | Agent pipeline timeout (seconds) → 504. Must leave room for `AGENT_EVAL_RESERVE_S`, or verification is skipped on every run |
@@ -443,7 +500,7 @@ Key settings (all overridable via environment variables):
 | `AGENT_REFLEXION_BUDGET_S` | `90` | Wall-clock budget for reflexion **loops** — blocks starting another cycle, from iteration 2 onwards |
 | `AGENT_EVAL_RESERVE_S` | `90` | Room that must remain under `AGENT_TIMEOUT` to attempt an evaluation at all. Can skip iteration 1, but only when finishing would overrun the timeout and discard the draft |
 | `AGENT_THINKING_BUDGET` | `0` | **Legacy.** Agent thinking tokens: `0`=off, `-1`=dynamic, `N`=cap. Gemini 3.x models reject this field; the backend translates it to a level |
-| `LLM_THINKING_LEVEL` | `minimal` | Thinking level for standard RAG — the Gemini 3.x control. `minimal`, `low`, `medium`, `high`, or empty to accept the model default. **Not neutral:** `gemini-3.6-flash` defaults to `medium`, and those thought tokens come out of `LLM_MAX_TOKENS`, squeezing the answer |
+| `LLM_THINKING_LEVEL` | `minimal` | Thinking level for standard RAG — the Gemini 3.x control. `minimal`, `low`, `medium`, `high`, or empty to accept the model default. **Not neutral:** the model's own default is `medium`, and those thought tokens come out of `LLM_MAX_TOKENS`, squeezing the answer. Not every model offers every level — `gemini-3.7-flash` rejects `minimal`; the backend learns that per model and escalates one level up rather than failing |
 | `AGENT_THINKING_LEVEL` | `minimal` | Same, for the agentic pipeline |
 | `AGENT_MAX_SUB_QUERIES` | `3` | Cap per-cycle retrievals to bound latency |
 | `CONTRADICTION_DETECT_ENABLE` | `false` | NLI-based cross-source contradiction flagging |
@@ -469,6 +526,13 @@ Key settings (all overridable via environment variables):
 | `ENRICH_METADATA` | `true` | Auto-fetch arXiv metadata at ingest |
 | `DEDUP_PAPERS` | `true` | Reject near-duplicate titles |
 | `DEDUP_TITLE_THRESHOLD` | `0.9` | Title similarity cutoff for dedup |
+| `EMBED_ONNX_INT8` | `false` | int8 ONNX embeddings on CPU. 1.4x on a small synthetic batch, **1.9x on a real bulk ingest** (batch 32, long chunks) — an 84-minute corpus embed dropped to ~45. But it shifts every vector (cosine ~0.987 vs fp32), so near-neighbours can reorder and retrieval may change. Switching requires re-embedding the whole corpus; every chunk records its backend so a mixed one is flagged at startup. Opt in deliberately, ideally with a working eval gate |
+| `TORCH_NUM_THREADS` | `4` | Caps torch/ONNX intra-op threads; `0` leaves library defaults alone. The process already runs several pools, and each library otherwise takes one thread per core. Raise it (or set `0`) for a bulk ingest on a many-core box, where one job wants everything |
+| `BM25_PERSIST` | `true` | Save the BM25 index to disk so a restart skips the rebuild (8x faster cold start). Validated against the live document count and ignored when stale |
+| `BM25_CACHE_DIR` | `chroma_db/` | Where that index cache lives |
+| `JOB_LEASE_SECONDS` | `900` | How long an in-flight job's lease survives without a heartbeat. Only has to exceed the gap *between* progress updates, not the job's total runtime |
+| `WATCH_LEASE_SECONDS` | `3600` | How long a claimed watch is parked before becoming due again. Must exceed a real run, and bounds how long a watch stalls if its claimer dies |
+| `FIGURE_CAPTION_WORKERS` | `4` | Concurrent VLM caption calls per paper; `1` restores sequential. Keep small — unbounded fan-out trades slow ingest for 429s |
 | `HNSW_EF_SEARCH` | `100` | ChromaDB HNSW query-time search breadth |
 | `HNSW_EF_CONSTRUCTION` | `100` | HNSW build-time breadth (index quality vs. ingest speed) |
 | `HNSW_M` | `16` | HNSW graph connectivity |
@@ -633,13 +697,50 @@ python purge.py --models      # Remove cached models
 python purge.py --all --yes   # Clear everything
 ```
 
+### Reindexing
+
+The search indexes are derived views over the ingest log, so a rebuild is a replay
+rather than a re-ingest:
+
+```bash
+python reindex.py --check          # report drift between the log and current config
+python reindex.py --dry-run        # show what a rebuild would do
+python reindex.py                  # rebuild the live collection
+python reindex.py --into staging   # rebuild elsewhere, verify, then switch
+```
+
+Replay **re-embeds** recorded chunks; it does not re-chunk. So it implements an
+embedding-model change and **not** a chunker change — a chunker change needs a real
+re-ingest from the PDFs, and `--check` says so rather than letting you believe you
+migrated when you did not. Papers ingested before the log existed are not replayable;
+`--check` reports that too.
+
+### Retrieval evaluation
+
+```bash
+cd docs/Eval
+python run_live.py                 # run judged queries through the live pipeline
+python evaluate.py --ci --threshold 0.85
+```
+
+`evaluate.py` scores whatever sits in `answers_and_citations.json`. That file was
+originally hand-written, so the CI gate scored a frozen snapshot and no code change
+could move the number. `run_live.py` regenerates it from the real pipeline, which is
+what makes the gate able to fail. It refuses to run when the judged papers are not in
+the indexed corpus, since that produces a uniform 0.000 indistinguishable from
+"retrieval is completely broken".
+
 ---
 
 ## 🤝 Contributing
 
 Contributions welcome! See [CONTRIBUTING.md](docs/CONTRIBUTING.md).
 
-**v2.4 highlights:** gemini-3.6-flash default model · multi-user data isolation with per-API-key scoping · configurable session management · dedicated admin API key · clean CI linting. Full history in the git log and `docs/`.
+**v2.5 highlights:** gemini-3.7-flash default · per-API-key data isolation actually enforced · SSRF DNS pinning · BM25 inverted index with incremental updates and disk persistence · ChromaDB circuit breaker and sparse-only degraded mode · leased jobs reaped on restart · claimed watch scheduling · index provenance stamps · replayable ingest log and `reindex.py` · per-stage Prometheus metrics · integration test suite.
+
+**v2.4 highlights:** gemini-3.6-flash default model · multi-user data isolation with per-API-key scoping · configurable session management · dedicated admin API key · clean CI linting.
+
+Full history in the git log and `docs/` — see [ARCHITECTURE_REVIEW_v2.4.md](docs/ARCHITECTURE_REVIEW_v2.4.md) for the review that drove most of v2.5, including what was deliberately deferred and why.
 
 ---
 

--- a/api_server.py
+++ b/api_server.py
@@ -39,7 +39,15 @@ async def lifespan(app):
     import embeddings
     import vector_store
     embeddings.load_embedding_model()
-    vector_store.get_or_create_collection()
+    collection = vector_store.get_or_create_collection()
+
+    # Loud at startup rather than silent at query time: comparing vectors from two
+    # different embedding spaces is meaningless but never raises, so a model or
+    # chunker swap otherwise shows up only as retrieval quality quietly getting
+    # worse — which is nearly undebuggable from the outside.
+    problem = vector_store.check_index_compatibility(collection)
+    if problem:
+        logger.warning("INDEX PROVENANCE: %s", problem)
     if config.USE_RERANKER:
         import rerank
         rerank._load()

--- a/api_server.py
+++ b/api_server.py
@@ -48,6 +48,26 @@ async def lifespan(app):
     problem = vector_store.check_index_compatibility(collection)
     if problem:
         logger.warning("INDEX PROVENANCE: %s", problem)
+
+    # Jobs run inside this process, so anything left in-flight by the previous
+    # one is dead — but the row still said `running`, and clients polled it
+    # forever. Reap by expired lease, so a job another live worker is still
+    # heartbeating is left alone.
+    from datetime import datetime, timezone
+    import persistence
+    import deps
+    reaped = persistence.reap_stale_jobs(datetime.now(timezone.utc).isoformat())
+    if reaped:
+        # deps._jobs was hydrated from SQLite at import, before this ran, so the
+        # in-memory copies still say `running`. Status is served from memory, so
+        # both have to move or the API would keep reporting the stale state.
+        with deps._jobs_lock:
+            for job in reaped:
+                jid = job.get("job_id")
+                if jid in deps._jobs:
+                    deps._jobs[jid].update(job)
+        logger.warning("Reaped %d job(s) abandoned by a previous process: %s",
+                       len(reaped), ", ".join(j.get("job_id", "?") for j in reaped))
     if config.USE_RERANKER:
         import rerank
         rerank._load()

--- a/bm25_search.py
+++ b/bm25_search.py
@@ -254,18 +254,22 @@ def save_index(coll_name: str = None) -> bool:
         path = _cache_path(name)
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
-            payload = {
-                "format": _CACHE_FORMAT,
-                "k1": idx.k1,
-                "b": idx.b,
-                "doc_ids": idx.doc_ids,
-                "doc_lens": idx.doc_lens,
-                "postings": {t: [list(p) for p in ps] for t, ps in idx.postings.items()},
-                "deleted": sorted(idx._deleted),
-                "total_len": idx._total_len,
-                "id_fingerprint": _id_fingerprint(
-                    [d for i, d in enumerate(idx.doc_ids) if i not in idx._deleted]),
-            }
+            # Snapshot under the index's own lock: a concurrent add_documents
+            # between reading doc_ids and reading postings would serialise a
+            # payload that never existed.
+            with idx._lock:
+                payload = {
+                    "format": _CACHE_FORMAT,
+                    "k1": idx.k1,
+                    "b": idx.b,
+                    "doc_ids": list(idx.doc_ids),
+                    "doc_lens": list(idx.doc_lens),
+                    "postings": {t: [list(p) for p in ps] for t, ps in idx.postings.items()},
+                    "deleted": sorted(idx._deleted),
+                    "total_len": idx._total_len,
+                    "id_fingerprint": _id_fingerprint(
+                        [d for i, d in enumerate(idx.doc_ids) if i not in idx._deleted]),
+                }
             tmp = path.with_suffix(".tmp")
             with gzip.open(tmp, "wt", encoding="utf-8") as f:
                 json.dump(payload, f, separators=(",", ":"))
@@ -330,6 +334,11 @@ def add_to_index(ids: List[str], texts: List[str], collection_name: str = None) 
     """
     if not ids:
         return True
+    if len(ids) != len(texts):
+        # zip() would silently drop the tail and leave the index quietly short of
+        # the collection — a wrong index is worse than a failed ingest.
+        raise ValueError(
+            f"add_to_index got {len(ids)} ids but {len(texts)} texts")
     with _lock:
         if collection_name is not None:
             targets = [_indices[collection_name]] if collection_name in _indices else []
@@ -368,4 +377,13 @@ def invalidate():
     """
     global _indices
     with _lock:
+        names = list(_indices)
         _indices = {}
+    # Drop the on-disk copies too. The id fingerprint catches a changed corpus,
+    # but not text edited under unchanged ids (reindex), so a surviving file
+    # could be reloaded and serve the old text.
+    for name in names:
+        try:
+            _cache_path(name).unlink(missing_ok=True)
+        except OSError:
+            logger.warning("Could not delete BM25 cache for '%s'", name, exc_info=True)

--- a/bm25_search.py
+++ b/bm25_search.py
@@ -14,14 +14,23 @@ Updates are incremental (`add_documents`, `remove_documents`), so an ingest no
 longer throws the whole index away and leaves the next query paying for a full
 rebuild.
 """
+import gzip
+import json
 import math
+import os
 import regex
 import threading
 import logging
 from collections import Counter, defaultdict
 from typing import List, Dict, Optional, Tuple
 
+import config
+
 logger = logging.getLogger(__name__)
+
+# Bump when the on-disk shape changes; an older file is then ignored, not
+# misread — a silently misinterpreted index is worse than a rebuild.
+_CACHE_FORMAT = 1
 
 _indices: dict[str, "BM25Index"] = {}
 _lock = threading.Lock()
@@ -161,8 +170,96 @@ def rrf(dense_ids: List[str], sparse_ids: List[str], k: int = 60) -> List[str]:
     return sorted(scores, key=scores.get, reverse=True)
 
 
+def _cache_path(coll_name: str) -> "pathlib.Path":
+    safe = regex.sub(r"[^\w.-]", "_", coll_name)
+    return config.BM25_CACHE_DIR / f"bm25_{safe}.pkl"
+
+
+def _load_cached(coll_name: str, expected_docs: int) -> Optional["BM25Index"]:
+    """Load a persisted index, or None if it is missing, unreadable, or stale.
+
+    Staleness is judged on live document count: the corpus changing under a saved
+    index is exactly when it must not be trusted. A corrupt or version-mismatched
+    file is not an error — it just means rebuild.
+    """
+    path = _cache_path(coll_name)
+    if not path.exists():
+        return None
+    try:
+        with gzip.open(path, "rt", encoding="utf-8") as f:
+            payload = json.load(f)
+        if payload.get("format") != _CACHE_FORMAT:
+            return None
+        idx = BM25Index(k1=payload["k1"], b=payload["b"])
+        idx.doc_ids = payload["doc_ids"]
+        idx.doc_lens = payload["doc_lens"]
+        idx.postings = defaultdict(list, {t: [tuple(p) for p in ps]
+                                          for t, ps in payload["postings"].items()})
+        idx._deleted = set(payload["deleted"])
+        idx._total_len = payload["total_len"]
+        if idx.n_docs != expected_docs:
+            logger.info("BM25 cache for '%s' is stale (%d docs on disk vs %d live); rebuilding",
+                        coll_name, idx.n_docs, expected_docs)
+            return None
+        logger.info("BM25 index for '%s' loaded from cache (%d docs)", coll_name, idx.n_docs)
+        return idx
+    except Exception:
+        logger.warning("BM25 cache unreadable for '%s'; rebuilding", coll_name, exc_info=True)
+        return None
+
+
+def save_index(coll_name: str = None) -> bool:
+    """Persist an in-memory index so the next process start skips the rebuild.
+
+    Gzipped JSON rather than pickle: this file is read back and trusted at
+    startup, and unpickling attacker-controlled bytes is arbitrary code
+    execution. JSON can only ever produce data. Gzip keeps it compact — the
+    postings dominate the size.
+
+    Best-effort: a failure to save costs a rebuild later, never a request now.
+    Writes to a temp file and replaces atomically, so a crash mid-write cannot
+    leave a half-written index for the next start to load.
+    """
+    with _lock:
+        if coll_name is None:
+            items = list(_indices.items())
+        else:
+            items = [(coll_name, _indices[coll_name])] if coll_name in _indices else []
+    if not items:
+        return False
+    ok = True
+    for name, idx in items:
+        path = _cache_path(name)
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "format": _CACHE_FORMAT,
+                "k1": idx.k1,
+                "b": idx.b,
+                "doc_ids": idx.doc_ids,
+                "doc_lens": idx.doc_lens,
+                "postings": {t: [list(p) for p in ps] for t, ps in idx.postings.items()},
+                "deleted": sorted(idx._deleted),
+                "total_len": idx._total_len,
+            }
+            tmp = path.with_suffix(".tmp")
+            with gzip.open(tmp, "wt", encoding="utf-8") as f:
+                json.dump(payload, f, separators=(",", ":"))
+            os.replace(tmp, path)
+            logger.info("BM25 index for '%s' saved to %s (%d docs)", name, path, idx.n_docs)
+        except Exception:
+            logger.warning("Could not persist BM25 index for '%s'", name, exc_info=True)
+            ok = False
+    return ok
+
+
 def get_or_build_index(collection=None) -> Optional[BM25Index]:
-    """Return (and lazily build) the BM25 index for the given collection."""
+    """Return (and lazily build) the BM25 index for the given collection.
+
+    Tries the on-disk cache first: rebuilding reads every document out of
+    ChromaDB, so a restart otherwise pays a full corpus scan on the first query
+    (and the lifespan warm-up pays it on every deploy).
+    """
     global _indices
     if collection is None:
         import vector_store
@@ -180,6 +277,12 @@ def get_or_build_index(collection=None) -> Optional[BM25Index]:
         if count == 0:
             return None
 
+        if config.BM25_PERSIST:
+            cached = _load_cached(coll_name, count)
+            if cached is not None:
+                _indices[coll_name] = cached
+                return cached
+
         logger.info(f"Building BM25 index for '{coll_name}' from {count} documents...")
         all_docs = collection.get(include=["documents"])
         idx = BM25Index()
@@ -187,6 +290,8 @@ def get_or_build_index(collection=None) -> Optional[BM25Index]:
         _indices[coll_name] = idx
         logger.info(f"BM25 index built for '{coll_name}'")
 
+    if config.BM25_PERSIST:
+        save_index(coll_name)
     return _indices[coll_name]
 
 

--- a/bm25_search.py
+++ b/bm25_search.py
@@ -1,9 +1,24 @@
-"""BM25 lexical search index for hybrid retrieval (dense + sparse)."""
+"""BM25 lexical search index for hybrid retrieval (dense + sparse).
+
+Inverted index: `term -> [(doc_idx, tf), ...]`. Scoring touches only the postings
+of the query's own terms, so cost tracks how often those terms occur rather than
+how big the corpus is.
+
+The earlier version scored by looping over EVERY document for EVERY query
+(`for i in range(self.n_docs)`) and kept a `Counter` per chunk resident to do it.
+At ~500k chunks that is multiple GB of Counters and a per-query scan in the
+hundreds of milliseconds — sparse retrieval, not the cross-encoder, becomes the
+dominant term in p99.
+
+Updates are incremental (`add_documents`, `remove_documents`), so an ingest no
+longer throws the whole index away and leaves the next query paying for a full
+rebuild.
+"""
 import math
 import regex
 import threading
 import logging
-from collections import Counter
+from collections import Counter, defaultdict
 from typing import List, Dict, Optional, Tuple
 
 logger = logging.getLogger(__name__)
@@ -13,62 +28,127 @@ _lock = threading.Lock()
 
 
 class BM25Index:
-    """Lightweight BM25 index that lives alongside ChromaDB's dense vectors."""
+    """Lightweight BM25 inverted index that lives alongside ChromaDB's dense vectors."""
 
     def __init__(self, k1: float = 1.5, b: float = 0.75):
         self.k1 = k1
         self.b = b
         self.doc_ids: List[str] = []
-        self.doc_freqs: List[Counter] = []
         self.doc_lens: List[int] = []
-        self.avg_dl: float = 0.0
-        self.df: Counter = Counter()
-        self.n_docs: int = 0
+        # term -> [(doc_idx, term_frequency), ...]
+        self.postings: Dict[str, List[Tuple[int, int]]] = defaultdict(list)
+        # Removed documents are tombstoned rather than compacted out: reclaiming a
+        # slot would renumber every later doc_idx and invalidate every posting.
+        self._deleted: set[int] = set()
+        self._total_len = 0
+        self._lock = threading.Lock()
+
+    @property
+    def n_docs(self) -> int:
+        """Live document count (tombstones excluded)."""
+        return len(self.doc_ids) - len(self._deleted)
+
+    @property
+    def avg_dl(self) -> float:
+        n = self.n_docs
+        return (self._total_len / n) if n else 1.0
 
     @staticmethod
     def _tokenize(text: str) -> List[str]:
         return regex.findall(r'[\p{L}\p{M}\p{N}]+', text.lower())
 
+    # -- construction -------------------------------------------------------
     def build(self, ids: List[str], texts: List[str]):
-        self.doc_ids = list(ids)
-        self.doc_freqs = []
-        self.doc_lens = []
-        self.df = Counter()
+        """Build from scratch, discarding any existing content."""
+        with self._lock:
+            self.doc_ids = []
+            self.doc_lens = []
+            self.postings = defaultdict(list)
+            self._deleted = set()
+            self._total_len = 0
+            self._add_unlocked(ids, texts)
 
-        for text in texts:
+    def add_documents(self, ids: List[str], texts: List[str]) -> None:
+        """Append documents without rebuilding.
+
+        Re-adding an existing id tombstones the old copy first, so an updated
+        chunk is not scored twice.
+        """
+        with self._lock:
+            self._add_unlocked(ids, texts)
+
+    def _add_unlocked(self, ids: List[str], texts: List[str]) -> None:
+        existing = {d: i for i, d in enumerate(self.doc_ids) if i not in self._deleted}
+        for doc_id, text in zip(ids, texts):
+            prior = existing.get(doc_id)
+            if prior is not None:
+                self._tombstone(prior)
             tokens = self._tokenize(text)
-            freq = Counter(tokens)
-            self.doc_freqs.append(freq)
+            idx = len(self.doc_ids)
+            self.doc_ids.append(doc_id)
             self.doc_lens.append(len(tokens))
-            for term in freq:
-                self.df[term] += 1
+            self._total_len += len(tokens)
+            for term, tf in Counter(tokens).items():
+                self.postings[term].append((idx, tf))
+            existing[doc_id] = idx
 
-        self.n_docs = len(texts)
-        self.avg_dl = sum(self.doc_lens) / self.n_docs if self.n_docs else 1.0
+    def remove_documents(self, ids) -> int:
+        """Tombstone documents by id. Returns how many were removed.
 
+        Deleting a paper used to leave its chunks in the index until something
+        triggered a full rebuild, so deleted papers kept being retrieved and cited.
+        """
+        wanted = set(ids)
+        removed = 0
+        with self._lock:
+            for i, doc_id in enumerate(self.doc_ids):
+                if doc_id in wanted and i not in self._deleted:
+                    self._tombstone(i)
+                    removed += 1
+        return removed
+
+    def _tombstone(self, idx: int) -> None:
+        """Mark a slot dead. Postings stay put and are skipped at query time —
+        rewriting every posting list on each delete would cost far more than the
+        occasional skipped entry."""
+        self._deleted.add(idx)
+        self._total_len -= self.doc_lens[idx]
+
+    # -- query --------------------------------------------------------------
     def search(self, query: str, top_k: int = 30) -> Tuple[List[str], List[float]]:
-        if self.n_docs == 0:
+        n_docs = self.n_docs
+        if n_docs == 0:
             return [], []
 
         query_terms = self._tokenize(query)
-        scores = []
+        if not query_terms:
+            return [], []
 
-        for i in range(self.n_docs):
-            score = 0.0
-            dl = self.doc_lens[i]
-            for term in query_terms:
-                if term not in self.doc_freqs[i]:
+        avg_dl = self.avg_dl
+        scores: Dict[int, float] = defaultdict(float)
+
+        # Each query term is looked at once, and only the documents that actually
+        # contain it are touched — this is the whole point of the inverted index.
+        for term in set(query_terms):
+            postings = self.postings.get(term)
+            if not postings:
+                continue
+            df = sum(1 for idx, _ in postings if idx not in self._deleted)
+            if df == 0:
+                continue
+            idf = math.log((n_docs - df + 0.5) / (df + 0.5) + 1.0)
+            for idx, tf in postings:
+                if idx in self._deleted:
                     continue
-                tf = self.doc_freqs[i][term]
-                df = self.df.get(term, 0)
-                idf = math.log((self.n_docs - df + 0.5) / (df + 0.5) + 1.0)
-                numerator = tf * (self.k1 + 1)
-                denominator = tf + self.k1 * (1 - self.b + self.b * dl / self.avg_dl)
-                score += idf * numerator / denominator
-            scores.append(score)
+                dl = self.doc_lens[idx]
+                denom = tf + self.k1 * (1 - self.b + self.b * dl / avg_dl)
+                scores[idx] += idf * (tf * (self.k1 + 1)) / denom
 
-        ranked = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[:top_k]
-        return [self.doc_ids[i] for i in ranked], [scores[i] for i in ranked]
+        if not scores:
+            return [], []
+
+        ranked = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)[:top_k]
+        return [self.doc_ids[i] for i, _ in ranked], [s for _, s in ranked]
 
 
 def rrf(dense_ids: List[str], sparse_ids: List[str], k: int = 60) -> List[str]:
@@ -110,8 +190,46 @@ def get_or_build_index(collection=None) -> Optional[BM25Index]:
     return _indices[coll_name]
 
 
+def add_to_index(ids: List[str], texts: List[str], collection_name: str = None) -> bool:
+    """Fold newly ingested chunks into a live index.
+
+    Returns False when no index is built yet — the caller should then leave it
+    alone and let the next query build it, rather than forcing a rebuild.
+    """
+    if not ids:
+        return True
+    with _lock:
+        if collection_name is not None:
+            targets = [_indices[collection_name]] if collection_name in _indices else []
+        else:
+            targets = list(_indices.values())
+    if not targets:
+        return False
+    for idx in targets:
+        idx.add_documents(ids, texts)
+    return True
+
+
+def remove_from_index(ids, collection_name: str = None) -> bool:
+    """Drop deleted chunks from a live index. Returns False if none is built."""
+    with _lock:
+        if collection_name is not None:
+            targets = [_indices[collection_name]] if collection_name in _indices else []
+        else:
+            targets = list(_indices.values())
+    if not targets:
+        return False
+    for idx in targets:
+        idx.remove_documents(ids)
+    return True
+
+
 def invalidate():
-    """Clear all cached indices (call after ingestion)."""
+    """Clear all cached indices (full rebuild on next query).
+
+    Prefer add_to_index / remove_from_index: this drops everything, and the next
+    query pays a full rebuild from ChromaDB while holding the build lock.
+    """
     global _indices
     with _lock:
         _indices = {}

--- a/bm25_search.py
+++ b/bm25_search.py
@@ -170,9 +170,11 @@ def rrf(dense_ids: List[str], sparse_ids: List[str], k: int = 60) -> List[str]:
     return sorted(scores, key=scores.get, reverse=True)
 
 
-def _cache_path(coll_name: str) -> "pathlib.Path":
+def _cache_path(coll_name: str):
+    # .json.gz, because that is what it is — naming a JSON file .pkl invites the
+    # next reader to reach for pickle.load().
     safe = regex.sub(r"[^\w.-]", "_", coll_name)
-    return config.BM25_CACHE_DIR / f"bm25_{safe}.pkl"
+    return config.BM25_CACHE_DIR / f"bm25_{safe}.json.gz"
 
 
 def _load_cached(coll_name: str, expected_docs: int) -> Optional["BM25Index"]:

--- a/bm25_search.py
+++ b/bm25_search.py
@@ -15,6 +15,7 @@ longer throws the whole index away and leaves the next query paying for a full
 rebuild.
 """
 import gzip
+import hashlib
 import json
 import math
 import os
@@ -30,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 # Bump when the on-disk shape changes; an older file is then ignored, not
 # misread — a silently misinterpreted index is worse than a rebuild.
-_CACHE_FORMAT = 1
+_CACHE_FORMAT = 2  # 2: id fingerprint replaced the count-only staleness check
 
 _indices: dict[str, "BM25Index"] = {}
 _lock = threading.Lock()
@@ -177,12 +178,29 @@ def _cache_path(coll_name: str):
     return config.BM25_CACHE_DIR / f"bm25_{safe}.json.gz"
 
 
-def _load_cached(coll_name: str, expected_docs: int) -> Optional["BM25Index"]:
+def _id_fingerprint(ids) -> str:
+    """Order-independent digest of a set of chunk ids.
+
+    Document COUNT is not sufficient to detect staleness: deleting one paper and
+    ingesting another of the same size leaves the count identical while every
+    affected chunk differs, and the cache would then load and serve deleted text
+    while missing its replacement. Comparing id sets catches that; comparing
+    counts cannot.
+    """
+    h = hashlib.sha256()
+    for i in sorted(ids):
+        h.update(i.encode("utf-8", "ignore"))
+        h.update(b"\x00")
+    return h.hexdigest()
+
+
+def _load_cached(coll_name: str, live_ids) -> Optional["BM25Index"]:
     """Load a persisted index, or None if it is missing, unreadable, or stale.
 
-    Staleness is judged on live document count: the corpus changing under a saved
-    index is exactly when it must not be trusted. A corrupt or version-mismatched
-    file is not an error — it just means rebuild.
+    Staleness is judged by comparing the cached id set against the collection's:
+    the corpus changing under a saved index is exactly when it must not be
+    trusted. A corrupt or version-mismatched file is not an error — it just
+    means rebuild.
     """
     path = _cache_path(coll_name)
     if not path.exists():
@@ -199,9 +217,11 @@ def _load_cached(coll_name: str, expected_docs: int) -> Optional["BM25Index"]:
                                           for t, ps in payload["postings"].items()})
         idx._deleted = set(payload["deleted"])
         idx._total_len = payload["total_len"]
-        if idx.n_docs != expected_docs:
-            logger.info("BM25 cache for '%s' is stale (%d docs on disk vs %d live); rebuilding",
-                        coll_name, idx.n_docs, expected_docs)
+        live_fp = _id_fingerprint(live_ids)
+        if payload.get("id_fingerprint") != live_fp:
+            logger.info("BM25 cache for '%s' does not match the collection "
+                        "(%d docs cached vs %d live); rebuilding",
+                        coll_name, idx.n_docs, len(live_ids))
             return None
         logger.info("BM25 index for '%s' loaded from cache (%d docs)", coll_name, idx.n_docs)
         return idx
@@ -243,6 +263,8 @@ def save_index(coll_name: str = None) -> bool:
                 "postings": {t: [list(p) for p in ps] for t, ps in idx.postings.items()},
                 "deleted": sorted(idx._deleted),
                 "total_len": idx._total_len,
+                "id_fingerprint": _id_fingerprint(
+                    [d for i, d in enumerate(idx.doc_ids) if i not in idx._deleted]),
             }
             tmp = path.with_suffix(".tmp")
             with gzip.open(tmp, "wt", encoding="utf-8") as f:
@@ -280,7 +302,10 @@ def get_or_build_index(collection=None) -> Optional[BM25Index]:
             return None
 
         if config.BM25_PERSIST:
-            cached = _load_cached(coll_name, count)
+            # ids only — no text payload, so this stays far cheaper than the
+            # rebuild it is deciding whether to skip.
+            live_ids = collection.get(include=[]).get("ids", [])
+            cached = _load_cached(coll_name, live_ids)
             if cached is not None:
                 _indices[coll_name] = cached
                 return cached
@@ -328,6 +353,10 @@ def remove_from_index(ids, collection_name: str = None) -> bool:
         return False
     for idx in targets:
         idx.remove_documents(ids)
+    # Persist: a delete mutates the in-memory index, and leaving the disk copy
+    # untouched is how it diverges from the collection between restarts.
+    if config.BM25_PERSIST:
+        save_index(collection_name)
     return True
 
 

--- a/cache.py
+++ b/cache.py
@@ -23,26 +23,40 @@ logger = logging.getLogger(__name__)
 class TTLCache:
     """Thread-safe LRU cache with per-entry TTL expiration."""
 
-    def __init__(self, max_size: int = 256, ttl_seconds: float = 300):
+    def __init__(self, max_size: int = 256, ttl_seconds: float = 300, name: str = "cache"):
         self._max_size = max_size
         self._ttl = ttl_seconds
+        self._name = name
         self._store: OrderedDict[str, tuple[Any, float]] = OrderedDict()
         self._lock = threading.Lock()
         self._hits = 0
         self._misses = 0
 
+    def _record(self, hit: bool) -> None:
+        """Export hit/miss to Prometheus. GET /cache/stats already exposes these
+        counters, but only as a point-in-time reading, and nothing scrapes it —
+        so there is no history to compare a bad day against."""
+        try:
+            import metrics
+            metrics.record_cache(self._name, hit)
+        except Exception:
+            pass  # instrumentation must never break a cache lookup
+
     def get(self, key: str) -> Optional[Any]:
         with self._lock:
             if key not in self._store:
                 self._misses += 1
+                self._record(False)
                 return None
             value, ts = self._store[key]
             if time.monotonic() - ts > self._ttl:
                 del self._store[key]
                 self._misses += 1
+                self._record(False)
                 return None
             self._store.move_to_end(key)
             self._hits += 1
+            self._record(True)
             return value
 
     def put(self, key: str, value: Any) -> None:
@@ -83,8 +97,8 @@ def make_key(*args) -> str:
 # ── Shared cache instances ──────────────────────────────────────────────────
 # Sizes and TTLs are configurable via environment variables (see config.py).
 
-llm_cache = TTLCache(max_size=_cfg.LLM_CACHE_SIZE, ttl_seconds=_cfg.LLM_CACHE_TTL)
+llm_cache = TTLCache(max_size=_cfg.LLM_CACHE_SIZE, ttl_seconds=_cfg.LLM_CACHE_TTL, name="llm")
 
-retrieval_cache = TTLCache(max_size=_cfg.RETRIEVAL_CACHE_SIZE, ttl_seconds=_cfg.RETRIEVAL_CACHE_TTL)
+retrieval_cache = TTLCache(max_size=_cfg.RETRIEVAL_CACHE_SIZE, ttl_seconds=_cfg.RETRIEVAL_CACHE_TTL, name="retrieval")
 
-tool_cache = TTLCache(max_size=_cfg.TOOL_CACHE_SIZE, ttl_seconds=_cfg.TOOL_CACHE_TTL)
+tool_cache = TTLCache(max_size=_cfg.TOOL_CACHE_SIZE, ttl_seconds=_cfg.TOOL_CACHE_TTL, name="tool")

--- a/cache_refresh.py
+++ b/cache_refresh.py
@@ -19,8 +19,11 @@ def _post_ingest_refresh(new_ids=None, new_texts=None):
     """
     try:
         import bm25_search
-        if new_ids and bm25_search.add_to_index(list(new_ids), list(new_texts or [])):
-            logger.debug("BM25 index updated incrementally (+%d chunks)", len(new_ids))
+        ids, texts = list(new_ids or []), list(new_texts or [])
+        # Misaligned lists mean the caller lost track of which text belongs to
+        # which chunk; rebuild from the collection instead of indexing garbage.
+        if ids and len(ids) == len(texts) and bm25_search.add_to_index(ids, texts):
+            logger.debug("BM25 index updated incrementally (+%d chunks)", len(ids))
             # Re-persist off-thread: the in-memory index just moved ahead of the
             # saved copy, and a stale file only costs a rebuild on next start.
             threading.Thread(target=bm25_search.save_index, daemon=True).start()

--- a/cache_refresh.py
+++ b/cache_refresh.py
@@ -21,6 +21,9 @@ def _post_ingest_refresh(new_ids=None, new_texts=None):
         import bm25_search
         if new_ids and bm25_search.add_to_index(list(new_ids), list(new_texts or [])):
             logger.debug("BM25 index updated incrementally (+%d chunks)", len(new_ids))
+            # Re-persist off-thread: the in-memory index just moved ahead of the
+            # saved copy, and a stale file only costs a rebuild on next start.
+            threading.Thread(target=bm25_search.save_index, daemon=True).start()
         else:
             # Nothing handed over, or no index built yet: drop it and warm a new one
             # off-thread so the next request doesn't eat the rebuild.

--- a/cache_refresh.py
+++ b/cache_refresh.py
@@ -8,14 +8,26 @@ import threading
 logger = logging.getLogger(__name__)
 
 
-def _post_ingest_refresh():
-    """Rebuild BM25 index (async) and invalidate retrieval/tool caches after an ingest."""
+def _post_ingest_refresh(new_ids=None, new_texts=None):
+    """Refresh the BM25 index and invalidate retrieval/tool caches after an ingest.
+
+    Pass the newly indexed chunks to fold them in incrementally. Without them this
+    falls back to dropping the whole index, which makes the FIRST query after any
+    ingest — including every scheduled watch digest — pay a full rebuild from
+    ChromaDB while holding the build lock, with every concurrent query queued
+    behind it. That is a recurring p99 cliff that grows with corpus size.
+    """
     try:
         import bm25_search
-        bm25_search.invalidate()
-        threading.Thread(target=bm25_search.get_or_build_index, daemon=True).start()
+        if new_ids and bm25_search.add_to_index(list(new_ids), list(new_texts or [])):
+            logger.debug("BM25 index updated incrementally (+%d chunks)", len(new_ids))
+        else:
+            # Nothing handed over, or no index built yet: drop it and warm a new one
+            # off-thread so the next request doesn't eat the rebuild.
+            bm25_search.invalidate()
+            threading.Thread(target=bm25_search.get_or_build_index, daemon=True).start()
     except Exception:
-        logger.warning("Failed to invalidate/rebuild BM25 index after ingestion", exc_info=True)
+        logger.warning("Failed to refresh BM25 index after ingestion", exc_info=True)
     try:
         from cache import retrieval_cache, tool_cache
         retrieval_cache.invalidate()

--- a/config.py
+++ b/config.py
@@ -310,6 +310,15 @@ DISTANCE_METRIC = "cosine"  # cosine similarity for embeddings
 # ef_search is a query-time recall/latency knob. Defaults match ChromaDB's own, so
 # behaviour is unchanged until you deliberately A/B them once the eval set exists.
 HNSW_EF_CONSTRUCTION = int(os.getenv("HNSW_EF_CONSTRUCTION", "100"))
+# Writes are not queries. The general ChromaDB call timeout (5s) suits a query and
+# is far too short for an upsert of a whole corpus — that combination silently cost
+# a completed 27-minute ingest: the write succeeded, but the caller had already
+# given up and skipped everything after it, including the ingest-log record.
+# Upserts now go in batches, so each wait is bounded by batch size rather than by
+# corpus size and the timeout only has to cover ONE batch.
+CHROMA_UPSERT_BATCH = int(os.getenv("CHROMA_UPSERT_BATCH", "256"))
+CHROMA_WRITE_TIMEOUT_S = float(os.getenv("CHROMA_WRITE_TIMEOUT_S", "120"))
+
 HNSW_EF_SEARCH = int(os.getenv("HNSW_EF_SEARCH", "100"))
 HNSW_M = int(os.getenv("HNSW_M", "16"))
 

--- a/config.py
+++ b/config.py
@@ -635,7 +635,9 @@ ABSTAIN_COMPLETENESS_FLOOR = float(os.getenv("ABSTAIN_COMPLETENESS_FLOOR", "0.5"
 # ============================================================================
 # Version
 # ============================================================================
-VERSION = "2.3.0-dev"
+# Surfaced in the OpenAPI spec and /health, so it is what an operator reads when
+# asking "which build is this?" — it had drifted two releases behind the README.
+VERSION = "2.5.0-dev"
 
 # ============================================================================
 # Chat / Session

--- a/config.py
+++ b/config.py
@@ -15,6 +15,24 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 
 # ============================================================================
+# Thread budget
+# ============================================================================
+# The process already runs a 32-worker ChromaDB timeout pool, FastAPI's ~40-thread
+# default pool, a ProcessPoolExecutor for PDF parsing, and a ThreadPoolExecutor for
+# parallel agent tools. On top of that, torch and ONNX Runtime each default to one
+# intra-op thread PER CORE, so a single reranker pass can fan out across every core
+# while dozens of request threads are already runnable. The result is a ready queue
+# far deeper than the core count, where every stage slows down at once.
+#
+# Pin it: 0 means "leave the library default alone" (opt out); anything else caps
+# intra-op parallelism. Must be set BEFORE torch/onnxruntime are imported, which is
+# why it lives at the top of config.py — the first module everything else imports.
+TORCH_NUM_THREADS = int(os.getenv("TORCH_NUM_THREADS", "4"))
+if TORCH_NUM_THREADS > 0:
+    os.environ.setdefault("OMP_NUM_THREADS", str(TORCH_NUM_THREADS))
+    os.environ.setdefault("MKL_NUM_THREADS", str(TORCH_NUM_THREADS))
+
+# ============================================================================
 # Paths
 # ============================================================================
 PROJECT_ROOT = Path(__file__).parent
@@ -124,6 +142,11 @@ USE_HYDE = os.getenv("USE_HYDE", "false").lower() == "true"
 # per figure at ingest, bounded by MULTIMODAL_MAX_FIGS_PER_DOC.
 ENABLE_MULTIMODAL_INGEST = os.getenv("ENABLE_MULTIMODAL_INGEST", "false").lower() == "true"
 MULTIMODAL_MAX_FIGS_PER_DOC = int(os.getenv("MULTIMODAL_MAX_FIGS_PER_DOC", "12"))
+# Concurrent VLM caption calls per paper; 1 restores the old sequential behavior.
+# Keep this small — the cap bounds requests in flight at the provider, it is not
+# there to saturate the box. Too high just converts a slow ingest into 429s that
+# trip the LLM circuit breaker for every other caller.
+FIGURE_CAPTION_WORKERS = int(os.getenv("FIGURE_CAPTION_WORKERS", "4"))
 
 # Phase 5 — contradiction/consensus detection. When on, the answer generator
 # runs pairwise NLI (the same faithfulness model) over the top retrieved passages

--- a/config.py
+++ b/config.py
@@ -183,6 +183,11 @@ WATCH_ENABLE = os.getenv("WATCH_ENABLE", "false").lower() == "true"
 WATCH_DEFAULT_CADENCE = os.getenv("WATCH_DEFAULT_CADENCE", "weekly")  # daily|weekly|monthly
 WATCH_MAX_RESULTS = int(os.getenv("WATCH_MAX_RESULTS", "10"))  # papers fetched per watch run
 WATCH_POLL_INTERVAL = int(os.getenv("WATCH_POLL_INTERVAL", "3600"))  # seconds between schedule-loop sweeps
+# How long a claimed watch is parked before it becomes due again. Must comfortably
+# exceed a real run (arXiv search + ingest + digest generation), or a slow run
+# could be picked up a second time while the first is still going. It also bounds
+# how long a watch stays stuck if the claimer dies mid-run.
+WATCH_LEASE_SECONDS = int(os.getenv("WATCH_LEASE_SECONDS", "3600"))
 
 # Phase 7 — literature-review report workflow. POST /report decomposes a topic
 # into sections, synthesizes a cited section per part from the corpus, and

--- a/config.py
+++ b/config.py
@@ -148,6 +148,14 @@ MULTIMODAL_MAX_FIGS_PER_DOC = int(os.getenv("MULTIMODAL_MAX_FIGS_PER_DOC", "12")
 # trip the LLM circuit breaker for every other caller.
 FIGURE_CAPTION_WORKERS = int(os.getenv("FIGURE_CAPTION_WORKERS", "4"))
 
+# Persist the BM25 index between runs. Rebuilding reads every document out of
+# ChromaDB, so without this a restart pays a full corpus scan on the first query
+# and the lifespan warm-up pays it on every deploy. The cache is validated
+# against the live document count on load and ignored when it disagrees, so a
+# stale file costs a rebuild rather than wrong results.
+BM25_PERSIST = os.getenv("BM25_PERSIST", "true").lower() == "true"
+BM25_CACHE_DIR = Path(os.getenv("BM25_CACHE_DIR", PROJECT_ROOT / "chroma_db"))
+
 # Phase 5 — contradiction/consensus detection. When on, the answer generator
 # runs pairwise NLI (the same faithfulness model) over the top retrieved passages
 # and, if any pair contradicts above the threshold, instructs the model to

--- a/config.py
+++ b/config.py
@@ -85,6 +85,27 @@ def ensure_directories():
 # bge-m3: dense + sparse + ColBERT, strong on Indic scripts
 # NOTE: switching from e5-base (768d) requires re-ingesting all documents
 EMBEDDING_MODEL_NAME = os.getenv("EMBEDDING_MODEL_NAME", "BAAI/bge-m3")
+# int8 ONNX for the embedding model on CPU. Works, but OFF by default — measured,
+# the trade is worse than it is for the cross-encoders:
+#
+#   speed              1.38x faster (the reranker/NLI get ~3-11x)
+#   cosine vs fp32     mean 0.987, min 0.983 across a 24-chunk sample
+#
+# Every vector moves. 0.983 is enough for near-neighbours to reorder, so this can
+# change what retrieval returns — and there is currently no working way to measure
+# that (docs/Eval/run_live.py is blocked on the judgments/corpus mismatch). Trading
+# unmeasurable retrieval quality for 1.38x on an operation that runs once per
+# corpus is a bad deal; the reranker's 3-11x on a per-QUERY path is a good one.
+#
+# Turn it on deliberately, and only with a working eval gate to confirm quality
+# held. Switching it means re-embedding the whole corpus — mixing backends in one
+# collection is the incomparable-vectors problem. Every chunk records which
+# backend produced it (vector_store._provenance_stamp) and a mixed collection is
+# reported at startup; `reindex.py` replays the ingest log to re-embed without
+# re-parsing PDFs.
+#
+# CPU-only regardless: on GPU, fp16 is both faster and more accurate than int8.
+EMBED_ONNX_INT8 = os.getenv("EMBED_ONNX_INT8", "false").lower() == "true"
 EMBEDDING_DIMENSION = 1024  # bge-m3 dimension
 
 # E5 models require specific prefixes for queries and passages

--- a/config.py
+++ b/config.py
@@ -344,10 +344,12 @@ TRANSLATION_MODEL_INDIC_TO_EN = "facebook/nllb-200-distilled-600M"
 # LLM Configuration
 # ============================================================================
 # Google Gemini API configuration
-# Caps thinking + answer together, not just the answer. gemini-3.6-flash rejects
-# thinking_budget=0 and spends 0-4856 thought tokens on identical prompts, so a
-# 2048 cap left as little as 80 tokens for the answer and truncated mid-sentence.
-# Measured: answer <=2100, worst thinking+answer 6926.
+# Caps thinking + answer together, not just the answer. Gemini 3.x Flash models
+# reject thinking_budget=0 and spend a variable number of thought tokens on
+# identical prompts (measured on 3.6-flash: 0-4856), so a 2048 cap left as little
+# as 80 tokens for the answer and truncated mid-sentence.
+# Measured on 3.6-flash: answer <=2100, worst thinking+answer 6926. Keep the
+# headroom for newer Flash models rather than re-tuning per release.
 LLM_MAX_TOKENS = int(os.getenv("LLM_MAX_TOKENS", "8192"))  # maximum tokens to generate
 AGENT_MAX_TOKENS = int(os.getenv("AGENT_MAX_TOKENS", "8192"))  # higher limit for agentic pipeline
 # Thinking budget for ALL agentic-mode LLM calls (query planner, tool routing,
@@ -360,7 +362,7 @@ AGENT_MAX_TOKENS = int(os.getenv("AGENT_MAX_TOKENS", "8192"))  # higher limit fo
 # knobs below, which supersede it). Still honoured by models that accept budgets.
 AGENT_THINKING_BUDGET = int(os.getenv("AGENT_THINKING_BUDGET", "0"))
 # Thinking LEVEL — the Gemini 3.x control, replacing thinking_budget. Google's docs
-# list minimal | low | medium | high for gemini-3.6-flash, defaulting to MEDIUM when
+# list minimal | low | medium | high for Gemini 3.x Flash, defaulting to MEDIUM when
 # nothing is sent. That default is the trap: sending the legacy thinking_budget=0 gets
 # a 400, the backend used to drop the field entirely, and the model then thought at
 # MEDIUM — the opposite of the "thinking off" that was asked for, with those thought
@@ -412,10 +414,13 @@ AGENT_EVAL_RESERVE_S = float(os.getenv("AGENT_EVAL_RESERVE_S", "90"))
 # fraction of the latency of 6. Raise for broad checklist queries if recall suffers.
 AGENT_MAX_SUB_QUERIES = int(os.getenv("AGENT_MAX_SUB_QUERIES", "3"))
 LLM_TEMPERATURE = float(os.getenv("LLM_TEMPERATURE", "0.1"))  # low temperature for grounded citation tasks
-LLM_MODEL_NAME = os.getenv("LLM_MODEL_NAME", "gemini-3.6-flash")  # Gemini model
+# gemini-3.7-flash is the current Flash generation: built for complex coding,
+# agentic workflows and multi-step execution, which is what the agent pipeline
+# does. 3.6-flash remains selectable as the previous generation.
+LLM_MODEL_NAME = os.getenv("LLM_MODEL_NAME", "gemini-3.7-flash")  # Gemini model
 
 # Explicit Gemini context caching of the (stable) system-instruction prefix.
-# gemini-3.6-flash already does IMPLICIT caching for free; explicit caching adds
+# Gemini 3.x Flash already does IMPLICIT caching for free; explicit caching adds
 # guaranteed reuse but is billed per token-hour of storage — so it's OFF by default.
 # Enable only if your system prompts clear the model's min-token cache floor and you
 # want deterministic cache hits. Falls back to inline prompts on any create failure.
@@ -452,7 +457,12 @@ OPENROUTER_BASE_URL = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/ap
 # Bare name → Gemini; slug with "/" → OpenRouter. First entry is the default.
 _raw_selectable = os.getenv(
     "LLM_SELECTABLE_MODELS",
-    "gemini-3.6-flash,gemini-3.5-flash,anthropic/claude-haiku,openai/gpt-5.4-nano",
+    # Current Flash first (the default), then the previous generation, then a
+    # cheap high-throughput option for routine calls, then cross-vendor entries.
+    # The cross-vendor slugs matter beyond user choice: failover picks a "/"-shaped
+    # slug from this list, so an all-Gemini list would leave nothing to fail over to.
+    "gemini-3.7-flash,gemini-3.6-flash,gemini-3.5-flash-lite,"
+    "anthropic/claude-haiku,openai/gpt-5.4-nano",
 )
 LLM_SELECTABLE_MODELS = [m.strip() for m in _raw_selectable.split(",") if m.strip()]
 # How long the enriched OpenRouter /models catalog is cached (seconds).

--- a/config.py
+++ b/config.py
@@ -471,7 +471,7 @@ _raw_selectable = os.getenv(
     # The cross-vendor slugs matter beyond user choice: failover picks a "/"-shaped
     # slug from this list, so an all-Gemini list would leave nothing to fail over to.
     "gemini-3.7-flash,gemini-3.6-flash,gemini-3.5-flash-lite,"
-    "anthropic/claude-haiku,openai/gpt-5.4-nano",
+    "anthropic/claude-haiku-4.5,openai/gpt-5.4-nano",
 )
 LLM_SELECTABLE_MODELS = [m.strip() for m in _raw_selectable.split(",") if m.strip()]
 # How long the enriched OpenRouter /models catalog is cached (seconds).

--- a/config.py
+++ b/config.py
@@ -471,7 +471,7 @@ _raw_selectable = os.getenv(
     # The cross-vendor slugs matter beyond user choice: failover picks a "/"-shaped
     # slug from this list, so an all-Gemini list would leave nothing to fail over to.
     "gemini-3.7-flash,gemini-3.6-flash,gemini-3.5-flash-lite,"
-    "anthropic/claude-haiku-4.5,openai/gpt-5.4-nano",
+    "nvidia/nemotron-3-super-120b-a12b:free,google/gemma-4-31b-it:free",
 )
 LLM_SELECTABLE_MODELS = [m.strip() for m in _raw_selectable.split(",") if m.strip()]
 # How long the enriched OpenRouter /models catalog is cached (seconds).

--- a/config.py
+++ b/config.py
@@ -189,6 +189,12 @@ WATCH_POLL_INTERVAL = int(os.getenv("WATCH_POLL_INTERVAL", "3600"))  # seconds b
 # how long a watch stays stuck if the claimer dies mid-run.
 WATCH_LEASE_SECONDS = int(os.getenv("WATCH_LEASE_SECONDS", "3600"))
 
+# How long a job's lease stays valid without a heartbeat. Every progress update
+# renews it, so this only has to exceed the longest gap BETWEEN updates — not the
+# job's total runtime. Too low and a slow step gets its job reaped out from under
+# it; too high and a crashed job takes that long to be marked failed.
+JOB_LEASE_SECONDS = int(os.getenv("JOB_LEASE_SECONDS", "900"))
+
 # Phase 7 — literature-review report workflow. POST /report decomposes a topic
 # into sections, synthesizes a cited section per part from the corpus, and
 # stores a downloadable Markdown artifact as an async job. Off by default: a

--- a/deps.py
+++ b/deps.py
@@ -135,12 +135,25 @@ _jobs_lock = threading.Lock()
 _last_job_eviction = 0.0
 
 
+def job_lease() -> str:
+    """A fresh lease deadline for a job this process is actively working on."""
+    return (datetime.now(timezone.utc) + timedelta(seconds=config.JOB_LEASE_SECONDS)).isoformat()
+
+
 def _update_job(job_id: str, **kwargs):
-    """Thread-safe update of a job's fields; evicts completed jobs once per hour."""
+    """Thread-safe update of a job's fields; evicts completed jobs once per hour.
+
+    Every update to an unfinished job doubles as a lease heartbeat. A job that
+    stops heartbeating is one whose process died, which is what lets the startup
+    reaper tell an abandoned job from a slow one — previously a crash left the
+    row saying `running` forever and clients polled it indefinitely.
+    """
     global _last_job_eviction
     with _jobs_lock:
         _jobs[job_id].update(kwargs)
-        persistence.save_job(job_id, _jobs[job_id])
+        finished = _jobs[job_id].get("status") in ("success", "failed")
+        persistence.save_job(job_id, _jobs[job_id],
+                             lease_until=None if finished else job_lease())
         now = time.monotonic()
         if now - _last_job_eviction >= 3600:
             _last_job_eviction = now

--- a/deps.py
+++ b/deps.py
@@ -255,7 +255,15 @@ def _get_or_create_session(session_id: Optional[str], owner: Optional[str] = Non
 
 
 def _append_session_messages(session_id: str, user_text: str, assistant_text: str,
-                             owner: Optional[str] = None) -> None:
+                             owner: Optional[str] = None,
+                             citations: Optional[list] = None) -> None:
+    """Append one user/assistant exchange to a session.
+
+    `citations` is stored alongside the answer because reopening a conversation
+    from history otherwise cannot show its sources — only role and content were
+    ever saved, so the evidence panel had nothing to restore. Kept small (number,
+    title, section per source) so a long session's JSON blob stays modest.
+    """
     with _sessions_lock:
         # The session can be evicted (stale-age sweep) between _get_or_create_session
         # and here during a slow generation — re-materialize it rather than KeyError
@@ -270,7 +278,17 @@ def _append_session_messages(session_id: str, user_text: str, assistant_text: st
             _sessions[session_id] = sess
         msgs = sess["messages"]
         msgs.append({"role": "user", "content": user_text})
-        msgs.append({"role": "assistant", "content": assistant_text})
+        answer = {"role": "assistant", "content": assistant_text}
+        if citations:
+            # Only the fields the evidence panel needs to redraw. Chunk text is
+            # deliberately excluded: it would multiply the session blob for data
+            # the history view never renders.
+            answer["citations"] = [
+                {"number": c.get("number"), "title": c.get("title", ""),
+                 "section": c.get("section", "")}
+                for c in citations
+            ]
+        msgs.append(answer)
         max_msgs = config.CHAT_HISTORY_MAX_TURNS * 2
         if len(msgs) > max_msgs:
             del msgs[:len(msgs) - max_msgs]

--- a/deps.py
+++ b/deps.py
@@ -140,6 +140,28 @@ def job_lease() -> str:
     return (datetime.now(timezone.utc) + timedelta(seconds=config.JOB_LEASE_SECONDS)).isoformat()
 
 
+_last_lease_touch: Dict[str, float] = {}
+
+
+def touch_job_lease(job_id: str, min_interval: float = 60.0) -> None:
+    """Renew a running job's lease from a progress callback.
+
+    Progress is otherwise in-memory only, so a job whose steps take longer than
+    JOB_LEASE_SECONDS between _update_job calls looks abandoned to the startup
+    reaper while it is still working. Throttled, because progress fires per
+    paper/section and SQLite should not be written on every tick.
+    """
+    now = time.monotonic()
+    with _jobs_lock:
+        if now - _last_lease_touch.get(job_id, 0.0) < min_interval:
+            return
+        job = _jobs.get(job_id)
+        if job is None or job.get("status") in ("success", "failed"):
+            return
+        _last_lease_touch[job_id] = now
+        persistence.save_job(job_id, job, lease_until=job_lease())
+
+
 def _update_job(job_id: str, **kwargs):
     """Thread-safe update of a job's fields; evicts completed jobs once per hour.
 
@@ -192,7 +214,7 @@ _turn_locks: "weakref.WeakValueDictionary[str, asyncio.Lock]" = weakref.WeakValu
 _turn_locks_guard = threading.Lock()
 
 
-def session_turn_lock(session_id: str) -> asyncio.Lock:
+def session_turn_lock(session_id: str | None) -> asyncio.Lock:
     """One lock per session, serializing a whole conversational turn.
 
     A turn is read-history -> generate -> append, and generation takes seconds.
@@ -205,6 +227,11 @@ def session_turn_lock(session_id: str) -> asyncio.Lock:
     WeakValueDictionary so a lock disappears once no turn holds or awaits it;
     the strong reference lives in the caller's `async with`.
     """
+    if not session_id:
+        # A request that brings no session id shares no history with anything, so
+        # it needs no mutual exclusion. Keying them all on one literal made every
+        # new conversation in the process queue behind every other one.
+        return asyncio.Lock()
     with _turn_locks_guard:
         lock = _turn_locks.get(session_id)
         if lock is None:

--- a/deps.py
+++ b/deps.py
@@ -8,12 +8,14 @@ so routers can share them without importing api_server and creating a cycle.
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
+import asyncio
 import hashlib
 import hmac
 import os
 import threading
 import time
 import uuid
+import weakref
 
 from fastapi import HTTPException, Request, Security, status
 from fastapi.security import APIKeyHeader
@@ -173,17 +175,65 @@ def _evict_stale_sessions():
         persistence.delete_session(sid)
 
 
-def _get_or_create_session(session_id: Optional[str]) -> tuple[str, list]:
-    """Return (session_id, messages_list). Creates a new session when id is None."""
+_turn_locks: "weakref.WeakValueDictionary[str, asyncio.Lock]" = weakref.WeakValueDictionary()
+_turn_locks_guard = threading.Lock()
+
+
+def session_turn_lock(session_id: str) -> asyncio.Lock:
+    """One lock per session, serializing a whole conversational turn.
+
+    A turn is read-history -> generate -> append, and generation takes seconds.
+    Two concurrent requests on one session would otherwise both read history at
+    length N, both generate without seeing the other, and both append — so each
+    answer is blind to the turn running beside it (a lost update). Holding this
+    for the full turn makes them queue instead, which is the correct semantics:
+    turns in one conversation are not independent.
+
+    WeakValueDictionary so a lock disappears once no turn holds or awaits it;
+    the strong reference lives in the caller's `async with`.
+    """
+    with _turn_locks_guard:
+        lock = _turn_locks.get(session_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            _turn_locks[session_id] = lock
+        return lock
+
+
+def owns_session(session: Optional[dict], owner: Optional[str]) -> bool:
+    """True when `owner` may read, append to, or delete `session`.
+
+    Single-tenant (auth disabled, owner None) sees everything. Otherwise the
+    fingerprints must match; a session created before ownership existed carries
+    no owner and stays invisible to ordinary keys rather than defaulting open.
+    """
+    if session is None:
+        return False
+    if owner is None:
+        return True
+    return session.get("owner") == owner
+
+
+def _get_or_create_session(session_id: Optional[str], owner: Optional[str] = None) -> tuple[str, list]:
+    """Return (session_id, messages_list). Creates a new session when id is None.
+
+    Raises PermissionError when `session_id` names an existing session belonging
+    to a different API key — without that check, supplying a guessed id would
+    append to, and then read back, someone else's conversation.
+    """
     with _sessions_lock:
         _evict_stale_sessions()
         if session_id and session_id in _sessions:
-            return session_id, list(_sessions[session_id]["messages"])
+            existing = _sessions[session_id]
+            if not owns_session(existing, owner):
+                raise PermissionError(session_id)
+            return session_id, list(existing["messages"])
         new_id = session_id or str(uuid.uuid4())
         now = datetime.now(timezone.utc).isoformat()
         _sessions[new_id] = {
             "id": new_id,
             "messages": [],
+            "owner": owner,
             "created_at": now,
             "updated_at": now,
         }
@@ -191,15 +241,19 @@ def _get_or_create_session(session_id: Optional[str]) -> tuple[str, list]:
         return new_id, list(_sessions[new_id]["messages"])
 
 
-def _append_session_messages(session_id: str, user_text: str, assistant_text: str) -> None:
+def _append_session_messages(session_id: str, user_text: str, assistant_text: str,
+                             owner: Optional[str] = None) -> None:
     with _sessions_lock:
         # The session can be evicted (stale-age sweep) between _get_or_create_session
         # and here during a slow generation — re-materialize it rather than KeyError
-        # after the answer has already been computed.
+        # after the answer has already been computed. It has to be re-created with the
+        # same owner, or the resurrected session would be ownerless and drop out of
+        # its owner's listing.
         sess = _sessions.get(session_id)
         if sess is None:
             now = datetime.now(timezone.utc).isoformat()
-            sess = {"id": session_id, "messages": [], "created_at": now, "updated_at": now}
+            sess = {"id": session_id, "messages": [], "owner": owner,
+                    "created_at": now, "updated_at": now}
             _sessions[session_id] = sess
         msgs = sess["messages"]
         msgs.append({"role": "user", "content": user_text})

--- a/docs/ARCHITECTURE_REVIEW_v2.4.md
+++ b/docs/ARCHITECTURE_REVIEW_v2.4.md
@@ -5,8 +5,9 @@
 > Revision 2 folds in a second review pass; items marked **[R2]** came from it, and
 > §H records the recommendations that were checked and declined.
 >
-> Where this document and `README.md` disagree on a default, the code wins — the README's
-> `AGENT_TIMEOUT` "default 120" is stale (`config.py:314` sets 300).
+> Where this document and `README.md` disagree on a default, the code wins. (The README's
+> stale `AGENT_TIMEOUT` "default 120" was corrected after this review; both it and the code
+> now say 300.)
 
 ## Fix status
 
@@ -25,8 +26,9 @@ Items closed in the first implementation pass (318 unit tests green, 37 new):
 | **F5** migrations | **Partial** | `persistence._ensure_column` — idempotent `ADD COLUMN` only; a versioned runner is still needed for anything that backfills or transforms |
 | **F6a** BM25 test coverage | **Fixed** | `tests/test_bm25_search.py` — lands before the B2 rewrite |
 
-Known gap from this pass: the `degraded` marker is logged but not yet surfaced in any API
-response, so a sparse-only answer is visible to operators and not to end users.
+~~Known gap from this pass: the `degraded` marker is logged but not yet surfaced in any API
+response.~~ **Closed:** `degraded` is on `QueryResponse` (`routes/query.py:119`),
+`ChatResponse` (`routes/chat.py:68`) and the SSE `done` event on both streaming routes.
 
 **System as built:** single uvicorn process (`workers=1`), embedded ChromaDB (`PersistentClient` on a local dir), in-memory BM25 index, three process-local TTL caches, one SQLite connection behind one global lock, in-process asyncio watch scheduler, in-process ingest jobs, ~6 GB of models resident. Everything is one node with node-local state.
 
@@ -108,7 +110,7 @@ That is a coherent single-node design. Nearly every finding below follows from o
 
 **Change:** a global `asyncio.Semaphore` (or bounded threadpool) around agentic query / rerank / NLI, sized to cores. Over the limit, return 503 with `Retry-After` immediately.
 
-**Problem:** rate limiting (`deps.limiter`) counts requests, not concurrent work. An agent query can hold a thread for `AGENT_TIMEOUT` — **300s**, per `config.py:314`, not the 120 the README claims — while running cross-encoder + NLI + contradiction detection (up to 56 NLI passes). Twenty concurrent agent queries on an 8-core box means every one of them thrashes and times out — the classic failure where the system does maximum work and returns zero successful responses. A five-minute per-thread hold makes this materially worse than the README's numbers suggest.
+**Problem:** rate limiting (`deps.limiter`) counts requests, not concurrent work. An agent query can hold a thread for `AGENT_TIMEOUT` — **300s** — while running cross-encoder + NLI + contradiction detection (up to 56 NLI passes). Twenty concurrent agent queries on an 8-core box means every one of them thrashes and times out — the classic failure where the system does maximum work and returns zero successful responses. A five-minute per-thread hold makes this materially worse than the README's numbers suggest.
 
 **Benefit:** bounded, predictable p99 under overload; some requests shed fast instead of all failing slow.
 

--- a/docs/ARCHITECTURE_REVIEW_v2.4.md
+++ b/docs/ARCHITECTURE_REVIEW_v2.4.md
@@ -1,0 +1,624 @@
+# IndicRAG v2.4 — Architecture Review
+
+> Review date: 2026-08-21 · Branch: `v2.4.1-dev` · Scope: full system design
+> Method: source-grounded (code read, not README-derived). File:line references are load-bearing.
+> Revision 2 folds in a second review pass; items marked **[R2]** came from it, and
+> §H records the recommendations that were checked and declined.
+>
+> Where this document and `README.md` disagree on a default, the code wins — the README's
+> `AGENT_TIMEOUT` "default 120" is stale (`config.py:314` sets 300).
+
+## Fix status
+
+Items closed in the first implementation pass (318 unit tests green, 37 new):
+
+| Item | Status | Where |
+|---|---|---|
+| **A1 / A2** cross-user data exposure | **Fixed** | `owner` on sessions/watches/feedback/reports/query_log; scoping in `routes/chat.py`, `agent.py`, `watch.py`, `feedback.py`, `report.py`; mismatches 404 |
+| **D4** SQLite secondary indexes | **Fixed** | 9 indexes in `persistence.py` |
+| **E5** LLM-spend rate limits | **Fixed** | `5/minute` on `POST /report` and `POST /watch/{id}/run` (verified: 429 fires) |
+| **C6** session lost update | **Fixed** | `deps.session_turn_lock`, held across read→generate→append in both `/chat` handlers |
+| **C10a** ChromaDB circuit breaker | **Fixed** | `vector_store` — opens after 3 consecutive timeouts, 60s cooldown |
+| **C10b** embedding-failure fallback | **Fixed** | `rag._sparse_only_retrieval`, BM25-only with a `degraded` marker |
+| **D5** parallel figure captioning | **Fixed** | `FIGURE_CAPTION_WORKERS` (default 4), order preserved |
+| **B5** thread oversubscription | **Fixed** | `TORCH_NUM_THREADS` / `OMP_NUM_THREADS` pinned in `config.py` |
+| **F5** migrations | **Partial** | `persistence._ensure_column` — idempotent `ADD COLUMN` only; a versioned runner is still needed for anything that backfills or transforms |
+| **F6a** BM25 test coverage | **Fixed** | `tests/test_bm25_search.py` — lands before the B2 rewrite |
+
+Known gap from this pass: the `degraded` marker is logged but not yet surfaced in any API
+response, so a sparse-only answer is visible to operators and not to end users.
+
+**System as built:** single uvicorn process (`workers=1`), embedded ChromaDB (`PersistentClient` on a local dir), in-memory BM25 index, three process-local TTL caches, one SQLite connection behind one global lock, in-process asyncio watch scheduler, in-process ingest jobs, ~6 GB of models resident. Everything is one node with node-local state.
+
+That is a coherent single-node design. Nearly every finding below follows from one root fact: **state that must be shared lives inside the process**, so the system cannot be replicated, and correctness/latency guarantees are only as good as one box.
+
+---
+
+## A. Critical — data isolation is broken (contradicts the v2.4 multi-user claim)
+
+### A1. Chat sessions, watches, feedback, reports are globally readable across API keys — **High**
+
+**Change:** scope every list/read/delete by `current_owner` (SHA-256 key fingerprint), the same pattern `routes/query.py:401` already uses for jobs. Add an `owner` column to `sessions`, `feedback`, `reports`; stop trusting client-supplied `user_id`.
+
+**Problem:** `routes/chat.py:205,228,244` — `GET /chat`, `GET /chat/{id}`, `DELETE /chat/{id}` take only `verify_api_key`. Any valid key lists and reads every user's conversation history and deletes it. `routes/watch.py:101` takes `user_id` as a **query parameter** — omit it and get all users' watches; supply someone else's and read theirs. `persistence.get_feedback_with_context` and `list_reports` have no owner column at all. Watch creation (`routes/watch.py:85`) stores the caller-declared `user_id`, so identity is self-asserted.
+
+**Benefit:** the per-user isolation v2.4 advertises actually holds.
+
+**Trade-off:** existing rows have no owner — migration needs a backfill (assign to admin, or leave NULL = admin-only visible). One breaking API change: `user_id` on `POST /watch` becomes derived, not supplied.
+
+**Impact:** `persistence.py` schema + all list/get queries, `deps.py` (make `current_owner` a hard dependency), `routes/chat.py`, `routes/watch.py`, `routes/feedback.py`, `routes/report.py`.
+
+### A2. `current_owner` returns `None` when auth is disabled, and jobs treat `owner=None` as public — **High**
+
+**Change:** when `ALLOW_UNAUTHENTICATED=1`, force single-tenant mode explicitly — disable `/watch/*`, `/prefs/*`, and cross-session listing rather than silently making them shared.
+
+**Problem:** `job.get("owner") is not None and ...` (`routes/query.py:401`) means unauthenticated deployments have no ownership check anywhere; the isolation code path is inert exactly where it is least obvious.
+
+**Benefit:** no mode where multi-user routes exist but isolation is off.
+
+**Trade-off:** dev convenience.
+
+**Impact:** `deps.py`, route registration in `api_server.py`.
+
+---
+
+## B. Scalability — the single-process ceiling
+
+### B1. Externalize shared state so `workers > 1` and replicas become possible — **High**
+
+**Change:** move the BM25 index, the three TTL caches, `_sessions`, and `_jobs` out of process. Redis for caches + session/job state (already anticipated in the `docker-compose.yml` comment); BM25 either rebuilt per-worker from a shared snapshot or replaced (see B2).
+
+**Problem:** `start_server.py:workers=1` is not a tuning choice, it is forced. `bm25_search._indices`, `cache.llm_cache/retrieval_cache/tool_cache`, `deps._sessions`, `deps._jobs` are module globals. Two workers = two divergent BM25 indexes, halved cache hit rate, invalidation on ingest that reaches only one worker (stale retrieval served indefinitely from the other), and job status visible only from the worker that owns it.
+
+**Benefit:** horizontal scale; a crashed worker stops taking the whole service down.
+
+**Trade-off:** Redis is a new dependency and a new failure mode — the cache must fail-open (miss on Redis error, never 500). Serialization cost on session read/write.
+
+**Impact:** `cache.py` (swap `TTLCache` for a Redis-backed implementation behind the same `get/put/invalidate` interface — the interface is already right), `deps.py`, `bm25_search.py`, `cache_refresh.py`.
+
+**DDIA framing (Ch 1, Ch 5):** you cannot replicate what you have not first made shareable. Do this before any other scaling work — it gates everything else.
+
+### B2. BM25 is a full linear scan and a full-corpus RAM load — **High**
+
+**Change:** build a real inverted index (`term -> [(doc_idx, tf)]`) and score only the postings for query terms. Same file, roughly 30 lines.
+
+**Problem:** `BM25Index.search` loops `for i in range(self.n_docs)` over **every chunk** for every query — O(N·|q|) with a Python inner loop. `get_or_build_index` calls `collection.get(include=["documents"])`, materializing the entire corpus text in RAM to build, and keeps `doc_freqs` (a `Counter` per chunk) resident forever. At 10k papers ≈ 500k chunks that is multiple GB of Counters and a per-query scan in the hundreds of ms — sparse retrieval becomes the dominant term in p99, ahead of the cross-encoder.
+
+**Benefit:** query cost drops to postings length (typically 100–1000× less work); memory drops to one dict of postings.
+
+**Trade-off:** rebuild is slightly more code; deletions need tombstones or a rebuild.
+
+**Impact:** `bm25_search.py` only — `build`/`search` are behind a clean interface, `rrf` and callers unchanged.
+
+**DDIA framing (Ch 3, Ch 6):** this is exactly the scan-vs-index distinction. A term-partitioned inverted index is the standard answer.
+
+### B3. Every ingest nukes the whole BM25 index; the next query pays the rebuild — **High**
+
+**Change:** incremental `add_documents(ids, texts)` on the index (update `df`, `doc_lens`, `avg_dl`, postings). Keep full rebuild as a repair path. If a rebuild is unavoidable, build into a new object and swap the reference — never serve from a half-built index or block on it.
+
+**Problem:** `bm25_search.invalidate()` sets `_indices = {}`. The first query after any ingest — including every watch digest run — synchronously rebuilds from the full corpus while holding `_lock`, and every concurrent query blocks behind it. This is a self-inflicted periodic p99 cliff that grows linearly with corpus size.
+
+**Benefit:** ingest stops being a latency event.
+
+**Trade-off:** incremental IDF drifts slightly from a clean rebuild (negligible; schedule a nightly rebuild if it matters).
+
+**Impact:** `bm25_search.py`, `cache_refresh._post_ingest_refresh`.
+
+### B4. No admission control on expensive endpoints — **High**
+
+**Change:** a global `asyncio.Semaphore` (or bounded threadpool) around agentic query / rerank / NLI, sized to cores. Over the limit, return 503 with `Retry-After` immediately.
+
+**Problem:** rate limiting (`deps.limiter`) counts requests, not concurrent work. An agent query can hold a thread for `AGENT_TIMEOUT` — **300s**, per `config.py:314`, not the 120 the README claims — while running cross-encoder + NLI + contradiction detection (up to 56 NLI passes). Twenty concurrent agent queries on an 8-core box means every one of them thrashes and times out — the classic failure where the system does maximum work and returns zero successful responses. A five-minute per-thread hold makes this materially worse than the README's numbers suggest.
+
+**Benefit:** bounded, predictable p99 under overload; some requests shed fast instead of all failing slow.
+
+**Trade-off:** visible 503s at peak — which is the correct, honest behavior.
+
+**Impact:** `routes/agent.py`, `routes/query.py`, `rerank.py` / `verify.py` entry points.
+
+**DDIA framing (Ch 1):** response time is a distribution. Unbounded queueing converts a throughput problem into a total-availability problem.
+
+### B5. Thread oversubscription — **Medium**
+
+**Change:** pin `OMP_NUM_THREADS` / `torch.set_num_threads` and size the pools together; document the total.
+
+**Problem:** a 32-worker `_chroma_executor` + FastAPI's default 40-thread pool + `ProcessPoolExecutor` for PDF parsing + `ThreadPoolExecutor` for parallel agent tools + torch/ONNX intra-op threads, all unbounded relative to each other. On an 8-core box the ready queue is dozens deep and every stage gets slower simultaneously.
+
+**Trade-off:** lower peak throughput on an idle box, much better behavior under load.
+
+**Impact:** `config.py`, `vector_store.py`, `api_server.py` startup.
+
+### B6. BM25 index is rebuilt from ChromaDB on every process start — **Medium** **[R2]**
+
+**Change:** persist the index (pickle, or a plain postings file once B2 lands) and reload it at startup; fall back to a rebuild when the file is missing, corrupt, or stamped with a stale corpus count.
+
+**Problem:** `get_or_build_index` calls `collection.get(include=["documents"])` on the first query after every restart. Cold start therefore scales with corpus size, and the warm-up in `api_server.lifespan` pays it on every deploy. Combined with B3 (invalidate-on-ingest), the full rebuild is currently the system's most frequently executed expensive operation.
+
+**Benefit:** near-instant cold start; one less full read of the vector store per deploy.
+
+**Trade-off:** a persisted index is a second copy that can go stale — it must be invalidated on ingest and validated against the collection count on load.
+
+**Impact:** `bm25_search.py`, `cache_refresh.py`. Do it after B2, so what gets persisted is the postings structure and not the current per-chunk `Counter` list.
+
+---
+
+## C. Reliability & correctness
+
+### C1. Long-running work runs inside the web process with no durable queue — **High**
+
+**Change:** a real work queue for ingest, reports, and watch runs. Lazy version that fits what is already here: a `tasks` table in SQLite with `status`, `lease_expires_at`, `attempts`, `fencing_token`, plus a worker loop in a separate process. Full version: Redis + RQ/Celery.
+
+**Problem:** ingest jobs and report generation execute in the API process's threadpool. Consequences: (a) a bulk ingest starves query latency; (b) a restart mid-job leaves the job row `running` forever — nothing reaps it, so `/compare/status/{id}` polls a dead job indefinitely; (c) no retry; (d) the process cannot be scaled or restarted independently of the CPU-heavy work.
+
+**Benefit:** restart safety, retries, ingest isolated from query latency, workers scale independently.
+
+**Trade-off:** a second deployable unit; job handoff must be idempotent.
+
+**Impact:** `routes/ingest.py`, `deps._jobs` / `_update_job`, `report_runner.py`, `watch_runner.py`, `persistence.py`, `docker-compose.yml`.
+
+**DDIA framing (Ch 8):** a lease with a **fencing token** is required — a worker that hung and a worker that died are indistinguishable, and the recovered one must not write over its successor.
+
+### C2. In-process watch scheduler duplicates work the moment there is a second replica — **High (blocking for B1)**
+
+**Change:** either run the scheduler as its own single-replica deployment, or take a leader lease before each tick (`UPDATE watches SET next_run=? WHERE id=? AND next_run=?` — a compare-and-set claim is enough and needs no new infrastructure).
+
+**Problem:** `api_server.lifespan` starts `watch_runner.watch_loop()` unconditionally per process. Two workers = every watch runs twice = duplicate arXiv fetches, duplicate ingests (dedup catches most, but not the API cost), duplicate digests.
+
+**Benefit:** exactly-once-ish scheduling that survives scaling.
+
+**Trade-off:** a claimed-but-crashed watch needs a lease timeout to be re-runnable.
+
+**Impact:** `api_server.py`, `watch_runner.py`, `persistence.due_watches`.
+
+### C3. No backup or restore path for ChromaDB — **High**
+
+**Change:** a scheduled snapshot of `chroma_db/` (a plain copy while writes are in flight is unsafe — snapshot the volume, or add an export-collection job) plus a documented, *tested* restore. Add `/admin/snapshot`.
+
+**Problem:** the vector store is a bind-mounted directory with one writer and no replication. Volume loss or partial corruption during an ingest crash = full re-ingest of the corpus (hours of PDF parsing + embedding, and remote metadata that may no longer resolve). There is no snapshot, no checksum, no restore procedure.
+
+**Benefit:** recovery in minutes instead of hours.
+
+**Trade-off:** disk.
+
+**Impact:** ops + one management route.
+
+### C4. Derived indexes have no rebuild-from-source path — **Medium/High**
+
+**Change:** an append-only ingest event log (`doc_id`, `content_hash`, `source_path`, extracted chunks + section labels, timestamp) as the system of record. Chroma, BM25, and the figure store become **derived views** rebuildable from it.
+
+**Problem:** today the truth is split: PDFs in `papers/`, chunks in Chroma, the lexical index in RAM, metadata in Chroma metadata, artifacts in SQLite. There is no way to deterministically rebuild the vector store — you must re-parse every PDF and re-call the VLM captioner. That makes an embedding-model upgrade or a chunking-strategy change a multi-hour, non-reproducible operation, which in practice means it never happens.
+
+**Benefit:** reindexing becomes routine; model upgrades, chunker changes, and corruption recovery are all the same replayable operation.
+
+**Trade-off:** storage for chunk text (small next to the PDFs), one new write on the ingest path.
+
+**Impact:** `ingest.py`, `persistence.py`, new `reindex.py`.
+
+**DDIA framing (Ch 11, Ch 12):** unbundle — one durable log, many derived indexes. This is the highest-leverage structural change in the list for long-term evolvability.
+
+### C5. Embeddings and chunks carry no version stamp — **High**
+
+**Change:** stamp every chunk with `embed_model`, `embed_dim`, `chunker_version`, `schema_version`. Refuse to query a collection whose stamp differs from the running config (fail loudly), and make reindex the migration path.
+
+**Problem:** nothing records which model produced a vector. Swap `bge-m3` for anything else, or change per-section chunk sizes, and new chunks silently join old ones. Cosine distance between two different embedding spaces is meaningless but never errors — retrieval quality degrades quietly and is nearly undebuggable from the outside.
+
+**Benefit:** model migrations become detectable and safe.
+
+**Trade-off:** a few bytes of metadata per chunk; one migration to stamp existing rows.
+
+**Impact:** `ingest.py`, `vector_store.py`, `embeddings.py`, startup check in `lifespan`.
+
+**DDIA framing (Ch 4):** this is schema evolution. Un-versioned data written by two incompatible writers is the canonical failure.
+
+### C6. Concurrent turns on one session lose updates — **Medium**
+
+**Change:** a per-session lock across read-history → generate → append, or make the append conditional on the message count that was read.
+
+**Problem:** `_get_or_create_session` returns `list(...)` — a copy. Two concurrent requests on the same session both read history at length N, both generate, and both append; the result is a history where each turn was answered without knowledge of the other. `_append_session_messages` also re-materializes an evicted session (the correct fix for a KeyError, but it silently resurrects a session with empty history mid-conversation).
+
+**Benefit:** coherent multi-turn context.
+
+**Trade-off:** serializes concurrent turns per session (correct — they are not independent).
+
+**Impact:** `deps.py`.
+
+**DDIA framing (Ch 7):** read-modify-write without isolation = lost update.
+
+### C7. Timeouts do not cancel the work behind them — **Medium**
+
+**Change:** cooperative cancellation — a deadline in `AgentState` checked at each graph node boundary and before each tool dispatch. For Chroma, treat a timeout as a degraded-mode signal (circuit-break the collection) rather than only leaking a thread.
+
+**Problem:** `vector_store._chroma_call` documents that a timed-out call keeps running (the 32-worker pool is a leak budget, not a fix). `AGENT_TIMEOUT` returns 504 while the reflexion loop keeps burning LLM quota and CPU for a client that is gone. Under load, timed-out work is pure waste that makes the next request slower — a retry-storm amplifier.
+
+**Benefit:** timeouts actually free capacity.
+
+**Trade-off:** cancellation checks in agent nodes.
+
+**Impact:** `agent/graph.py`, `agent/tool_executor.py`, `vector_store.py`.
+
+### C8. Ingest dedup is check-then-write — **Medium**
+
+**Change:** a `UNIQUE` constraint on `content_hash` in the ingest log (C4), or a per-hash lock; let the DB decide the winner.
+
+**Problem:** the three-layer dedup (file hash, content hash, title similarity) reads current state and then writes. Two concurrent uploads of the same paper both pass all three checks and both index — duplicated chunks skew BM25 IDF and produce duplicate citations.
+
+**Benefit:** dedup holds under concurrency.
+
+**Trade-off:** one loser gets an "already ingested" response.
+
+**Impact:** `ingest.py`, `routes/ingest.py`.
+
+### C9. Health endpoint conflates liveness and readiness — **Low/Medium**
+
+**Change:** split `/livez` (process up) from `/readyz` (models loaded, collection reachable).
+
+**Problem:** the compose healthcheck already needs `start_period: 120s` to paper over this; an orchestrator would kill the pod during model load.
+
+**Impact:** `routes/management.py`, `docker-compose.yml`, any k8s manifest.
+
+### C10. No degraded retrieval mode: a sick ChromaDB or a failed embedding call fails the whole request — **High** **[R2]**
+
+**Change:** one piece of work with two halves. (a) Wrap ChromaDB in the same circuit breaker already used per `(provider, model)` in `llm_client.py` — after N consecutive timeouts, trip and skip the dense leg for the cooldown. (b) Wrap `embeddings.embed_query` so a failure degrades to the same path. In both cases serve BM25-only results with an explicit `degraded: "sparse_only"` field in the response.
+
+**Problem, half (a):** `_chroma_call` has a 5s timeout and no breaker. When ChromaDB is unhealthy — disk full, corrupt segment, hung compaction — *every* request pays the full 5s before failing, and each one parks a worker in the 32-thread `_chroma_executor` that cannot be cancelled. The pool is exhausted in seconds and the failure spreads to requests that would not have touched the dense path at all.
+
+**Problem, half (b):** `rag.py:358` calls `embeddings.embed_query(user_query)` unguarded on the main retrieval path. An OOM, a corrupted model file, or a driver fault takes down every query, including ones a BM25 index sitting in the same process could have answered.
+
+**Benefit:** the dense leg becomes a component that can fail rather than the whole system. Sparse-only answers are worse, but they exist.
+
+**Trade-off:** degraded results must be surfaced honestly — a silently sparse-only answer is worse than an error because it looks normal. This also demands the explicit degraded-mode contract listed in §G.
+
+**Impact:** `vector_store.py`, `rag.py` (`retrieve_context`), response models in `routes/query.py` and `routes/agent.py`. Reuse the breaker from `llm_client.py`; do not write a second one.
+
+**DDIA framing (Ch 8):** timeouts alone are a fragile failure detector. A breaker converts "slow" into "known down" and stops the pile-up.
+
+### C11. Agent streaming is post-hoc chunking, not streaming — **Low** **[R2]**
+
+**Change:** stream the answer generator's tokens through the existing `sse_utils` queue bridge instead of slicing the finished string.
+
+**Problem:** `routes/agent.py:325` sets `chunk_size = 80` and emits the completed answer in 80-character slices — the docstring at :247 says so plainly. Time-to-first-*answer*-token equals total pipeline time.
+
+**Not as bad as it looks:** thinking events (:275) and tool-call events (:301) *do* stream live during the run, so the user sees progress throughout. This is a fidelity problem, not a blank-screen problem — which is why it stays Low.
+
+**Trade-off:** the answer generator runs in a threadpool inside a LangGraph node; threading real tokens out means the node must yield through the queue bridge, and citation compaction currently has to complete before the first chunk goes out (:304). That ordering constraint is the actual blocker, not the streaming plumbing.
+
+**Impact:** `agent/graph.py`, `routes/agent.py`, `sse_utils.py`.
+
+---
+
+## D. Performance
+
+### D1. SQLite: one connection, one global lock, on the query hot path — **Medium**
+
+**Change:** connection-per-thread (or a small pool) with WAL — WAL's whole point is concurrent readers, and `_db_lock` around a single connection discards that. Batch `log_query` writes (buffer + flush) instead of committing synchronously inside request handling.
+
+**Problem:** `persistence._db_lock` serializes *all* DB access globally, and every function commits individually. Every `/query` writes a `query_log` row with an fsync-per-commit, in a threadpool thread, behind a process-global lock. The ceiling is roughly low hundreds of writes/sec and it contends with session writes and the watch scheduler.
+
+**Benefit:** reads stop blocking on writes; the query path stops paying an fsync.
+
+**Trade-off:** a crash can lose the last few query-log rows (acceptable — it is analytics, not answers).
+
+**Impact:** `persistence.py` only.
+
+### D2. Tags stored as one comma-joined string, filtered in Python with over-fetch — **Medium**
+
+**Change:** store each tag as its own Chroma metadata key (`tag_ml: true`) and filter server-side with `$and`/`$in`, or keep an authoritative `paper_tags` table in SQLite and pre-resolve to `paper_ids`.
+
+**Problem:** the v2.4 notes describe the current shape honestly — tags need `TAGS_OVERFETCH` because filtering happens after retrieval. That makes recall a function of a tuning constant: a rare tag on a large corpus silently returns fewer results than it should, and the failure is invisible.
+
+**Benefit:** correct, tuning-free tag filtering; no wasted over-fetch.
+
+**Trade-off:** a metadata migration.
+
+**Impact:** `ingest.py`, `vector_store.py`, `rag.py`.
+
+### D3. Contradiction detection costs up to 56 NLI passes per query — **Low**
+
+**Change:** make it opt-in per request, or run it after the answer streams and patch it in as a follow-up SSE event.
+
+**Trade-off:** contradiction warnings arrive slightly late.
+
+**Impact:** `contradiction.py`, `routes/agent.py`.
+
+### D4. SQLite has no secondary indexes at all — **Medium (cheapest item in this document)** **[R2]**
+
+**Change:** six statements.
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_watches_next_run  ON watches(next_run);
+CREATE INDEX IF NOT EXISTS idx_watches_user      ON watches(user_id);
+CREATE INDEX IF NOT EXISTS idx_feedback_query    ON feedback(query_id);
+CREATE INDEX IF NOT EXISTS idx_jobs_status       ON jobs(status);
+CREATE INDEX IF NOT EXISTS idx_sessions_updated  ON sessions(updated_at);
+CREATE INDEX IF NOT EXISTS idx_reports_watch     ON reports(watch_id);
+```
+
+**Problem:** all seven `CREATE TABLE` statements in `persistence.py` declare a PRIMARY KEY and nothing else. Every non-key access is a full scan: `due_watches` filters on `next_run` and runs on every scheduler tick; `get_feedback_with_context` LEFT JOINs `query_log` on `query_id`; `load_sessions` and `load_jobs` delete by timestamp on every startup; `list_reports` filters by `watch_id`. All are fine at current row counts and all degrade linearly as `query_log` and `sessions` accumulate.
+
+**Benefit:** O(log n) instead of O(n) on the scheduler's hot path and on every feedback read.
+
+**Trade-off:** marginal write amplification, invisible at this write rate.
+
+**Impact:** `persistence.py`, additive only — no query or logic changes. Pairs naturally with F5 (migrations) but does not need to wait for it: `CREATE INDEX IF NOT EXISTS` is safe to run at startup alongside the existing `CREATE TABLE IF NOT EXISTS` calls.
+
+**DDIA framing (Ch 3):** without an index the storage engine scans every row. That is the whole finding.
+
+### D5. Figure captioning is sequential — **Low** **[R2]**
+
+**Change:** a bounded `ThreadPoolExecutor` (3–5 workers) over the region list, sized to stay inside the Gemini rate limit.
+
+**Problem:** `figure_captioner.py:178` iterates `for r in regions:`, one VLM round-trip at a time. A figure-heavy paper serializes a dozen network calls into ingest latency.
+
+**Benefit:** figure-heavy ingestion drops to roughly wall-clock/N.
+
+**Trade-off:** must respect the API rate limit — unbounded concurrency here trades a slow ingest for a 429 storm that the LLM circuit breaker will then trip.
+
+**Impact:** `figure_captioner.py`, isolated.
+
+---
+
+## E. Security
+
+### E1. API keys are static plaintext env values — **Medium**
+
+**Change:** an `api_keys` table storing SHA-256 hashes with `owner`, `scopes`, `created_at`, `expires_at`, `revoked_at`. Keep the constant-time comparison (already correct in `_key_matches`). Add issue/revoke admin routes.
+
+**Problem:** rotation means a redeploy; revoking one user's access means rotating everyone's; a leaked key is valid forever; there is no scoping (any key can ingest — purge is admin-only, but everything else is uniform). `API_KEYS` sits in the process environment and in `.env` on disk.
+
+**Benefit:** rotation and revocation without downtime; per-key scopes and quotas.
+
+**Trade-off:** one lookup per request (cache it).
+
+**Impact:** `deps.py`, `persistence.py`, new admin routes.
+
+### E2. `execute_python` sandbox — **Medium/High**
+
+**Change:** default it off. When on, add hard resource limits (`RLIMIT_AS`, `RLIMIT_CPU`, no network namespace) on top of the existing AST validation and 10s timeout.
+
+**Problem:** AST whitelisting is a deny-list-shaped defense pretending to be an allow-list — a well-known bypass surface, and the tool is reachable by any authenticated user. Process isolation without an RSS limit still allows a memory bomb that OOM-kills the whole server (which, per B1, is the entire service).
+
+**Benefit:** a bypass costs one sandboxed process, not the node.
+
+**Trade-off:** setup complexity; `resource` limits are POSIX-only (Windows dev needs a fallback path).
+
+**Impact:** `agent/tool_executor.py`, deployment.
+
+### E3. SSRF guard has a DNS TOCTOU gap — **Medium** **[R2, corrected]**
+
+> Correction to revision 1, which asked for a size cap, timeouts, and a redirect guard on the
+> download path. All three already exist — `_MAX_PDF_BYTES` (50 MB), `timeout=30`, and
+> `_NoRedirectHandler` with per-hop re-validation. The real gap is narrower and is named in the
+> code's own `ponytail:` comment.
+
+**Change:** pin the resolution — resolve the hostname once, verify that address, then connect to *that IP* (custom `HTTPConnection` / connection adapter with the `Host` header preserved) instead of letting `urlopen` resolve a second time.
+
+**Problem:** `download_utils._is_private_ip` calls `socket.getaddrinfo`, and `_NoRedirectOpener.open(req)` then performs its own independent lookup. A hostile or rebinding DNS server can answer public for the check and `127.0.0.1` / `169.254.169.254` for the fetch. Every other SSRF control on this path is sound; this one hole bypasses all of them.
+
+**Benefit:** closes the last SSRF vector on the ingest path, including cloud metadata access.
+
+**Trade-off:** a custom opener, and TLS SNI/cert validation must still key on the hostname rather than the pinned IP — easy to get subtly wrong, so it needs a test.
+
+**Realistic severity:** the fetched URLs originate from arXiv / Semantic Scholar / OpenAlex records rather than raw user input, and the routes are authenticated. High impact, low likelihood — worth fixing, not worth blocking a release on.
+
+**Impact:** `download_utils.py` only. `tests/test_download_utils.py` already exists; extend it with a rebinding case.
+
+### E4. No per-key cost quota — **Medium**
+
+**Change:** track LLM tokens per owner in `query_log`; enforce a daily budget, 429 over it.
+
+**Problem:** rate limiting caps request *count*. One user running agentic queries with reflexion at 8192 max tokens can exhaust the shared Gemini quota (and bill), degrading every other user — a noisy-neighbor failure that per-IP/per-key request limits do not address at all.
+
+**Impact:** `providers/*`, `persistence.py`, `deps.py`.
+
+### E5. LLM-spending endpoints have no rate limit — **High** **[R2, re-prioritized]**
+
+**Change:** `@limiter.limit(...)` on `POST /report` (`routes/report.py:97`) and `POST /watch/{watch_id}/run` (`routes/watch.py:116`) first; then the read-heavy routes.
+
+**Problem:** rate limits are applied only in `routes/query.py`, `routes/chat.py`, `routes/agent.py`, and `routes/ingest.py`. The `management`, `feedback`, `watch`, `report`, and `models` routers have none. Two of those unprotected routes each kick off a full LLM workload — report generation decomposes a topic and synthesizes every section; a manual watch run searches, ingests, and generates a digest. An authenticated user can loop either one and drain the shared Gemini quota, which per E4 degrades every other user. `/search` and `/papers` are the milder case: ChromaDB threads and disk I/O.
+
+**Benefit:** the two endpoints that spend money get a bound.
+
+**Trade-off:** limits must be generous enough for legitimate bulk report generation; per-key rather than per-IP (already the behavior of `_rate_limit_key`).
+
+**Impact:** decorators in `routes/report.py`, `routes/watch.py`, then `routes/management.py`, `routes/feedback.py`, `routes/models.py`.
+
+---
+
+## F. Maintainability & observability
+
+### F1. Stage-level metrics are missing — **High** (highest observability payoff per line)
+
+**Change:** Prometheus histograms per stage: `retrieval_dense`, `retrieval_bm25`, `rrf`, `colbert`, `cross_encoder`, `llm_generate`, `nli_verify`, `contradiction`, plus counters for cache hits per cache, LLM tokens, circuit-breaker trips, failover hops, reflexion iterations, and abstentions.
+
+**Problem:** `Instrumentator()` gives HTTP-level latency only. When p99 doubles, nothing in the metrics distinguishes "BM25 rebuild after ingest" (B3) from "Gemini is slow" from "reranker thrashing" (B5). `GET /cache/stats` exists but is not scraped, so there is no history.
+
+**Benefit:** every other item in this review becomes measurable instead of arguable.
+
+**Trade-off:** a handful of decorators.
+
+**Impact:** `rag.py`, `rerank.py`, `verify.py`, `llm_client.py`.
+
+**DDIA framing (Ch 1):** measure percentiles per stage, not averages over the whole request.
+
+### F2. The retrieval-quality gate exists but cannot fail — **High** **[corrected]**
+
+> Correction to revision 1, which said "the harness exists but nothing enforces it."
+> `.github/workflows/ci.yml` **does** have an "Eval gate" step running
+> `python evaluate.py --ci --threshold 0.85`. The gate is real. The problem is narrower
+> and worse than a missing gate: it cannot fail from a code change.
+
+**Change:** add a CI job that **regenerates** `answers_and_citations.json` by running the
+live pipeline over the fixture corpus, then feeds the existing scorer. Keep the current
+snapshot job as a fast pre-check.
+
+**Problem:** `evaluate.py:220` reads `runs[qid]["retrieved_papers"]` from the committed
+`answers_and_citations.json`. It scores a frozen snapshot of past answers and never calls
+retrieval, so no change to `rag.py`, `bm25_search.py`, `embeddings.py`, or any retrieval
+env knob can move the number. The threshold (0.85, against a measured 0.94) is calibrated
+correctly and is still unreachable, because the input never changes unless someone
+regenerates the file by hand. The CI comment is honest about why — no keys, no model
+downloads in CI — but the effect is a gate that passes by construction.
+
+**Benefit:** the scoring half is already built and working; wiring a live run to it turns
+an ornament into an actual gate.
+
+**Trade-off:** needs either a small embedding model or a cached HF snapshot in CI (see F6),
+plus an LLM key or a jaccard-only judge for the generation half.
+
+**Impact:** `.github/workflows/ci.yml`, `docs/Eval/`. Effort drops from "build a quality
+gate" to "wire the harness to a live run".
+
+### F3. `rag.py` at 1221 lines is the coupling hotspot — **Medium**
+
+**Change:** split into `retrieval.py` (hybrid + fusion + rerank), `generation.py` (prompt + LLM + failover), `pipeline.py` (orchestration). Mechanical, no behavior change.
+
+**Problem:** it is imported by the agent, all query routes, `watch_runner`, and `report_runner`. Every change touches every consumer's blast radius, and it is the file where retrieval and generation concerns get accidentally entangled.
+
+**Trade-off:** one large diff, temporary merge friction.
+
+**Impact:** import sites only.
+
+### F4. Config sprawl without a printed effective config — **Low/Medium**
+
+**Change:** log the full resolved config (secrets redacted) at startup and expose it at `/config` behind admin auth.
+
+**Problem:** 584 lines of `config.py` with 74 `os.getenv` call sites. Reproducing a production behavior locally currently means reading source to find which variables exist.
+
+### F5. No schema migration framework — **Medium** **[R2]**
+
+**Change:** a `schema_version` table plus an ordered list of migration functions, applied at startup. Alembic works but drags in SQLAlchemy; for seven tables a 40-line versioned runner is enough.
+
+**Problem:** `persistence.py` creates schema imperatively with `CREATE TABLE IF NOT EXISTS`. That guard means an existing database silently keeps its *old* shape — add a column in a new release and every deployed instance quietly lacks it until something throws `no such column` at runtime. Which is exactly what A1 (owner columns), C4 (ingest log), and C5 (version stamps) all require. Every schema-touching item in this document is blocked on having a way to migrate.
+
+**Benefit:** schema changes become releasable. Rollback becomes possible.
+
+**Trade-off:** one more startup step; migrations must be tested against a populated database, not an empty one.
+
+**Impact:** `persistence.py` + a `migrations/` directory. Do this **before** A1, C4, and C5 rather than alongside them.
+
+**DDIA framing (Ch 4):** schema evolution needs an explicit, versioned path — `IF NOT EXISTS` is not one.
+
+### F6. Zero integration tests — every model is mocked — **High** **[R2]**
+
+**Change:** a small integration suite with a 2–3 paper fixture corpus, a temporary ChromaDB directory, and a real (small) embedding model, exercising ingest → retrieve → rerank → generate end to end. Mark it `@pytest.mark.integration` so the fast suite stays fast.
+
+**Problem:** 28 test files, and not one loads a real model — no reference to `load_embedding_model()`, `BGEM3FlagModel`, or `SentenceTransformer` anywhere in `tests/`. Every LLM, vector store, and embedding call is mocked. The consequence is that the seams *between* stages are untested: prompt assembly, context formatting, citation-marker compaction, chunk truncation, and the SSE bridge are each verified against a mock's idea of the contract. This is precisely how the v2.4 patch bugs happened — `verify.check_claims` receiving `(index, text)` tuples, the retrieval cache never populating, the answer generator ignoring the selected model. All three are seam defects that mocks cannot catch and one real end-to-end run would have.
+
+**Also:** `bm25_search.py` has no dedicated test at all (it is only reached incidentally through `test_agent.py`) — which matters now, because B2, B3, and B6 all propose rewriting it.
+
+**Benefit:** catches the exact class of bug this codebase has actually been shipping.
+
+**Trade-off:** seconds instead of milliseconds; needs a CI-friendly small model or a cached HF snapshot.
+
+**Impact:** new files under `tests/`. Write `tests/test_bm25_search.py` *before* touching B2.
+
+---
+
+## G. Missing functionality
+
+| Gap | Why it matters | Priority |
+|---|---|---|
+| **Delete consistency** | Deleting a paper leaves BM25 postings and cached retrievals stale until the next invalidate — deleted papers keep getting cited. Wire delete into `_post_ingest_refresh`. | **High** |
+| **Reindex / model-migration job** | No supported path to change embedding model or chunking (see C4/C5). | **High** |
+| **Stale-job reaper** | Jobs killed by a restart stay `running` forever; clients poll indefinitely. | **Medium** |
+| **Per-user cost/usage view** | Cannot answer "who is spending the quota" (see E4). | **Medium** |
+| **Multi-collection / tenant separation** | One Chroma collection for everyone — no path to per-org corpora. `get_or_create_collection` is already parameterized, so this is mostly routing. | **Medium** |
+| **Answer-level audit trail** | `query_log` stores question + answer, but not the retrieved chunk ids, model version, or config hash — a past answer cannot be reproduced or explained. DDIA Ch 12: end-to-end auditability. | **Medium** |
+| **Graceful degradation modes** | If the reranker or NLI model fails to load, behavior is undefined; declare explicit degraded modes (skip rerank, report `confidence: null` rather than `0.0`). | **Medium** |
+| **HNSW params frozen at creation** | `ef_construction` / `M` are silently ignored on an existing collection — a documented footgun that needs a rebuild path to actually tune. | **Low** |
+
+### Risk summary
+
+| Risk | Severity | Likelihood | Mitigation |
+|---|---|---|---|
+| Cross-user data exposure (sessions, watches, feedback, reports) | High | **Certain** — reachable today by any valid key | A1 / A2 |
+| Single-process SPOF; no worker can be added | High | Medium | B1 |
+| Unbounded LLM spend via `/report`, `/watch/{id}/run` | High | Medium | E5, E4 |
+| Silent retrieval degradation after a model or chunker change | High | Medium | C5, F2 |
+| ChromaDB unhealthy → thread-pool exhaustion → total outage | Medium | Medium | C10 |
+| Vector store loss with no restore path | High | Low | C3 |
+| Seam defects shipping undetected (mock-only tests) | Medium | **High** — three already shipped in v2.4 | F6 |
+| SQLite full-scan degradation as `query_log` grows | Medium | Medium | D4 |
+| Schema change cannot be deployed to an existing DB | Medium | **Certain** once A1/C4/C5 start | F5 |
+| BM25 p99 cliff after every ingest | Medium | High | B3, B6 |
+| SSRF via DNS rebinding | High | Low (URLs come from arXiv/S2/OpenAlex) | E3 |
+
+---
+
+## Verified strengths — do not "fix" these
+
+Checked in code, not taken from the README. Listed so a later pass does not propose work that is already done.
+
+- **Layered timeouts, real values:** 5s ChromaDB (`_chroma_call`), 60s `LLM_REQUEST_TIMEOUT_S`, 300s `LLM_STREAM_TIMEOUT_S`, 300s `AGENT_TIMEOUT`, 90s `AGENT_REFLEXION_BUDGET_S` — and `config.py:321-341` documents *why* the reflexion budget does not bound the failover chain. That comment is better than most systems' incident postmortems.
+- **SSRF controls, mostly complete:** scheme allow-list, DNS-resolved private/loopback/link-local rejection, 50 MB streaming cap, and manual per-hop redirect re-validation via `_NoRedirectHandler`. Only the DNS TOCTOU (E3) is open.
+- **Circuit breaker + failover:** per-`(provider, model)` keys with 60s cooldown, cross-vendor failover, guaranteed backstop. C10 should reuse this, not reinvent it.
+- **Concurrency discipline:** double-checked locking on every singleton, in-flight embedding dedup (`embeddings.py:104`), copy-on-read *and* copy-on-write for cached retrievals, `_ingest_lock` for URL dedup.
+- **Auth primitives:** `hmac.compare_digest` with no early exit across the key set, UTF-8 encoding so a non-ASCII header fails auth instead of 500ing, fail-closed `ADMIN_API_KEY`, and a production boot guard that refuses to bind `0.0.0.0` unauthenticated. The primitives are right — A1 is a *usage* gap in four routers, not a broken mechanism.
+- **Faithfulness verification:** claim-level NLI with contradiction detection and abstention is rare in production RAG and is the system's strongest differentiator.
+
+---
+
+## H. Considered and declined
+
+Two recommendations were checked against the code and rejected. Recorded so they are not re-proposed.
+
+### H1. Partition the ChromaDB collection per language — **do not do this**
+
+The proposal: split `scientific_papers` (`config.py:242`) into per-language collections so a Hindi query searches a smaller graph.
+
+**Why not:** BGE-M3 was chosen precisely because it embeds 100+ languages into one shared vector space. Cross-lingual retrieval — a Hindi query surfacing an English paper — is the product's headline capability, not an incidental benefit. Per-language partitioning either deletes that capability or forces a scatter-gather across every partition on every query, which is strictly worse than the single graph it replaced (§6 of the DDIA framing: local secondary indexes make reads expensive). The stated trade-off, "cross-language retrieval becomes harder," understates it: the feature stops working.
+
+**What is defensible:** partitioning by *domain* or *tenant*, where queries genuinely do not cross the boundary. That is the multi-collection item already in §G, and `get_or_create_collection` is parameterized for it.
+
+### H2. Replace the custom BM25 with Elasticsearch or Meilisearch
+
+Externalizing the vector store and the caches (B1) is right. Externalizing BM25 is not, for this corpus.
+
+**Why not:** the current index uses a Unicode-aware `[\p{L}\p{M}\p{N}]+` tokenizer specifically so Devanagari, Tamil, and the other Indic scripts tokenize correctly. Meilisearch's Indic tokenization is materially weaker; Elasticsearch needs per-language analyzer configuration to match what 20 lines of `regex` already do here. The swap risks a silent multilingual retrieval regression — the hardest kind to notice, given F2 (no quality gate) — in exchange for solving a scaling problem that B2 solves in one file with no new service.
+
+**Revisit when:** the corpus exceeds roughly 10⁵ chunks *and* B2 has been shown insufficient by the metrics from F1.
+
+---
+
+## Priority ordering
+
+**Phase 0 — unblock everything else (do these first, they gate the rest):**
+
+1. **F5** — migration framework. A1, C4, and C5 all add columns; without this they cannot ship safely.
+2. **D4** — six `CREATE INDEX` statements. Smallest diff in the document.
+3. **F6 (partial)** — `tests/test_bm25_search.py` before rewriting BM25.
+
+**Phase 1 — correctness and safety:**
+
+4. **A1 / A2** — data isolation (security bug, contradicts a shipped claim)
+5. **C5** — version-stamp embeddings (cheap now, unfixable-in-place later)
+6. **E5** — rate-limit `POST /report` and `POST /watch/{id}/run` (unbounded LLM spend)
+7. **B2 / B3** — BM25 inverted index + incremental update (single file, largest latency win)
+8. **C10** — Chroma circuit breaker + embedding fallback → sparse-only degraded mode
+9. **F1** — stage metrics (makes everything else measurable)
+10. **C3** — ChromaDB backup + restore
+11. **B4** — admission control (worse than it first looked: `AGENT_TIMEOUT` is 300s)
+
+**Phase 2 — structural, enables scale:**
+
+12. **B1** — externalize state to Redis (vectors and cache; *not* BM25 — see H2)
+13. **C1 / C2** — durable job queue + scheduler lease with fencing token
+14. **C4** — ingest event log, derived-view rebuilds
+15. **F2 + F6 (full)** — eval gate and integration suite in CI
+16. **E2 / E3** — sandbox resource limits, SSRF DNS pinning
+
+**Then:** B6, D1, D2, D5, E1, E4, C6–C9, C11, F3, F4, and the §G table.
+
+---
+
+## Overall
+
+The retrieval and agent design is genuinely strong — hybrid + RRF + two-stage rerank + claim-level NLI is the right pipeline, the per-request defenses are layered and deliberate, and the recent fix log shows failure modes being found and closed properly.
+
+The weaknesses cluster in three places, none of them in the retrieval logic:
+
+1. **The state layer.** Shared mutable state lives inside one process, derived indexes have no source to be rebuilt from, and the multi-user isolation exists in the job store but not in the four routers added since.
+2. **The data layer's evolvability.** No migrations, no version stamps, no secondary indexes — three cheap omissions that together make every schema-touching improvement expensive.
+3. **The test layer.** Everything is mocked, so defects live in the seams between stages. The v2.4 patch notes are a list of exactly that class of bug.
+
+Fix isolation, get a migration path, version the data, and put one real end-to-end test in place. Then get state out of the process. The rest is tuning.

--- a/docs/Eval/run_live.py
+++ b/docs/Eval/run_live.py
@@ -119,18 +119,29 @@ def run(judgments_path: Path, out_path: Path, top_k: int, with_answers: bool,
         if with_answers:
             answer_data = rag.answer_question(text, top_k=top_k, strategy=strategy)
             answer = answer_data.get("answer", "")
-            chunks = ctx.get("chunks", [])
-            # Citation numbers are per paper in first-seen order — the same
-            # mapping format_context uses, so resolve through it rather than
-            # inventing a second numbering scheme here.
-            num_to_meta = rag.citation_number_map(metas)
+            # The answer's OWN context, not the ctx retrieved above: strategy B
+            # retrieves on the translated query, so the two differ and resolving
+            # markers against the wrong one mislabels every claim.
+            answer_ctx = answer_data.get("context") or {}
+            answer_metas = answer_ctx.get("metadatas", metas)
+            chunks = answer_ctx.get("chunks", [])
+            # The markers in `answer` are the COMPACTED ones, so resolve through
+            # the returned citation list (number → title) rather than the raw
+            # per-paper numbering, which is what the answer had before compaction.
+            title_to_meta = {}
+            for m in answer_metas:
+                title_to_meta.setdefault((m.get("title") or "Unknown").strip(), m)
+            num_to_meta = {
+                int(c["number"]): title_to_meta.get((c.get("title") or "").strip(), {})
+                for c in answer_data.get("citations", [])
+            }
             for claim in _split_claims(answer):
                 nums = [int(n) for n in re.findall(r"\[(\d+)\]", claim)]
                 meta = num_to_meta.get(nums[0]) if nums else None
                 cited_paper = (meta or {}).get("paper_id")
                 chunk_text = ""
                 if cited_paper:
-                    for m, c in zip(metas, chunks):
+                    for m, c in zip(answer_metas, chunks):
                         if m.get("paper_id") == cited_paper:
                             chunk_text = c
                             break

--- a/docs/Eval/run_live.py
+++ b/docs/Eval/run_live.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Regenerate answers_and_citations.json by running the live pipeline.
+
+Why this exists
+---------------
+evaluate.py scores whatever is in answers_and_citations.json. That file was
+produced by hand — its own `_instructions` field said "Paste your system's
+output for each query" — so the CI eval gate scored a frozen snapshot and never
+called retrieval. No change to rag.py, bm25_search.py, embeddings.py or any
+retrieval env knob could move the number. The threshold was calibrated correctly
+(0.85 against a measured 0.94) and was still unreachable, because the input only
+changed when a human edited it.
+
+This closes that loop: run the judged queries through the real pipeline, emit the
+file evaluate.py already knows how to score, and the gate becomes able to fail.
+
+Usage
+-----
+    python run_live.py                      # retrieval only (no LLM, no API key)
+    python run_live.py --with-answers       # also generate answers for grounding
+    python run_live.py --top-k 10 --out /tmp/live.json
+
+Then:
+    python evaluate.py --results <out> --ci --threshold 0.85
+
+Retrieval-only is the default deliberately: retrieval metrics (precision,
+recall, MRR, nDCG) are the ones that regress silently when a knob changes, and
+they need no API key, no tokens and no non-determinism. Grounding metrics need
+generated answers, so they cost money and vary run to run — opt in.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Import the application from the repo root, not this directory.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+HERE = Path(__file__).resolve().parent
+
+
+def _split_claims(answer: str) -> list:
+    """Split an answer into claim-sized sentences.
+
+    Deliberately crude and dependency-free: the grounding judge compares a claim
+    against the chunk it cites, so sentence boundaries only need to be roughly
+    right. Anything smarter here would be a second thing to keep in sync with
+    verify.py.
+    """
+    parts = re.split(r"(?<=[.!?])\s+", (answer or "").strip())
+    return [p.strip() for p in parts if len(p.strip()) > 20]
+
+
+def _paper_ids(metadatas: list) -> list:
+    """Retrieved paper ids in rank order, de-duplicated.
+
+    Judgments are per paper and one paper contributes several chunks — leaving
+    the duplicates in would let a single paper fill top-k and inflate precision.
+    """
+    seen, out = set(), []
+    for m in metadatas or []:
+        pid = m.get("paper_id")
+        if pid and pid not in seen:
+            seen.add(pid)
+            out.append(pid)
+    return out
+
+
+def _corpus_mismatch(judgments_path: Path, collection) -> set:
+    """Judged paper ids that are not in the indexed corpus.
+
+    The judgments were written alongside hand-pasted answers, using readable
+    aliases ("tandem_nn") rather than the filename-derived ids the ingest
+    pipeline actually assigns ("2608_06352v1"). Nothing ever compared the two,
+    because nothing ever ran the judged queries against the live index — which
+    is exactly why the eval gate could never be wired up.
+
+    Caught here rather than in evaluate.py: a total id mismatch produces a
+    uniform 0.000, which is indistinguishable from "retrieval is completely
+    broken" unless something says otherwise.
+    """
+    judgments = json.loads(judgments_path.read_text(encoding="utf-8"))
+    judged = set(judgments.get("corpus") or [])
+    if not judged:
+        return set()
+    got = collection.get(include=["metadatas"])
+    live = {m.get("paper_id") for m in got.get("metadatas", []) if m.get("paper_id")}
+    return judged - live
+
+
+def run(judgments_path: Path, out_path: Path, top_k: int, with_answers: bool,
+        strategy: str) -> dict:
+    import config
+    import rag
+
+    judgments = json.loads(judgments_path.read_text(encoding="utf-8"))
+    queries = judgments["queries"]
+
+    results = []
+    for q in queries:
+        qid, text = q["id"], q["text"]
+        print(f"[{qid}] {text[:70]}...", flush=True)
+
+        ctx = rag.retrieve_context(text, top_k=top_k)
+        metas = ctx.get("metadatas", [])
+        entry = {
+            "query_id": qid,
+            "retrieved_papers": _paper_ids(metas),
+            "answer_claims": [],
+        }
+        if ctx.get("degraded"):
+            # A degraded run scores as if the dense leg were simply worse. Record
+            # it so a surprising score arrives with its explanation attached.
+            entry["degraded"] = ctx["degraded"]
+            print(f"    WARNING: retrieval degraded ({ctx['degraded']})", flush=True)
+
+        if with_answers:
+            answer_data = rag.answer_question(text, top_k=top_k, strategy=strategy)
+            answer = answer_data.get("answer", "")
+            chunks = ctx.get("chunks", [])
+            # Citation numbers are per paper in first-seen order — the same
+            # mapping format_context uses, so resolve through it rather than
+            # inventing a second numbering scheme here.
+            num_to_meta = rag.citation_number_map(metas)
+            for claim in _split_claims(answer):
+                nums = [int(n) for n in re.findall(r"\[(\d+)\]", claim)]
+                meta = num_to_meta.get(nums[0]) if nums else None
+                cited_paper = (meta or {}).get("paper_id")
+                chunk_text = ""
+                if cited_paper:
+                    for m, c in zip(metas, chunks):
+                        if m.get("paper_id") == cited_paper:
+                            chunk_text = c
+                            break
+                entry["answer_claims"].append({
+                    "claim": re.sub(r"\s*\[\d+(?:\s*,\s*\d+)*\]", "", claim).strip(),
+                    "cited_paper": cited_paper,
+                    "cited_chunk_text": chunk_text,
+                })
+
+        results.append(entry)
+
+    payload = {
+        "_instructions": (
+            "GENERATED by run_live.py against the live pipeline — do not hand-edit. "
+            "Re-run it after any retrieval change so the eval gate scores current "
+            "behavior rather than a snapshot."
+        ),
+        "_generated": {
+            "top_k": top_k,
+            "with_answers": with_answers,
+            "strategy": strategy,
+            "embed_model": config.EMBEDDING_MODEL_NAME,
+        },
+        "results": results,
+    }
+    out_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"\nWrote {len(results)} results to {out_path}")
+    return payload
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--judgments", default=str(HERE / "relevance_judgments.json"))
+    ap.add_argument("--out", default=str(HERE / "answers_and_citations.json"))
+    ap.add_argument("--top-k", type=int, default=5)
+    ap.add_argument("--strategy", default="A")
+    ap.add_argument("--with-answers", action="store_true",
+                    help="also generate answers (needs an LLM key; costs tokens)")
+    ap.add_argument("--skip-corpus-check", action="store_true",
+                    help="run even when the judged papers are not indexed (scores will be 0)")
+    args = ap.parse_args()
+
+    import config
+    import vector_store
+
+    collection = vector_store.get_or_create_collection()
+    count = collection.count()
+    if count == 0:
+        # Scoring an empty corpus reports 0.0 across the board and reads as a
+        # catastrophic regression, when the real problem is that nothing is indexed.
+        print("ERROR: the corpus is empty — ingest documents before running the eval.",
+              file=sys.stderr)
+        return 2
+    print(f"Corpus: {count} chunks in '{config.COLLECTION_NAME}'")
+
+    problem = vector_store.check_index_compatibility(collection)
+    if problem:
+        print(f"WARNING: {problem}", file=sys.stderr)
+
+    if not args.skip_corpus_check:
+        missing = _corpus_mismatch(Path(args.judgments), collection)
+        if missing:
+            print(
+                "\nERROR: the judged papers are not in the indexed corpus.\n"
+                f"  judged but missing: {', '.join(sorted(missing))}\n"
+                "\nEvery retrieval metric would score 0.000 — not because retrieval is\n"
+                "broken, but because the judgments describe a different corpus than the\n"
+                "one indexed. Scoring that would read as a catastrophic regression.\n"
+                "\nFix one of:\n"
+                "  - ingest the papers the judgments refer to, or\n"
+                "  - rewrite relevance_judgments.json against the corpus you actually have\n"
+                "    (paper_id values must match the indexed ids exactly), or\n"
+                "  - pass --skip-corpus-check to run anyway and inspect the raw output.\n",
+                file=sys.stderr)
+            return 3
+
+    run(Path(args.judgments), Path(args.out), args.top_k, args.with_answers, args.strategy)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/GEMINI_SETUP.md
+++ b/docs/GEMINI_SETUP.md
@@ -4,7 +4,7 @@ IndicRAG dispatches generation through `llm_client.py`, which supports two
 backends:
 
 - **Gemini** (`providers/gemini.py`) — any bare model name, e.g. `gemini-3.6-flash`
-- **OpenRouter** (`providers/openrouter.py`) — any `vendor/model` slug, e.g. `anthropic/claude-haiku`
+- **OpenRouter** (`providers/openrouter.py`) — any `vendor/model` slug, e.g. `google/gemma-4-31b-it:free`
 
 Everything else in the pipeline (embeddings, vector store, reranking, NLI
 verification) runs locally. Only generation is remote.
@@ -85,7 +85,7 @@ Model choice is not hard-coded. Two settings control it:
 | `LLM_SELECTABLE_MODELS` | Comma-separated dropdown exposed to the UI (`GET /models`); **first entry is the default** |
 
 Routing rule: a **bare name** (`gemini-3.6-flash`) goes to Gemini; anything
-containing a **`/`** (`anthropic/claude-haiku`) goes to OpenRouter.
+containing a **`/`** (`google/gemma-4-31b-it:free`) goes to OpenRouter.
 
 **Keep at least one `/` slug in `LLM_SELECTABLE_MODELS`.** Cross-vendor
 failover picks the first slug in that list, and OpenRouter silently rewrites a
@@ -141,8 +141,8 @@ several times a classic query because it makes multiple LLM turns.
 Set these in `.env` (defaults live in `config.py`):
 
 ```bash
-LLM_MODEL_NAME=gemini-3.6-flash
-LLM_SELECTABLE_MODELS=gemini-3.6-flash,gemini-3.5-flash,anthropic/claude-haiku
+LLM_MODEL_NAME=gemini-3.7-flash
+LLM_SELECTABLE_MODELS=gemini-3.7-flash,gemini-3.6-flash,gemini-3.5-flash-lite,nvidia/nemotron-3-super-120b-a12b:free,google/gemma-4-31b-it:free
 
 LLM_MAX_TOKENS=8192    # Maximum response length (thinking + answer share this)
 LLM_TEMPERATURE=0.3    # Lower = more factual, higher = more creative

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -184,8 +184,8 @@ and it must keep at least one `vendor/model` slug, because cross-vendor
 failover picks the first slug in that list.
 
 ```bash
-LLM_MODEL_NAME=gemini-3.6-flash
-LLM_SELECTABLE_MODELS=gemini-3.6-flash,gemini-3.5-flash,anthropic/claude-haiku
+LLM_MODEL_NAME=gemini-3.7-flash
+LLM_SELECTABLE_MODELS=gemini-3.7-flash,gemini-3.6-flash,gemini-3.5-flash-lite,nvidia/nemotron-3-super-120b-a12b:free,google/gemma-4-31b-it:free
 ```
 
 A bare name routes to Gemini; anything containing `/` routes to OpenRouter and

--- a/download_utils.py
+++ b/download_utils.py
@@ -6,7 +6,9 @@ address (127.0.0.1, 169.254.169.254, an internal 10.x service, ...) still got
 fetched. This adds the missing DNS-resolved private-IP check.
 """
 
+from typing import Optional
 from urllib.parse import urljoin, urlparse
+import http.client
 import ipaddress
 import logging
 import os
@@ -34,25 +36,89 @@ class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
 _NoRedirectOpener = urllib.request.build_opener(_NoRedirectHandler)
 
 
-def _is_private_ip(hostname: str) -> bool:
-    """Reject loopback, link-local, and private IPs after DNS resolution.
+def _is_blocked_ip(ip) -> bool:
+    """True for any address a fetch must never reach."""
+    return bool(ip.is_loopback or ip.is_link_local or ip.is_private or ip.is_reserved
+                or ip.is_multicast or ip.is_unspecified)
 
-    A hostname that fails to resolve is not itself an SSRF vector (the
-    subsequent urlopen() call will simply fail on it), so treat resolution
-    failure as "not private" rather than raising.
+
+def _resolve_public_ip(hostname: str, port: int) -> Optional[str]:
+    """Resolve `hostname` once and return a single vetted IP to connect to.
+
+    Returning the address — rather than a yes/no verdict — is what closes the
+    TOCTOU hole. The old code asked "is this hostname private?" and then let
+    urlopen() resolve the name a SECOND time, so a hostile or rebinding DNS
+    server could answer public for the check and 127.0.0.1 or 169.254.169.254
+    for the actual fetch. The connection is now pinned to exactly this address.
+
+    Returns None when the name doesn't resolve (not itself an SSRF vector — the
+    fetch would simply fail) or when it resolves to anything blocked.
     """
     try:
-        addrs = socket.getaddrinfo(hostname, None)
+        addrs = socket.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)
     except socket.gaierror:
-        return False
-    for family, _, _, _, sockaddr in addrs:
+        return None
+    for _family, _type, _proto, _canon, sockaddr in addrs:
         try:
             ip = ipaddress.ip_address(sockaddr[0])
         except ValueError:
             continue
-        if ip.is_loopback or ip.is_link_local or ip.is_private or ip.is_reserved:
-            return True
-    return False
+        if _is_blocked_ip(ip):
+            # One bad answer condemns the host: a name resolving to both a public
+            # and a private address is the rebinding pattern itself.
+            return None
+        return sockaddr[0]
+    return None
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """HTTPS connection to a pre-resolved IP, with TLS still verified against
+    the original hostname.
+
+    `self.host` stays the hostname so SNI, certificate validation and the Host
+    header all remain correct; only the socket's destination is overridden.
+    Validating the certificate against the IP instead would break every ordinary
+    HTTPS fetch.
+    """
+
+    def __init__(self, host, *args, pinned_ip=None, **kwargs):
+        super().__init__(host, *args, **kwargs)
+        self._pinned_ip = pinned_ip
+
+    def connect(self):
+        sock = socket.create_connection((self._pinned_ip, self.port), self.timeout)
+        self.sock = self._context.wrap_socket(sock, server_hostname=self.host)
+
+
+class _PinnedHTTPConnection(http.client.HTTPConnection):
+    """Plain-HTTP counterpart of _PinnedHTTPSConnection."""
+
+    def __init__(self, host, *args, pinned_ip=None, **kwargs):
+        super().__init__(host, *args, **kwargs)
+        self._pinned_ip = pinned_ip
+
+    def connect(self):
+        self.sock = socket.create_connection((self._pinned_ip, self.port), self.timeout)
+
+
+def _pinned_opener(pinned_ip: str) -> urllib.request.OpenerDirector:
+    """Opener that refuses redirects and connects only to `pinned_ip`."""
+    class _HTTPHandler(urllib.request.HTTPHandler):
+        def http_open(self, req):
+            return self.do_open(
+                lambda host, **kw: _PinnedHTTPConnection(host, pinned_ip=pinned_ip, **kw), req)
+
+    class _HTTPSHandler(urllib.request.HTTPSHandler):
+        def https_open(self, req):
+            # Forward this handler's SSL context rather than letting the connection
+            # fall back to a default one — the handler's context is what carries
+            # verification settings, and silently swapping it is how a "pinning"
+            # change turns into an unverified-TLS change.
+            return self.do_open(
+                lambda host, **kw: _PinnedHTTPSConnection(host, pinned_ip=pinned_ip, **kw),
+                req, context=self._context)
+
+    return urllib.request.build_opener(_NoRedirectHandler, _HTTPHandler, _HTTPSHandler)
 
 
 def download_pdf(url: str, _redirects_left: int = _MAX_REDIRECTS) -> str | None:
@@ -65,11 +131,10 @@ def download_pdf(url: str, _redirects_left: int = _MAX_REDIRECTS) -> str | None:
     let a public, guard-passing URL 302 to an internal address and bypass the
     check entirely).
 
-    # ponytail: the private-IP check and urlopen()'s own DNS resolution are two
-    # separate lookups (TOCTOU) — a malicious/rebinding DNS server could return
-    # a public IP for the check and a private one for the actual fetch. Full
-    # fix is connection pinning (resolve once, connect to that exact IP); add
-    # it if this is ever exposed to untrusted third-party DNS at scale.
+    DNS is resolved exactly once and the connection is pinned to that address,
+    so a rebinding DNS server cannot answer public for the check and private for
+    the fetch. TLS still validates against the hostname, not the pinned IP.
+
     # ponytail: timeout=30 bounds each individual connect/read, not the total
     # transfer — a slow-drip server can hold the connection open indefinitely
     # under the byte cap. Add a wall-clock ceiling across the whole read loop
@@ -79,12 +144,15 @@ def download_pdf(url: str, _redirects_left: int = _MAX_REDIRECTS) -> str | None:
     if parsed.scheme not in ("http", "https"):
         logger.warning(f"Rejected non-HTTP(S) URL: {url}")
         return None
-    if _is_private_ip(parsed.hostname or ""):
-        logger.warning(f"Rejected private/loopback URL: {url}")
+    hostname = parsed.hostname or ""
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    pinned_ip = _resolve_public_ip(hostname, port)
+    if pinned_ip is None:
+        logger.warning(f"Rejected unresolvable or private/loopback URL: {url}")
         return None
     req = urllib.request.Request(url, headers={"User-Agent": "IndicRAG/2.0"})
     try:
-        resp = _NoRedirectOpener.open(req, timeout=30)
+        resp = _pinned_opener(pinned_ip).open(req, timeout=30)
     except urllib.error.HTTPError as e:
         if e.code in _REDIRECT_CODES:
             location = e.headers.get("Location") if e.headers else None

--- a/download_utils.py
+++ b/download_utils.py
@@ -140,12 +140,24 @@ def download_pdf(url: str, _redirects_left: int = _MAX_REDIRECTS) -> str | None:
     # under the byte cap. Add a wall-clock ceiling across the whole read loop
     # if this becomes a real self-DoS problem (route is auth'd + rate-limited).
     """
-    parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https"):
+    # Parsing is inside the guard too: urlparse() itself raises on a malformed
+    # IPv6 authority ("http://[bad/"), and .port raises on a non-numeric or
+    # out-of-range port — neither of which .hostname does. This function's
+    # contract with its callers is "returns None on failure"; they treat a raise
+    # as a crash, and a background ingest task that raises here skips its
+    # reservation cleanup and its terminal job update, stranding the job as
+    # `running` forever.
+    try:
+        parsed = urlparse(url)
+        scheme = parsed.scheme
+        hostname = parsed.hostname or ""
+        port = parsed.port or (443 if scheme == "https" else 80)
+    except ValueError as exc:
+        logger.warning("Rejected malformed URL (%s): %s", exc, url)
+        return None
+    if scheme not in ("http", "https"):
         logger.warning(f"Rejected non-HTTP(S) URL: {url}")
         return None
-    hostname = parsed.hostname or ""
-    port = parsed.port or (443 if parsed.scheme == "https" else 80)
     pinned_ip = _resolve_public_ip(hostname, port)
     if pinned_ip is None:
         logger.warning(f"Rejected unresolvable or private/loopback URL: {url}")

--- a/download_utils.py
+++ b/download_utils.py
@@ -58,17 +58,20 @@ def _resolve_public_ip(hostname: str, port: int) -> Optional[str]:
         addrs = socket.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)
     except socket.gaierror:
         return None
+    # Every answer is inspected before any is used: returning on the first public
+    # one would let a name that resolves public-then-private through purely
+    # because of answer order, and that mix is the rebinding pattern itself.
+    chosen = None
     for _family, _type, _proto, _canon, sockaddr in addrs:
         try:
             ip = ipaddress.ip_address(sockaddr[0])
         except ValueError:
             continue
         if _is_blocked_ip(ip):
-            # One bad answer condemns the host: a name resolving to both a public
-            # and a private address is the rebinding pattern itself.
             return None
-        return sockaddr[0]
-    return None
+        if chosen is None:
+            chosen = sockaddr[0]
+    return chosen
 
 
 class _PinnedHTTPSConnection(http.client.HTTPSConnection):

--- a/embeddings.py
+++ b/embeddings.py
@@ -17,12 +17,17 @@ logger = logging.getLogger(__name__)
 _embedding_model = None
 _lock = threading.Lock()
 
+# Which weights are actually in use: 'unloaded' | 'fp32' | 'fp16' | 'onnx-int8'.
+# vector_store stamps this onto every chunk, because int8 and fp32 vectors of the
+# SAME model are not interchangeable and nothing else would notice them mixing.
+EMBED_BACKEND = "unloaded"
+
 
 def load_embedding_model(model_name: str = None) -> SentenceTransformer:
     """
     Load the multilingual embedding model with caching (thread-safe).
     """
-    global _embedding_model
+    global _embedding_model, EMBED_BACKEND
 
     if _embedding_model is not None:
         return _embedding_model
@@ -39,15 +44,37 @@ def load_embedding_model(model_name: str = None) -> SentenceTransformer:
 
         cache_dir = str(config.MODELS_CACHE_DIR)
         device = "cuda" if torch.cuda.is_available() else "cpu"
-        model = SentenceTransformer(
-            model_name,
-            cache_folder=cache_dir,
-            device=device
-        )
+
+        # int8 ONNX on CPU only. Embedding dominates a bulk ingest — the
+        # cross-encoders were already quantized while this one still ran fp32.
+        # On GPU, fp16 (below) is both faster and more accurate than int8, so the
+        # quantized path is CPU-only by design.
+        #
+        # Fail-open, matching rerank.py and verify.py: any problem here falls back
+        # to fp32 rather than taking the system down for a speed optimization.
+        model = None
+        if device == "cpu" and config.EMBED_ONNX_INT8:
+            try:
+                import onnx_ce
+                model = onnx_ce.load(model_name, "embed", kind="bi")
+                EMBED_BACKEND = "onnx-int8"
+                logger.info("Using int8 ONNX embeddings (CPU)")
+            except Exception as e:
+                logger.warning("int8 ONNX embeddings unavailable, using fp32: %s", e)
+                model = None
+
+        if model is None:
+            model = SentenceTransformer(
+                model_name,
+                cache_folder=cache_dir,
+                device=device
+            )
+            EMBED_BACKEND = "fp32"
 
         # ponytail: model.half() on CPU silently produces NaN on many architectures
         if device == "cuda":
             model.half()
+            EMBED_BACKEND = "fp16"
             logger.info("Using float16 precision on GPU")
 
         logger.info(f"Model loaded on device: {device}")

--- a/figure_captioner.py
+++ b/figure_captioner.py
@@ -20,6 +20,7 @@ by ``config.MULTIMODAL_MAX_FIGS_PER_DOC``.
 
 import logging
 import re
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Optional
 
 import fitz  # PyMuPDF (already a project dependency via pdf_utils)
@@ -165,18 +166,33 @@ def caption_regions(
 ) -> List[Dict[str, Any]]:
     """Caption each region (network) and build figure chunk dicts.
 
-    Parent-side only, sequential — one paper's figures at a time, no concurrent
-    fan-out at the VLM (matches ingest.py's network discipline). A region's crop
-    is written to disk only if it yields an indexable chunk, so dropped regions
-    leave no orphan PNGs.
+    Parent-side only. Captioning fans out across a small thread pool — a
+    figure-heavy paper used to serialize a dozen VLM round-trips into ingest
+    latency. Concurrency is deliberately small and bounded
+    (`config.FIGURE_CAPTION_WORKERS`): unbounded fan-out just trades a slow
+    ingest for a 429 storm that trips the LLM circuit breaker for everything
+    else running at the time.
 
-    Returns chunk dicts: {text, chunk_type, page, crop_path, caption}. Regions the
-    VLM can't describe and that also carry no caption/table text are dropped.
+    A region's crop is written to disk only if it yields an indexable chunk, so
+    dropped regions leave no orphan PNGs.
+
+    Returns chunk dicts: {text, chunk_type, page, crop_path, caption}, in region
+    order regardless of which caption finished first. Regions the VLM can't
+    describe and that also carry no caption/table text are dropped.
     """
     out_dir = config.FIGURES_DIR / _safe_id(paper_id)
     chunks: List[Dict[str, Any]] = []
-    for r in regions:
-        desc = _caption_one(r)
+
+    workers = max(1, min(config.FIGURE_CAPTION_WORKERS, len(regions))) if regions else 1
+    if workers == 1:
+        descs = [_caption_one(r) for r in regions]
+    else:
+        # map() yields results in submission order, so chunk order still follows
+        # page/figure order and does not depend on completion order.
+        with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="vlm-caption") as pool:
+            descs = list(pool.map(_caption_one, regions))
+
+    for r, desc in zip(regions, descs):
         parts = [p for p in (r["caption"], desc, r["table_md"]) if p]
         body = "\n".join(parts).strip()
         if not body:

--- a/ingest.py
+++ b/ingest.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import List, Dict, Optional, Any, Tuple
 import logging
 import os
+from datetime import datetime, timezone
 from tqdm import tqdm
 import hashlib
 import concurrent.futures
@@ -188,6 +189,7 @@ def ingest_paper(
     metadata: Optional[Dict[str, Any]] = None,
     collection=None,
     figures: Optional[List[dict]] = None,
+    source_path: Optional[str] = None,
 ) -> int:
     """
     Ingest a single paper into the vector store.
@@ -225,6 +227,33 @@ def ingest_paper(
         ids=prepared['ids'],
         collection=collection
     )
+
+    # Record what was indexed, so the vector and lexical indexes can be rebuilt
+    # without re-parsing the PDF or re-calling the VLM captioner. Written AFTER
+    # the indexes, so the log never claims chunks that failed to land — the
+    # reverse order would leave a replay that reinstates nothing real.
+    #
+    # Best-effort: a logging failure must not fail an ingest that already
+    # succeeded. It costs the ability to replay that paper, not the paper itself.
+    try:
+        import persistence
+        persistence.record_ingest(
+            event_id=paper_id,          # one row per paper: the log describes the
+                                        # current index contents, not history
+            paper_id=paper_id,
+            content_hash=_content_hash("".join(text for _, text in sections)),
+            title=title,
+            source_path=source_path or "",
+            chunks=prepared['chunks'],
+            metadatas=prepared['metadatas'],
+            ids=prepared['ids'],
+            embed_model=config.EMBEDDING_MODEL_NAME,
+            chunker_version=vector_store.CHUNKER_VERSION,
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+    except Exception:
+        logger.warning("Could not record ingest log for %s — this paper will not be "
+                       "replayable by reindex.py", paper_id, exc_info=True)
 
     return len(prepared['chunks'])
 
@@ -327,6 +356,7 @@ def ingest_pdf(
         metadata=metadata,
         collection=collection,
         figures=figures,
+        source_path=str(pdf_path),
     )
     
     logger.info(f"Ingested {num_chunks} chunks from '{result['title']}'")

--- a/ingest.py
+++ b/ingest.py
@@ -175,11 +175,47 @@ def _build_paper_chunks(
 
     return {
         'paper_id': paper_id,
+        'title': title,
+        'content_hash': content_hash or '',
         'chunks': all_chunks,
         'metadatas': all_metadata,
         'ids': all_ids,
         'needs_deletion': needs_deletion,
     }
+
+
+def _record_ingest(prepared: Dict[str, Any], source_path: str = None) -> None:
+    """Write one paper's ingest-log row.
+
+    Shared by both ingest paths on purpose. ingest_paper() and ingest_directory()
+    each do their own embed-and-add, so putting the log write in only one of them
+    (as the first version did) silently left the bulk path — the one /ingest/all
+    uses — unlogged, and reindex.py would report an empty log after a perfectly
+    successful ingest.
+
+    Best-effort: a logging failure costs replayability for this paper, not the
+    ingest that already succeeded.
+    """
+    try:
+        import persistence
+        persistence.record_ingest(
+            event_id=prepared['paper_id'],   # one row per paper: the log describes
+                                             # current index contents, not history
+            paper_id=prepared['paper_id'],
+            content_hash=prepared.get('content_hash') or '',
+            title=prepared.get('title') or '',
+            source_path=source_path or prepared.get('source_path') or '',
+            chunks=prepared['chunks'],
+            metadatas=prepared['metadatas'],
+            ids=prepared['ids'],
+            embed_model=config.EMBEDDING_MODEL_NAME,
+            chunker_version=vector_store.CHUNKER_VERSION,
+            created_at=datetime.now(timezone.utc).isoformat(),
+            embed_backend=vector_store._embed_backend(),
+        )
+    except Exception:
+        logger.warning("Could not record ingest log for %s — this paper will not be "
+                       "replayable by reindex.py", prepared.get('paper_id'), exc_info=True)
 
 
 def ingest_paper(
@@ -228,32 +264,10 @@ def ingest_paper(
         collection=collection
     )
 
-    # Record what was indexed, so the vector and lexical indexes can be rebuilt
-    # without re-parsing the PDF or re-calling the VLM captioner. Written AFTER
-    # the indexes, so the log never claims chunks that failed to land — the
-    # reverse order would leave a replay that reinstates nothing real.
-    #
-    # Best-effort: a logging failure must not fail an ingest that already
-    # succeeded. It costs the ability to replay that paper, not the paper itself.
-    try:
-        import persistence
-        persistence.record_ingest(
-            event_id=paper_id,          # one row per paper: the log describes the
-                                        # current index contents, not history
-            paper_id=paper_id,
-            content_hash=_content_hash("".join(text for _, text in sections)),
-            title=title,
-            source_path=source_path or "",
-            chunks=prepared['chunks'],
-            metadatas=prepared['metadatas'],
-            ids=prepared['ids'],
-            embed_model=config.EMBEDDING_MODEL_NAME,
-            chunker_version=vector_store.CHUNKER_VERSION,
-            created_at=datetime.now(timezone.utc).isoformat(),
-        )
-    except Exception:
-        logger.warning("Could not record ingest log for %s — this paper will not be "
-                       "replayable by reindex.py", paper_id, exc_info=True)
+    # Record what was indexed so the indexes can be rebuilt without re-parsing
+    # the PDF. Written AFTER the indexes, so the log never claims chunks that
+    # failed to land.
+    _record_ingest(prepared, source_path)
 
     return len(prepared['chunks'])
 
@@ -508,6 +522,7 @@ def ingest_directory(
                 )
                 if prepared is not None:
                     stats["successful"] += 1
+                    prepared['source_path'] = str(path)
                     prepared_papers.append(prepared)
                 else:
                     # Unchanged or deduplicated — processed fine, just nothing to ingest.
@@ -555,6 +570,10 @@ def ingest_directory(
             collection=collection,
         )
         stats["total_chunks"] = len(all_chunks)
+
+        # Same log write as the single-paper path, after the indexes are written.
+        for p in prepared_papers:
+            _record_ingest(p)
 
     # Print summary
     logger.info("\n" + "=" * 60)

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,145 @@
+"""Stage-level Prometheus metrics.
+
+The HTTP instrumentator in api_server gives per-route latency and counts, which
+answers "is /query slow" but never "why". When p99 doubles, request-level
+numbers cannot distinguish a BM25 rebuild after an ingest from a slow LLM
+provider from a reranker thrashing on an oversubscribed box — and each of those
+has a different fix.
+
+These are the per-stage timings and counters that make them distinguishable.
+Everything registers on the default registry, so the existing /metrics endpoint
+serves them (behind the same API key) with no extra wiring.
+
+Metrics must never break a request: prometheus_client arrives transitively via
+prometheus_fastapi_instrumentator, so if it is ever absent this module degrades
+to no-ops instead of taking the pipeline down with it.
+"""
+
+from contextlib import contextmanager
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+try:
+    from prometheus_client import Counter, Gauge, Histogram
+    _ENABLED = True
+except Exception:  # pragma: no cover - depends on the deployment's deps
+    _ENABLED = False
+    logger.warning("prometheus_client unavailable; stage metrics disabled")
+
+
+class _NoopMetric:
+    """Stand-in exposing the subset of the API used here."""
+
+    def labels(self, *a, **k):
+        return self
+
+    def observe(self, *a, **k):
+        pass
+
+    def inc(self, *a, **k):
+        pass
+
+    def set(self, *a, **k):
+        pass
+
+
+if _ENABLED:
+    # Buckets span the real spread: a cache hit is sub-millisecond, a cross-encoder
+    # pass is hundreds of ms, an LLM call with failover is tens of seconds. The
+    # default buckets top out at 10s and would dump every interesting slow case
+    # into +Inf, which is precisely the case worth seeing.
+    _BUCKETS = (0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120)
+
+    stage_seconds = Histogram(
+        "indicrag_stage_seconds",
+        "Time spent in one pipeline stage",
+        ["stage"],
+        buckets=_BUCKETS,
+    )
+    stage_errors = Counter(
+        "indicrag_stage_errors_total",
+        "Exceptions raised inside a pipeline stage",
+        ["stage"],
+    )
+    cache_events = Counter(
+        "indicrag_cache_events_total",
+        "Cache hits and misses by cache name",
+        ["cache", "event"],
+    )
+    llm_tokens = Counter(
+        "indicrag_llm_tokens_total",
+        "Tokens billed, by provider/model and direction",
+        ["provider", "model", "direction"],
+    )
+    llm_failovers = Counter(
+        "indicrag_llm_failovers_total",
+        "Failover hops taken, labelled by why the previous path was abandoned",
+        ["provider", "model", "reason"],
+    )
+    circuit_trips = Counter(
+        "indicrag_circuit_trips_total",
+        "Circuit breaker openings by component",
+        ["component"],
+    )
+    reflexion_iterations = Histogram(
+        "indicrag_reflexion_iterations",
+        "Reflexion loops per agent answer",
+        buckets=(0, 1, 2, 3, 4),
+    )
+    answers = Counter(
+        "indicrag_answers_total",
+        "Answers produced, by pipeline mode and outcome",
+        ["mode", "outcome"],
+    )
+    corpus_chunks = Gauge(
+        "indicrag_corpus_chunks",
+        "Chunks currently indexed",
+    )
+else:  # pragma: no cover
+    stage_seconds = stage_errors = cache_events = _NoopMetric()
+    llm_tokens = llm_failovers = circuit_trips = _NoopMetric()
+    reflexion_iterations = answers = corpus_chunks = _NoopMetric()
+
+
+@contextmanager
+def stage(name: str):
+    """Time a pipeline stage.
+
+    Records the elapsed time whether or not the body raised — a stage that fails
+    after 30s is exactly the one worth seeing, and dropping it on the error path
+    would make an outage look like reduced latency.
+    """
+    start = time.perf_counter()
+    try:
+        yield
+    except BaseException:
+        stage_errors.labels(stage=name).inc()
+        raise
+    finally:
+        stage_seconds.labels(stage=name).observe(time.perf_counter() - start)
+
+
+def record_cache(cache_name: str, hit: bool) -> None:
+    cache_events.labels(cache=cache_name, event="hit" if hit else "miss").inc()
+
+
+def record_tokens(provider: str, model: str, prompt: int = 0, completion: int = 0) -> None:
+    if prompt:
+        llm_tokens.labels(provider=provider or "?", model=model or "?", direction="prompt").inc(prompt)
+    if completion:
+        llm_tokens.labels(provider=provider or "?", model=model or "?", direction="completion").inc(completion)
+
+
+def record_failover(provider: str, model: str, reason: str) -> None:
+    llm_failovers.labels(provider=provider or "?", model=model or "?", reason=reason).inc()
+
+
+def record_circuit_trip(component: str) -> None:
+    circuit_trips.labels(component=component).inc()
+
+
+def record_answer(mode: str, outcome: str) -> None:
+    """outcome: ok | abstained | degraded | no_documents | error."""
+    answers.labels(mode=mode, outcome=outcome).inc()

--- a/onnx_ce.py
+++ b/onnx_ce.py
@@ -23,15 +23,36 @@ _QFILE = f"onnx/model_quint8_{_QUANT}.onnx"
 
 
 def _snapshot_dir(model_id: str) -> str | None:
-    """Newest local HF snapshot dir for a repo id, or None if not cached."""
+    """Newest COMPLETE local HF snapshot dir for a repo id, or None if not cached.
+
+    Completeness matters, not just recency. A repo can have several snapshots —
+    a PR revision often lands as a partial one holding just model.safetensors,
+    with no config.json or tokenizer. Picking purely by mtime selects that
+    partial dir, and the export then fails deep inside transformers with an
+    unrelated-looking error (`A configuration of type rag cannot be
+    instantiated...`), because AutoConfig cannot find a config to read.
+
+    config.json is the marker: without it nothing downstream can load the model.
+    """
     safe = "models--" + model_id.replace("/", "--")
     snaps = glob.glob(str(config.MODELS_CACHE_DIR / safe / "snapshots" / "*"))
-    return max(snaps, key=os.path.getmtime) if snaps else None
+    complete = [s for s in snaps if os.path.isfile(os.path.join(s, "config.json"))]
+    if not complete:
+        return None
+    return max(complete, key=os.path.getmtime)
 
 
-def _build(model_id: str, out: Path) -> None:
+def _model_class(kind: str):
+    """CrossEncoder for rerank/NLI, SentenceTransformer for the bi-encoder embedder.
+
+    Both quantize through the same export path; only the wrapper class differs.
+    """
+    from sentence_transformers import CrossEncoder, SentenceTransformer
+    return SentenceTransformer if kind == "bi" else CrossEncoder
+
+
+def _build(model_id: str, out: Path, kind: str = "cross") -> None:
     """Export int8 ONNX from the local snapshot and drop config/tokenizer beside it."""
-    from sentence_transformers import CrossEncoder
     from sentence_transformers.backend import export_dynamic_quantized_onnx_model
 
     snap = _snapshot_dir(model_id)
@@ -41,29 +62,47 @@ def _build(model_id: str, out: Path) -> None:
     # backend="onnx" uses the snapshot's onnx/ if present, else auto-exports fp32 from
     # the torch weights (offline OK). export_dynamic_quantized_onnx_model requires an
     # onnx-backend model, then writes onnx/model_quint8_<quant>.onnx into `out`.
-    base = CrossEncoder(snap, backend="onnx", local_files_only=True)
+    base = _model_class(kind)(snap, backend="onnx", local_files_only=True)
     out.mkdir(parents=True, exist_ok=True)
     export_dynamic_quantized_onnx_model(base, _QUANT, str(out))
 
     # The quantized .onnx alone isn't loadable — copy the config + tokenizer (not the
     # big fp32 weights) so `out` is a self-contained, offline-loadable model dir.
+    #
+    # Subdirectories matter for bi-encoders: modules.json points at 1_Pooling/ (and
+    # sometimes 2_Normalize/), and without them SentenceTransformer builds Pooling
+    # with no config and fails with `missing 1 required positional argument:
+    # 'embedding_dimension'`. Cross-encoders have no such dirs, so this is a no-op
+    # for them.
+    #
+    # Every fp32 weight format is excluded, not just .safetensors: bge-m3 ships
+    # pytorch_model.bin, and copying it added 2.3 GB of weights that the ONNX
+    # runtime never reads.
+    weight_suffixes = (".safetensors", ".bin", ".h5", ".msgpack", ".ckpt", ".pth", ".pt")
     for name in os.listdir(snap):
         src = os.path.join(snap, name)
-        if os.path.isfile(src) and not name.endswith(".safetensors"):
-            shutil.copy2(src, out / name)
+        if os.path.isfile(src):
+            if not name.endswith(weight_suffixes):
+                shutil.copy2(src, out / name)
+        elif os.path.isdir(src) and name != "onnx":
+            # dirs_exist_ok: a rebuild over an existing export must not fail.
+            shutil.copytree(src, out / name, dirs_exist_ok=True)
 
 
-def load(model_id: str, subdir: str):
-    """Return an int8-ONNX CrossEncoder for model_id, building it once if needed.
+def load(model_id: str, subdir: str, kind: str = "cross"):
+    """Return an int8-ONNX model for model_id, building it once if needed.
+
+    kind="cross" -> CrossEncoder (reranker, NLI). kind="bi" -> SentenceTransformer
+    (the embedding model), where the win matters most: embedding is the dominant
+    cost of a bulk ingest, and it ran fp32 while the cross-encoders were already
+    quantized.
 
     Raises on any failure — the caller decides whether to fall back to fp32.
     """
-    from sentence_transformers import CrossEncoder
-
     out = config.MODELS_CACHE_DIR / "onnx_ce" / subdir
     if not (out / _QFILE).exists():
         logger.info(f"[onnx_ce] building int8 ONNX for {model_id} (one-time, ~90s)...")
-        _build(model_id, out)
+        _build(model_id, out, kind)
         logger.info(f"[onnx_ce] built {out}")
-    return CrossEncoder(str(out), backend="onnx",
-                        model_kwargs={"file_name": _QFILE}, local_files_only=True)
+    return _model_class(kind)(str(out), backend="onnx",
+                              model_kwargs={"file_name": _QFILE}, local_files_only=True)

--- a/persistence.py
+++ b/persistence.py
@@ -47,6 +47,23 @@ _conn.execute(
 )
 
 
+_conn.execute(
+    # Append-only record of what was ingested, and of the chunks that ingestion
+    # produced. This is the system of record; ChromaDB, the BM25 index and the
+    # figure store are derived views over it.
+    #
+    # Without this, the only way to rebuild the vector store was to re-parse every
+    # PDF and re-call the VLM captioner — hours of work, non-reproducible, and
+    # dependent on source files still being present. That made changing the
+    # embedding model or the chunking strategy so expensive it never happened.
+    # With it, reindexing is a replay.
+    "CREATE TABLE IF NOT EXISTS ingest_log ("
+    "event_id TEXT PRIMARY KEY, paper_id TEXT, content_hash TEXT, title TEXT, "
+    "source_path TEXT, chunks TEXT, metadatas TEXT, ids TEXT, "
+    "embed_model TEXT, chunker_version INTEGER, created_at TEXT)"
+)
+
+
 def _ensure_column(table: str, column: str, decl: str) -> None:
     """Add a column to an existing table if it isn't there yet.
 
@@ -85,6 +102,8 @@ _conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_completed ON jobs(completed_a
 _conn.execute("CREATE INDEX IF NOT EXISTS idx_sessions_updated ON sessions(updated_at)")
 _conn.execute("CREATE INDEX IF NOT EXISTS idx_reports_watch ON reports(watch_id)")
 _conn.execute("CREATE INDEX IF NOT EXISTS idx_reports_owner ON reports(owner)")
+_conn.execute("CREATE INDEX IF NOT EXISTS idx_ingest_paper ON ingest_log(paper_id)")
+_conn.execute("CREATE INDEX IF NOT EXISTS idx_ingest_hash ON ingest_log(content_hash)")
 
 _conn.commit()
 _db_lock = threading.Lock()
@@ -373,6 +392,78 @@ def due_watches(now_iso: str) -> list[dict]:
             (now_iso,),
         ).fetchall()
     return [json.loads(r[0]) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Ingest log — the system of record the search indexes are derived from.
+# ---------------------------------------------------------------------------
+def record_ingest(event_id: str, paper_id: str, content_hash: str, title: str,
+                  source_path: str, chunks: list, metadatas: list, ids: list,
+                  embed_model: str, chunker_version: int, created_at: str) -> None:
+    """Record one ingestion, including the chunks it produced.
+
+    Re-ingesting a paper replaces its row rather than appending a second one:
+    the log describes the CURRENT contents of the indexes, and keeping
+    superseded versions would make a replay reinstate deleted chunks.
+    """
+    with _db_lock:
+        _conn.execute(
+            "INSERT INTO ingest_log (event_id, paper_id, content_hash, title, source_path, "
+            "chunks, metadatas, ids, embed_model, chunker_version, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(event_id) DO UPDATE SET content_hash=excluded.content_hash, "
+            "title=excluded.title, source_path=excluded.source_path, chunks=excluded.chunks, "
+            "metadatas=excluded.metadatas, ids=excluded.ids, embed_model=excluded.embed_model, "
+            "chunker_version=excluded.chunker_version, created_at=excluded.created_at",
+            (event_id, paper_id, content_hash, title, source_path,
+             json.dumps(chunks), json.dumps(metadatas), json.dumps(ids),
+             embed_model, chunker_version, created_at),
+        )
+        _conn.commit()
+
+
+def get_ingest_events(paper_id: str = None) -> list[dict]:
+    """Every recorded ingestion, oldest first, or just one paper's.
+
+    Oldest first so a replay reproduces the original ingest order — chunk ids
+    and citation numbering follow insertion order.
+    """
+    with _db_lock:
+        if paper_id is None:
+            rows = _conn.execute(
+                "SELECT event_id, paper_id, content_hash, title, source_path, chunks, "
+                "metadatas, ids, embed_model, chunker_version, created_at "
+                "FROM ingest_log ORDER BY created_at ASC").fetchall()
+        else:
+            rows = _conn.execute(
+                "SELECT event_id, paper_id, content_hash, title, source_path, chunks, "
+                "metadatas, ids, embed_model, chunker_version, created_at "
+                "FROM ingest_log WHERE paper_id = ? ORDER BY created_at ASC",
+                (paper_id,)).fetchall()
+    return [{
+        "event_id": r[0], "paper_id": r[1], "content_hash": r[2], "title": r[3],
+        "source_path": r[4], "chunks": json.loads(r[5]), "metadatas": json.loads(r[6]),
+        "ids": json.loads(r[7]), "embed_model": r[8], "chunker_version": r[9],
+        "created_at": r[10],
+    } for r in rows]
+
+
+def ingest_event_count() -> int:
+    with _db_lock:
+        return _conn.execute("SELECT COUNT(*) FROM ingest_log").fetchone()[0]
+
+
+def delete_ingest_events(paper_id: str) -> int:
+    """Drop a paper from the log. Returns rows removed.
+
+    Must accompany deleting the paper from the indexes — otherwise a later
+    replay would resurrect it, which is the failure mode a system of record is
+    supposed to prevent.
+    """
+    with _db_lock:
+        cur = _conn.execute("DELETE FROM ingest_log WHERE paper_id = ?", (paper_id,))
+        _conn.commit()
+        return cur.rowcount
 
 
 def claim_watch(watch_id: str, expected_next_run: str, lease_until: str) -> bool:

--- a/persistence.py
+++ b/persistence.py
@@ -89,6 +89,10 @@ _ensure_column("query_log", "owner", "TEXT")
 # when that process dies the lease simply expires and the row can be reaped.
 _ensure_column("jobs", "lease_until", "TEXT")
 
+# Which weights produced the vectors. int8 and fp32 output for the SAME model id
+# are not interchangeable, so embed_model alone cannot detect a mixed corpus.
+_ensure_column("ingest_log", "embed_backend", "TEXT")
+
 # Secondary indexes. Every table above declared a PRIMARY KEY and nothing else, so
 # each of these access paths was a full scan: due_watches runs on every scheduler
 # tick, the feedback join runs on every read, and the startup prunes delete by
@@ -399,7 +403,8 @@ def due_watches(now_iso: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 def record_ingest(event_id: str, paper_id: str, content_hash: str, title: str,
                   source_path: str, chunks: list, metadatas: list, ids: list,
-                  embed_model: str, chunker_version: int, created_at: str) -> None:
+                  embed_model: str, chunker_version: int, created_at: str,
+                  embed_backend: str = None) -> None:
     """Record one ingestion, including the chunks it produced.
 
     Re-ingesting a paper replaces its row rather than appending a second one:
@@ -409,15 +414,16 @@ def record_ingest(event_id: str, paper_id: str, content_hash: str, title: str,
     with _db_lock:
         _conn.execute(
             "INSERT INTO ingest_log (event_id, paper_id, content_hash, title, source_path, "
-            "chunks, metadatas, ids, embed_model, chunker_version, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "chunks, metadatas, ids, embed_model, chunker_version, created_at, embed_backend) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(event_id) DO UPDATE SET content_hash=excluded.content_hash, "
             "title=excluded.title, source_path=excluded.source_path, chunks=excluded.chunks, "
             "metadatas=excluded.metadatas, ids=excluded.ids, embed_model=excluded.embed_model, "
-            "chunker_version=excluded.chunker_version, created_at=excluded.created_at",
+            "chunker_version=excluded.chunker_version, created_at=excluded.created_at, "
+            "embed_backend=excluded.embed_backend",
             (event_id, paper_id, content_hash, title, source_path,
              json.dumps(chunks), json.dumps(metadatas), json.dumps(ids),
-             embed_model, chunker_version, created_at),
+             embed_model, chunker_version, created_at, embed_backend),
         )
         _conn.commit()
 
@@ -432,19 +438,19 @@ def get_ingest_events(paper_id: str = None) -> list[dict]:
         if paper_id is None:
             rows = _conn.execute(
                 "SELECT event_id, paper_id, content_hash, title, source_path, chunks, "
-                "metadatas, ids, embed_model, chunker_version, created_at "
+                "metadatas, ids, embed_model, chunker_version, created_at, embed_backend "
                 "FROM ingest_log ORDER BY created_at ASC").fetchall()
         else:
             rows = _conn.execute(
                 "SELECT event_id, paper_id, content_hash, title, source_path, chunks, "
-                "metadatas, ids, embed_model, chunker_version, created_at "
+                "metadatas, ids, embed_model, chunker_version, created_at, embed_backend "
                 "FROM ingest_log WHERE paper_id = ? ORDER BY created_at ASC",
                 (paper_id,)).fetchall()
     return [{
         "event_id": r[0], "paper_id": r[1], "content_hash": r[2], "title": r[3],
         "source_path": r[4], "chunks": json.loads(r[5]), "metadatas": json.loads(r[6]),
         "ids": json.loads(r[7]), "embed_model": r[8], "chunker_version": r[9],
-        "created_at": r[10],
+        "created_at": r[10], "embed_backend": r[11],
     } for r in rows]
 
 

--- a/persistence.py
+++ b/persistence.py
@@ -45,6 +45,43 @@ _conn.execute(
     "CREATE TABLE IF NOT EXISTS reports (id TEXT PRIMARY KEY, watch_id TEXT, topic TEXT, "
     "language TEXT, markdown TEXT, citation_count INTEGER, created_at TEXT)"
 )
+
+
+def _ensure_column(table: str, column: str, decl: str) -> None:
+    """Add a column to an existing table if it isn't there yet.
+
+    `CREATE TABLE IF NOT EXISTS` silently keeps an old database's old shape, so a
+    column added in a later release never appears on an already-deployed instance
+    and the first query referencing it fails with `no such column`. This is the
+    whole migration story for now: idempotent, runs at import, no framework.
+    Replace it with a versioned runner once a change needs to backfill or
+    transform data rather than just append a nullable column.
+    """
+    cols = {row[1] for row in _conn.execute(f"PRAGMA table_info({table})")}
+    if column not in cols:
+        _conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {decl}")
+
+
+# `owner` is the SHA-256 fingerprint of the caller's API key (deps.current_owner).
+# NULL means "written before ownership existed, or written while auth was disabled".
+_ensure_column("feedback", "owner", "TEXT")
+_ensure_column("reports", "owner", "TEXT")
+_ensure_column("query_log", "owner", "TEXT")
+
+# Secondary indexes. Every table above declared a PRIMARY KEY and nothing else, so
+# each of these access paths was a full scan: due_watches runs on every scheduler
+# tick, the feedback join runs on every read, and the startup prunes delete by
+# timestamp.
+_conn.execute("CREATE INDEX IF NOT EXISTS idx_watches_next_run ON watches(next_run)")
+_conn.execute("CREATE INDEX IF NOT EXISTS idx_watches_user ON watches(user_id)")
+_conn.execute("CREATE INDEX IF NOT EXISTS idx_feedback_query ON feedback(query_id)")
+_conn.execute("CREATE INDEX IF NOT EXISTS idx_feedback_owner ON feedback(owner)")
+_conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status)")
+_conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_completed ON jobs(completed_at)")
+_conn.execute("CREATE INDEX IF NOT EXISTS idx_sessions_updated ON sessions(updated_at)")
+_conn.execute("CREATE INDEX IF NOT EXISTS idx_reports_watch ON reports(watch_id)")
+_conn.execute("CREATE INDEX IF NOT EXISTS idx_reports_owner ON reports(owner)")
+
 _conn.commit()
 _db_lock = threading.Lock()
 
@@ -109,27 +146,29 @@ def save_job(job_id: str, job: dict) -> None:
         _conn.commit()
 
 
-def save_feedback(feedback_id: str, query_id: str, rating: str, comment: str, created_at: str) -> None:
+def save_feedback(feedback_id: str, query_id: str, rating: str, comment: str, created_at: str,
+                  owner: str | None = None) -> None:
     with _db_lock:
         _conn.execute(
-            "INSERT INTO feedback (id, query_id, rating, comment, created_at) VALUES (?, ?, ?, ?, ?)",
-            (feedback_id, query_id, rating, comment, created_at),
+            "INSERT INTO feedback (id, query_id, rating, comment, created_at, owner) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (feedback_id, query_id, rating, comment, created_at, owner),
         )
         _conn.commit()
 
 
 def log_query(query_id: str, question: str, answer: str, mode: str,
               model: str, language: str, confidence: float, coverage: float,
-              created_at: str) -> None:
+              created_at: str, owner: str | None = None) -> None:
     """Persist a query/answer record so feedback can be correlated with it."""
     with _db_lock:
         _conn.execute(
             "INSERT INTO query_log "
-            "(query_id, question, answer, mode, model, language, confidence, coverage, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "(query_id, question, answer, mode, model, language, confidence, coverage, created_at, owner) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(query_id) DO UPDATE SET "
             "answer=excluded.answer, confidence=excluded.confidence, coverage=excluded.coverage",
-            (query_id, question, answer, mode, model, language, confidence, coverage, created_at),
+            (query_id, question, answer, mode, model, language, confidence, coverage, created_at, owner),
         )
         _conn.commit()
 
@@ -140,15 +179,25 @@ _FEEDBACK_CONTEXT_COLUMNS = [
 ]
 
 
-def get_feedback_with_context(limit: int = 50, offset: int = 0) -> list[dict]:
-    """Return feedback joined with its query context, newest first."""
+def get_feedback_with_context(limit: int = 50, offset: int = 0,
+                              owner: str | None = None) -> list[dict]:
+    """Return feedback joined with its query context, newest first.
+
+    `owner` scopes the result to one caller's submissions. None means unscoped —
+    only pass None when auth is disabled (single-tenant) or for an admin read;
+    an authenticated multi-user route must always pass the caller's fingerprint,
+    or every user reads every other user's feedback and query text.
+    """
+    where = "" if owner is None else "WHERE f.owner = ? "
+    params = (limit, offset) if owner is None else (owner, limit, offset)
     with _db_lock:
         rows = _conn.execute(
             "SELECT f.id, f.query_id, f.rating, f.comment, f.created_at, "
             "q.question, q.answer, q.mode, q.model, q.language, q.confidence, q.coverage "
             "FROM feedback f LEFT JOIN query_log q ON f.query_id = q.query_id "
+            f"{where}"
             "ORDER BY f.created_at DESC LIMIT ? OFFSET ?",
-            (limit, offset),
+            params,
         ).fetchall()
     return [
         dict(zip(_FEEDBACK_CONTEXT_COLUMNS, r))
@@ -156,16 +205,27 @@ def get_feedback_with_context(limit: int = 50, offset: int = 0) -> list[dict]:
     ]
 
 
-def feedback_stats() -> dict:
-    """Aggregate feedback totals and per-language approval rate."""
+def feedback_stats(owner: str | None = None) -> dict:
+    """Aggregate feedback totals and per-language approval rate, optionally per owner."""
+    where = "" if owner is None else " WHERE owner = ?"
+    join_where = "" if owner is None else " WHERE f.owner = ?"
+    args: tuple = () if owner is None else (owner,)
     with _db_lock:
-        total = _conn.execute("SELECT COUNT(*) FROM feedback").fetchone()[0]
-        up = _conn.execute("SELECT COUNT(*) FROM feedback WHERE rating='up'").fetchone()[0]
-        down = _conn.execute("SELECT COUNT(*) FROM feedback WHERE rating='down'").fetchone()[0]
+        total = _conn.execute(f"SELECT COUNT(*) FROM feedback{where}", args).fetchone()[0]
+        up = _conn.execute(
+            f"SELECT COUNT(*) FROM feedback WHERE rating='up'{'' if owner is None else ' AND owner = ?'}",
+            args,
+        ).fetchone()[0]
+        down = _conn.execute(
+            f"SELECT COUNT(*) FROM feedback WHERE rating='down'{'' if owner is None else ' AND owner = ?'}",
+            args,
+        ).fetchone()[0]
         by_lang = _conn.execute(
             "SELECT COALESCE(q.language, 'unknown'), COUNT(*), AVG(CASE WHEN f.rating='up' THEN 1.0 ELSE 0.0 END) "
             "FROM feedback f LEFT JOIN query_log q ON f.query_id = q.query_id "
-            "GROUP BY COALESCE(q.language, 'unknown')"
+            f"{join_where} "
+            "GROUP BY COALESCE(q.language, 'unknown')",
+            args,
         ).fetchall()
     return {
         "total": total, "up": up, "down": down,
@@ -217,8 +277,14 @@ def get_watch(watch_id: str) -> dict | None:
     return json.loads(row[0]) if row else None
 
 
-def list_watches(user_id: str | None = None) -> list[dict]:
-    """All watches, or just one user's, newest first."""
+def list_watches(user_id: str | None = None, owner: str | None = None) -> list[dict]:
+    """All watches, or just one user's, newest first.
+
+    `user_id` is a caller-supplied label and is NOT an authorization boundary —
+    anyone can pass anyone's. `owner` is the API-key fingerprint and is the real
+    scope; when it is not None, only that key's watches are returned regardless
+    of what user_id says.
+    """
     with _db_lock:
         if user_id is None:
             rows = _conn.execute(
@@ -229,7 +295,24 @@ def list_watches(user_id: str | None = None) -> list[dict]:
                 "SELECT data FROM watches WHERE user_id = ? ORDER BY created_at DESC",
                 (user_id,),
             ).fetchall()
-    return [json.loads(r[0]) for r in rows]
+    watches = [json.loads(r[0]) for r in rows]
+    if owner is not None:
+        watches = [w for w in watches if w.get("owner") == owner]
+    return watches
+
+
+def owns_watch(watch: dict | None, owner: str | None) -> bool:
+    """True when `owner` may act on `watch`.
+
+    Single-tenant (auth disabled, owner None) sees everything. Otherwise the
+    fingerprints must match; a watch created before ownership existed has no
+    owner and is treated as admin-only, i.e. not visible to an ordinary key.
+    """
+    if watch is None:
+        return False
+    if owner is None:
+        return True
+    return watch.get("owner") == owner
 
 
 def due_watches(now_iso: str) -> list[dict]:
@@ -255,45 +338,55 @@ def delete_watch(watch_id: str) -> None:
 # review" needs to survive indefinitely and be regenerated in place.
 # ---------------------------------------------------------------------------
 def save_report(report_id: str, watch_id: str, topic: str, language: str,
-                markdown: str, citation_count: int, created_at: str) -> None:
+                markdown: str, citation_count: int, created_at: str,
+                owner: str | None = None) -> None:
     """Insert or update a report. Re-saving the same report_id overwrites in place
     (that's how a watch-owned living review gets regenerated)."""
     with _db_lock:
         _conn.execute(
-            "INSERT INTO reports (id, watch_id, topic, language, markdown, citation_count, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?) "
+            "INSERT INTO reports (id, watch_id, topic, language, markdown, citation_count, created_at, owner) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(id) DO UPDATE SET topic=excluded.topic, language=excluded.language, "
             "markdown=excluded.markdown, citation_count=excluded.citation_count, "
             "created_at=excluded.created_at",
-            (report_id, watch_id, topic, language, markdown, citation_count, created_at),
+            (report_id, watch_id, topic, language, markdown, citation_count, created_at, owner),
         )
         _conn.commit()
 
 
-def get_report(report_id: str) -> dict | None:
+def get_report(report_id: str, owner: str | None = None) -> dict | None:
+    """One report, or None. When `owner` is set, a report belonging to another key
+    reads as missing — a 404 rather than a 403, so the response can't be used to
+    probe which report ids exist."""
     with _db_lock:
         row = _conn.execute(
-            "SELECT id, watch_id, topic, language, markdown, citation_count, created_at "
+            "SELECT id, watch_id, topic, language, markdown, citation_count, created_at, owner "
             "FROM reports WHERE id = ?", (report_id,),
         ).fetchone()
     if not row:
+        return None
+    if owner is not None and row[7] != owner:
         return None
     return {"id": row[0], "watch_id": row[1], "topic": row[2], "language": row[3],
             "markdown": row[4], "citation_count": row[5], "created_at": row[6]}
 
 
-def list_reports(watch_id: str | None = None) -> list[dict]:
-    """Summary rows (no markdown body) — newest first, or scoped to one watch."""
+def list_reports(watch_id: str | None = None, owner: str | None = None) -> list[dict]:
+    """Summary rows (no markdown body) — newest first, optionally scoped to one
+    watch and/or one owner."""
+    clauses, args = [], []
+    if watch_id:
+        clauses.append("watch_id = ?")
+        args.append(watch_id)
+    if owner is not None:
+        clauses.append("owner = ?")
+        args.append(owner)
+    where = f"WHERE {' AND '.join(clauses)} " if clauses else ""
     with _db_lock:
-        if watch_id:
-            rows = _conn.execute(
-                "SELECT id, watch_id, topic, language, citation_count, created_at "
-                "FROM reports WHERE watch_id = ? ORDER BY created_at DESC", (watch_id,),
-            ).fetchall()
-        else:
-            rows = _conn.execute(
-                "SELECT id, watch_id, topic, language, citation_count, created_at "
-                "FROM reports ORDER BY created_at DESC",
-            ).fetchall()
+        rows = _conn.execute(
+            "SELECT id, watch_id, topic, language, citation_count, created_at "
+            f"FROM reports {where}ORDER BY created_at DESC",
+            tuple(args),
+        ).fetchall()
     return [{"id": r[0], "watch_id": r[1], "topic": r[2], "language": r[3],
              "citation_count": r[4], "created_at": r[5]} for r in rows]

--- a/persistence.py
+++ b/persistence.py
@@ -326,6 +326,28 @@ def due_watches(now_iso: str) -> list[dict]:
     return [json.loads(r[0]) for r in rows]
 
 
+def claim_watch(watch_id: str, expected_next_run: str, lease_until: str) -> bool:
+    """Atomically claim a due watch. True if this caller won the claim.
+
+    The scheduler runs in-process, so two workers (or two replicas) both see the
+    same watch as due and both run it — duplicate arXiv fetches, duplicate
+    ingests, duplicate LLM spend on the digest. This is a compare-and-set on the
+    row: the UPDATE only matches while next_run is still what the claimer read,
+    so exactly one caller can move it and the losers see rowcount 0.
+
+    `lease_until` parks next_run far enough ahead that a claimer which crashes
+    mid-run doesn't wedge the watch forever — the lease simply expires and the
+    watch becomes due again. run_watch rewrites next_run properly on success.
+    """
+    with _db_lock:
+        cur = _conn.execute(
+            "UPDATE watches SET next_run = ? WHERE id = ? AND next_run = ?",
+            (lease_until, watch_id, expected_next_run),
+        )
+        _conn.commit()
+        return cur.rowcount == 1
+
+
 def delete_watch(watch_id: str) -> None:
     with _db_lock:
         _conn.execute("DELETE FROM watches WHERE id = ?", (watch_id,))

--- a/persistence.py
+++ b/persistence.py
@@ -486,9 +486,14 @@ def claim_watch(watch_id: str, expected_next_run: str, lease_until: str) -> bool
     watch becomes due again. run_watch rewrites next_run properly on success.
     """
     with _db_lock:
+        # The JSON copy moves with the column. due_watches reads the row but
+        # claim_watch compares the column, so leaving data.next_run behind after a
+        # failed run means every later claim compares the stale value against the
+        # lease and fails — the watch never runs again.
         cur = _conn.execute(
-            "UPDATE watches SET next_run = ? WHERE id = ? AND next_run = ?",
-            (lease_until, watch_id, expected_next_run),
+            "UPDATE watches SET next_run = ?, data = json_set(data, '$.next_run', ?) "
+            "WHERE id = ? AND next_run = ?",
+            (lease_until, lease_until, watch_id, expected_next_run),
         )
         _conn.commit()
         return cur.rowcount == 1
@@ -516,7 +521,7 @@ def save_report(report_id: str, watch_id: str, topic: str, language: str,
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(id) DO UPDATE SET topic=excluded.topic, language=excluded.language, "
             "markdown=excluded.markdown, citation_count=excluded.citation_count, "
-            "created_at=excluded.created_at",
+            "created_at=excluded.created_at, owner=excluded.owner",
             (report_id, watch_id, topic, language, markdown, citation_count, created_at, owner),
         )
         _conn.commit()

--- a/persistence.py
+++ b/persistence.py
@@ -68,6 +68,10 @@ _ensure_column("feedback", "owner", "TEXT")
 _ensure_column("reports", "owner", "TEXT")
 _ensure_column("query_log", "owner", "TEXT")
 
+# Job leases. An in-flight job is owned by whichever process is heartbeating it;
+# when that process dies the lease simply expires and the row can be reaped.
+_ensure_column("jobs", "lease_until", "TEXT")
+
 # Secondary indexes. Every table above declared a PRIMARY KEY and nothing else, so
 # each of these access paths was a full scan: due_watches runs on every scheduler
 # tick, the feedback join runs on every read, and the startup prunes delete by
@@ -135,15 +139,60 @@ def delete_job(job_id: str) -> None:
         _conn.commit()
 
 
-def save_job(job_id: str, job: dict) -> None:
+def save_job(job_id: str, job: dict, lease_until: str = None) -> None:
+    """Persist a job. `lease_until` renews the caller's claim on an in-flight job.
+
+    Every update to a running job is also a heartbeat: it pushes the lease
+    forward, which is how a still-alive worker distinguishes itself from a dead
+    one. See reap_stale_jobs.
+    """
     with _db_lock:
         _conn.execute(
-            "INSERT INTO jobs (id, data, status, submitted_at, completed_at) VALUES (?, ?, ?, ?, ?) "
+            "INSERT INTO jobs (id, data, status, submitted_at, completed_at, lease_until) "
+            "VALUES (?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(id) DO UPDATE SET data=excluded.data, status=excluded.status, "
-            "completed_at=excluded.completed_at",
-            (job_id, json.dumps(job), job.get("status"), job.get("submitted_at"), job.get("completed_at")),
+            "completed_at=excluded.completed_at, lease_until=excluded.lease_until",
+            (job_id, json.dumps(job), job.get("status"), job.get("submitted_at"),
+             job.get("completed_at"), lease_until),
         )
         _conn.commit()
+
+
+def reap_stale_jobs(now_iso: str) -> list[dict]:
+    """Fail jobs left in-flight by a process that died. Returns what was reaped.
+
+    Ingest and report jobs run inside the API process, so a restart, crash or
+    OOM mid-job left the row saying `running` forever — nothing ever moved it,
+    and a client polling /ingest/status or /report/status waited on a job that
+    no longer existed anywhere.
+
+    Reaping is by expired lease rather than by "not mine": a live worker renews
+    its lease on every progress update, so an expired lease is real evidence the
+    owner is gone. A job with no lease at all predates this and is also reaped —
+    it cannot be running, because running jobs heartbeat.
+    """
+    with _db_lock:
+        rows = _conn.execute(
+            "SELECT id, data FROM jobs WHERE status IN ('pending', 'running') "
+            "AND (lease_until IS NULL OR lease_until < ?)",
+            (now_iso,),
+        ).fetchall()
+        reaped = []
+        for jid, data in rows:
+            job = json.loads(data)
+            job["status"] = "failed"
+            job["error"] = ("Abandoned: the process running this job exited before it "
+                            "finished. Resubmit to try again.")
+            job["completed_at"] = now_iso
+            _conn.execute(
+                "UPDATE jobs SET data = ?, status = 'failed', completed_at = ?, "
+                "lease_until = NULL WHERE id = ?",
+                (json.dumps(job), now_iso, jid),
+            )
+            reaped.append(job)
+        if reaped:
+            _conn.commit()
+    return reaped
 
 
 def save_feedback(feedback_id: str, query_id: str, rating: str, comment: str, created_at: str,

--- a/providers/gemini.py
+++ b/providers/gemini.py
@@ -138,6 +138,81 @@ class GeminiBackend(LLMBackend):
         tc = getattr(gen_config, "thinking_config", None)
         return tc is not None and getattr(tc, "thinking_budget", None) is not None
 
+    # Not every model supports every level. gemini-3.7-flash rejects MINIMAL
+    # outright ("Thinking level MINIMAL is not supported for this model"), while
+    # 3.6-flash accepts it — so the configured default cannot be assumed valid for
+    # whatever model is selected. Learned per (model, level), exactly like the
+    # budget rejections above, so a new model generation needs no hardcoded list.
+    _LEVEL_LADDER = ("MINIMAL", "LOW", "MEDIUM", "HIGH")
+    _level_rejected: set = set()
+    _level_lock = threading.Lock()
+
+    @staticmethod
+    def _current_level_name(gen_config):
+        """Name of the thinking_level on this config, or None."""
+        tc = getattr(gen_config, "thinking_config", None)
+        level = getattr(tc, "thinking_level", None) if tc is not None else None
+        if level is None:
+            return None
+        return getattr(level, "name", str(level)).upper()
+
+    def _escalate_level(self, gen_config):
+        """Same config at the next level UP the ladder, or thinking dropped.
+
+        Upwards, never downwards: a rejected level means the model will not think
+        that little, so the only direction that can succeed is more thinking.
+        Running off the end drops thinking_config entirely, which means "model
+        decides" — worse than asking, but better than failing the request.
+        """
+        current = self._current_level_name(gen_config)
+        if current is None:
+            return None
+        try:
+            nxt = self._LEVEL_LADDER[self._LEVEL_LADDER.index(current) + 1]
+        except (ValueError, IndexError):
+            return gen_config.model_copy(update={"thinking_config": None})
+        level = self._thinking_level(nxt)
+        if level is None:
+            return gen_config.model_copy(update={"thinking_config": None})
+        return gen_config.model_copy(update={
+            "thinking_config": genai_types.ThinkingConfig(thinking_level=level),
+        })
+
+    def _skip_rejected_levels(self, model: str, gen_config):
+        """Advance past levels this model already refused, before calling out."""
+        for _ in self._LEVEL_LADDER:
+            name = self._current_level_name(gen_config)
+            if name is None:
+                return gen_config
+            with self._level_lock:
+                if (model, name) not in self._level_rejected:
+                    return gen_config
+            nxt = self._escalate_level(gen_config)
+            if nxt is None:
+                return gen_config
+            gen_config = nxt
+        return gen_config
+
+    def _remember_level_rejection(self, model: str, gen_config, exc: Exception) -> bool:
+        """True if `exc` is this model refusing the requested thinking_level, so
+        the caller can retry one level up. Narrow on purpose, and matched on the
+        message: any other 400 is a genuine bad request that must keep
+        propagating rather than being retried with different thinking."""
+        name = self._current_level_name(gen_config)
+        if not name or not self._is_invalid_argument(exc):
+            return False
+        if "thinking level" not in str(exc).lower():
+            return False
+        with self._level_lock:
+            first_time = (model, name) not in self._level_rejected
+            self._level_rejected.add((model, name))
+        if first_time:
+            logger.warning(
+                "Model %s does not support thinking level %s; using the next level up "
+                "for this model from now on.", model, name,
+            )
+        return True
+
     @staticmethod
     def _is_invalid_argument(exc: Exception) -> bool:
         status = getattr(exc, "status_code", None) or getattr(exc, "code", None)
@@ -187,7 +262,9 @@ class GeminiBackend(LLMBackend):
             known_rejected = model in self._zero_budget_rejected
         if known_rejected and self._has_thinking_budget(call_config):
             call_config = self._translate_thinking(call_config)
-        return call_config
+        # A level this model already refused would 400 again; step past it here so
+        # only the FIRST call per (model, level) pays a round-trip to learn it.
+        return self._skip_rejected_levels(model, call_config)
 
     def _remember_zero_budget_rejection(self, model: str, gen_config, exc: Exception) -> bool:
         """True if `exc` is this model refusing a legacy thinking_budget, so the
@@ -214,11 +291,18 @@ class GeminiBackend(LLMBackend):
         try:
             return client.models.generate_content(model=model, contents=contents, config=call_config)
         except Exception as exc:
-            if not self._remember_zero_budget_rejection(model, call_config, exc):
+            # Two distinct refusals, each retried once: a legacy budget this model
+            # no longer accepts, and a level it does not offer.
+            if self._remember_zero_budget_rejection(model, call_config, exc):
+                retry_config = self._translate_thinking(call_config)
+            elif self._remember_level_rejection(model, call_config, exc):
+                retry_config = self._escalate_level(call_config)
+            else:
+                raise
+            if retry_config is None:
                 raise
             return client.models.generate_content(
-                model=model, contents=contents,
-                config=self._translate_thinking(call_config),
+                model=model, contents=contents, config=retry_config,
             )
 
     def generate_stream(self, model: str, contents, gen_config, client=None) -> Iterator[str]:
@@ -252,9 +336,19 @@ class GeminiBackend(LLMBackend):
             # A zero-budget rejection is refused before any token is produced, so
             # retrying the stream here is safe. Once text has been emitted the
             # error is something else and must propagate.
-            if emitted or not self._remember_zero_budget_rejection(model, call_config, exc):
+            # `emitted` guard: once bytes are out, a retry would duplicate the
+            # answer's opening. Same two refusal kinds as the unary path.
+            if emitted:
                 raise
-            yield from _iter(self._translate_thinking(call_config))
+            if self._remember_zero_budget_rejection(model, call_config, exc):
+                retry_config = self._translate_thinking(call_config)
+            elif self._remember_level_rejection(model, call_config, exc):
+                retry_config = self._escalate_level(call_config)
+            else:
+                raise
+            if retry_config is None:
+                raise
+            yield from _iter(retry_config)
 
         if not emitted:
             raise RuntimeError("No text generated from Gemini stream")

--- a/providers/gemini.py
+++ b/providers/gemini.py
@@ -284,26 +284,36 @@ class GeminiBackend(LLMBackend):
             )
         return True
 
+    def _next_config(self, model: str, call_config, exc: Exception):
+        """Config to retry `exc` with, or None when the failure is not ours.
+
+        Two distinct refusals: a legacy budget this model no longer accepts, and
+        a level it does not offer. They chain — a budget rejection translates to
+        MINIMAL, which the same model may also refuse — so each failure is
+        reclassified rather than retried once and given up on.
+        """
+        if self._remember_zero_budget_rejection(model, call_config, exc):
+            return self._translate_thinking(call_config)
+        if self._remember_level_rejection(model, call_config, exc):
+            return self._escalate_level(call_config)
+        return None
+
     # ── single-client calls (dispatch/failover lives in llm_client) ─────
     def generate(self, model: str, contents, gen_config, client=None):
         client = client or self.pool[self.next_client_idx()]
         call_config = self._prep_config(client, model, gen_config)
-        try:
-            return client.models.generate_content(model=model, contents=contents, config=call_config)
-        except Exception as exc:
-            # Two distinct refusals, each retried once: a legacy budget this model
-            # no longer accepts, and a level it does not offer.
-            if self._remember_zero_budget_rejection(model, call_config, exc):
-                retry_config = self._translate_thinking(call_config)
-            elif self._remember_level_rejection(model, call_config, exc):
-                retry_config = self._escalate_level(call_config)
-            else:
-                raise
-            if retry_config is None:
-                raise
-            return client.models.generate_content(
-                model=model, contents=contents, config=retry_config,
-            )
+        # Bounded: each retry climbs the ladder, and past the top thinking is
+        # dropped, after which no rejection classifies and the error propagates.
+        for _ in range(len(self._LEVEL_LADDER) + 2):
+            try:
+                return client.models.generate_content(
+                    model=model, contents=contents, config=call_config)
+            except Exception as exc:
+                retry_config = self._next_config(model, call_config, exc)
+                if retry_config is None:
+                    raise
+                call_config = retry_config
+        raise RuntimeError("Gemini thinking-config retries did not converge")
 
     def generate_stream(self, model: str, contents, gen_config, client=None) -> Iterator[str]:
         client = client or self.stream_pool[self.next_client_idx()]
@@ -330,25 +340,23 @@ class GeminiBackend(LLMBackend):
                 logger.warning("Gemini stream hit max_output_tokens for %s — answer truncated", model)
                 yield TRUNCATION_NOTE
 
-        try:
-            yield from _iter(call_config)
-        except Exception as exc:
-            # A zero-budget rejection is refused before any token is produced, so
-            # retrying the stream here is safe. Once text has been emitted the
-            # error is something else and must propagate.
-            # `emitted` guard: once bytes are out, a retry would duplicate the
-            # answer's opening. Same two refusal kinds as the unary path.
-            if emitted:
-                raise
-            if self._remember_zero_budget_rejection(model, call_config, exc):
-                retry_config = self._translate_thinking(call_config)
-            elif self._remember_level_rejection(model, call_config, exc):
-                retry_config = self._escalate_level(call_config)
-            else:
-                raise
-            if retry_config is None:
-                raise
-            yield from _iter(retry_config)
+        for _ in range(len(self._LEVEL_LADDER) + 2):
+            try:
+                yield from _iter(call_config)
+                break
+            except Exception as exc:
+                # A thinking-config rejection is refused before any token is
+                # produced, so retrying the stream here is safe.
+                # `emitted` guard: once bytes are out, a retry would duplicate the
+                # answer's opening, and the error is something else anyway.
+                if emitted:
+                    raise
+                retry_config = self._next_config(model, call_config, exc)
+                if retry_config is None:
+                    raise
+                call_config = retry_config
+        else:
+            raise RuntimeError("Gemini thinking-config retries did not converge")
 
         if not emitted:
             raise RuntimeError("No text generated from Gemini stream")

--- a/rag.py
+++ b/rag.py
@@ -355,7 +355,19 @@ def retrieve_context(
 
     # Embed the query — HyDE embeds a drafted hypothetical answer instead of
     # the bare question; lexical (BM25) search below always uses the real query.
-    query_embedding = _hyde_embedding(user_query) if use_hyde else embeddings.embed_query(user_query)
+    #
+    # A failure here (model OOM, corrupt weights, driver fault) used to fail the
+    # whole request, including queries the in-process BM25 index could have
+    # answered on its own. Degrade to sparse-only instead; the result carries a
+    # `degraded` marker (logged now, surfaced in the API response as follow-up work).
+    try:
+        query_embedding = _hyde_embedding(user_query) if use_hyde else embeddings.embed_query(user_query)
+    except Exception as e:
+        logger.error(f"Embedding failed, trying sparse-only retrieval: {e}", exc_info=True)
+        sparse = _sparse_only_retrieval(user_query, top_k, collection, chroma_filter_dict, tags_post_filter)
+        if sparse is None:
+            raise  # no BM25 index either — nothing to degrade to
+        return sparse
 
     # A tags post-filter runs AFTER retrieval, so fetching exactly top_k returns
     # nothing whenever the tagged papers rank below the cut (measured: 1 tagged
@@ -503,6 +515,69 @@ def format_context(chunks: List[str], metadatas: List[Dict],
         chunks_used += 1
 
     return "\n".join(context_parts), chunks_used
+
+
+def _sparse_only_retrieval(user_query: str, top_k: int, collection,
+                           filter_dict: Dict[str, Any] = None,
+                           tags_post_filter: list = None) -> Dict[str, Any] | None:
+    """BM25-only retrieval, used when the dense leg is unavailable.
+
+    Returns None when there is nothing to degrade to (hybrid search disabled, or
+    no BM25 index because the corpus is empty) so the caller can re-raise the
+    original failure rather than serve a silently empty answer.
+
+    The result carries `degraded='sparse_only'` and logs at WARNING. Note that no
+    route reads that key yet — surfacing it in the API response is still to do, so
+    for now degradation is visible in the logs but not to the end user.
+    """
+    if not config.USE_HYBRID_SEARCH:
+        return None
+    try:
+        import bm25_search
+        idx = bm25_search.get_or_build_index(collection)
+        if idx is None:
+            return None
+        ids, _scores = idx.search(user_query, top_k=top_k)
+        if not ids:
+            return None
+        got = vector_store._chroma_call(
+            collection.get, ids=ids, include=['documents', 'metadatas'])
+    except Exception as e:
+        logger.error(f"Sparse-only fallback failed too: {e}", exc_info=True)
+        return None
+
+    # collection.get() does not preserve the order of the ids it was handed, and
+    # BM25 rank is the only ranking signal left here — restore it explicitly.
+    by_id = dict(zip(got.get('ids', []), zip(got.get('documents', []), got.get('metadatas', []))))
+    ordered = [(i, *by_id[i]) for i in ids if i in by_id]
+    if not ordered:
+        return None
+
+    results = {
+        'ids': [r[0] for r in ordered],
+        'chunks': [r[1] for r in ordered],
+        'documents': [r[1] for r in ordered],
+        'metadatas': [r[2] for r in ordered],
+        'distances': [1.0] * len(ordered),
+    }
+    if tags_post_filter:
+        results = _apply_tags_post_filter(results, tags_post_filter)
+        for key in _TAGS_POST_FILTER_KEYS:
+            if key in results:
+                results[key] = results[key][:top_k]
+
+    formatted_context, chunks_used = format_context(
+        chunks=results['chunks'], metadatas=results['metadatas'])
+    logger.warning("Serving DEGRADED sparse-only retrieval: %d chunks (dense leg unavailable)",
+                   chunks_used)
+    return {
+        'chunks': results['chunks'],
+        'metadatas': results['metadatas'],
+        'distances': results['distances'],
+        'formatted_context': formatted_context,
+        'chunks_used': chunks_used,
+        'degraded': 'sparse_only',
+    }
 
 
 def _retrieve_scoped(filter_dict: Dict[str, Any], collection) -> Dict[str, Any]:

--- a/rag.py
+++ b/rag.py
@@ -532,9 +532,9 @@ def _sparse_only_retrieval(user_query: str, top_k: int, collection,
     no BM25 index because the corpus is empty) so the caller can re-raise the
     original failure rather than serve a silently empty answer.
 
-    The result carries `degraded='sparse_only'` and logs at WARNING. Note that no
-    route reads that key yet — surfacing it in the API response is still to do, so
-    for now degradation is visible in the logs but not to the end user.
+    The result carries `degraded='sparse_only'` and logs at WARNING; /query and
+    /chat pass it through to the response and the SSE done event, so a degraded
+    answer is never mistaken for a normal one.
     """
     if not config.USE_HYBRID_SEARCH:
         return None
@@ -543,11 +543,20 @@ def _sparse_only_retrieval(user_query: str, top_k: int, collection,
         idx = bm25_search.get_or_build_index(collection)
         if idx is None:
             return None
-        ids, _scores = idx.search(user_query, top_k=top_k)
+        # Tags are post-filtered, so ask BM25 for the same widened set the dense
+        # path uses; taking exactly top_k here would leave too few after filtering.
+        search_k = top_k
+        if tags_post_filter:
+            search_k = min(top_k * config.TAGS_OVERFETCH, config.TAGS_OVERFETCH_MAX)
+        ids, _scores = idx.search(user_query, top_k=search_k)
         if not ids:
             return None
+        # BM25 knows nothing about metadata filters — a paper-scoped or
+        # tag-filtered query must not quietly widen just because the dense leg
+        # is down, so the filter is applied on the fetch.
         got = vector_store._chroma_call(
-            collection.get, ids=ids, include=['documents', 'metadatas'])
+            collection.get, ids=ids, where=filter_dict or None,
+            include=['documents', 'metadatas'])
     except Exception as e:
         logger.error(f"Sparse-only fallback failed too: {e}", exc_info=True)
         return None
@@ -1005,6 +1014,12 @@ def answer_question_strategy_a(
         'language_name': lang_name,
         'chunks_used': context_data['chunks_used'],
         'citations': citations,
+        # The exact context this answer was written from. Callers that need to
+        # resolve a citation marker back to a chunk (the eval harness) must use
+        # this and not a second retrieve_context call — strategy B retrieves on
+        # the TRANSLATED query, so a re-run does not reproduce it.
+        'context': {'metadatas': context_data.get('metadatas', []),
+                    'chunks': context_data.get('chunks', [])},
         # None on the normal path; 'sparse_only' when the dense leg was
         # unavailable and this answer came from BM25 alone.
         'degraded': context_data.get('degraded'),
@@ -1109,6 +1124,8 @@ def answer_question_strategy_b(
         'chunks_used': context_data['chunks_used'],
         'citations': citations,
         'english_answer': english_answer,
+        'context': {'metadatas': context_data.get('metadatas', []),
+                    'chunks': context_data.get('chunks', [])},
         'degraded': context_data.get('degraded'),
     }
     faith_result = _run_faithfulness(

--- a/rag.py
+++ b/rag.py
@@ -808,7 +808,8 @@ def prepare_query_for_stream(user_query: str, strategy: str = "A", top_k: int = 
     prompt = build_prompt(user_query=prompt_query, context=context_data["formatted_context"],
                           target_lang=detected_lang, strategy=strategy)
     return {"chunks_used": context_data["chunks_used"], "prompt": prompt,
-            "metadatas": context_data["metadatas"], "detected_lang": detected_lang, "lang_name": lang_name}
+            "metadatas": context_data["metadatas"], "detected_lang": detected_lang,
+            "lang_name": lang_name, "degraded": context_data.get("degraded")}
 
 
 def prepare_chat_for_stream(messages: List[Dict[str, str]], strategy: str = "A", top_k: int = None,
@@ -870,7 +871,8 @@ def prepare_chat_for_stream(messages: List[Dict[str, str]], strategy: str = "A",
         prompt = f"## Conversation History\n{history_str}\n\n---\n\n{prompt}"
 
     return {"chunks_used": context_data["chunks_used"], "prompt": prompt,
-            "metadatas": context_data["metadatas"], "detected_lang": detected_lang, "lang_name": lang_name}
+            "metadatas": context_data["metadatas"], "detected_lang": detected_lang,
+            "lang_name": lang_name, "degraded": context_data.get("degraded")}
 
 
 generate_with_failover = llm_client.generate_with_failover
@@ -995,7 +997,10 @@ def answer_question_strategy_a(
         'language': detected_lang,
         'language_name': lang_name,
         'chunks_used': context_data['chunks_used'],
-        'citations': citations
+        'citations': citations,
+        # None on the normal path; 'sparse_only' when the dense leg was
+        # unavailable and this answer came from BM25 alone.
+        'degraded': context_data.get('degraded'),
     }
     faith_result = _run_faithfulness(
         answer, context_data.get('chunks', []), context_data.get('metadatas', []))
@@ -1096,7 +1101,8 @@ def answer_question_strategy_b(
         'language_name': lang_name,
         'chunks_used': context_data['chunks_used'],
         'citations': citations,
-        'english_answer': english_answer
+        'english_answer': english_answer,
+        'degraded': context_data.get('degraded'),
     }
     faith_result = _run_faithfulness(
         english_answer, context_data.get('chunks', []), context_data.get('metadatas', []))
@@ -1246,6 +1252,7 @@ def answer_with_history(
         "language_name": lang_name,
         "chunks_used": context_data["chunks_used"],
         "citations": citations,
+        "degraded": context_data.get("degraded"),
     }
     if strategy == "B" and answer != english_answer:
         result["english_answer"] = english_answer

--- a/rag.py
+++ b/rag.py
@@ -11,6 +11,7 @@ import vector_store
 import lang_utils
 import translation
 import llm_client
+import metrics
 from google.genai import types
 
 logger = logging.getLogger(__name__)
@@ -378,20 +379,23 @@ def retrieve_context(
         search_k = min(top_k * config.TAGS_OVERFETCH, config.TAGS_OVERFETCH_MAX)
 
     # Search vector store (dense)
-    results = vector_store.search(
-        query_embedding=query_embedding,
-        top_k=search_k,
-        filter_dict=chroma_filter_dict,
-        collection=collection
-    )
+    with metrics.stage("retrieval_dense"):
+        results = vector_store.search(
+            query_embedding=query_embedding,
+            top_k=search_k,
+            filter_dict=chroma_filter_dict,
+            collection=collection
+        )
 
     # Hybrid: fuse dense results with BM25 lexical search
     if config.USE_HYBRID_SEARCH and results['documents'] and not chroma_filter_dict:
         try:
             import bm25_search
-            bm25_idx = bm25_search.get_or_build_index(collection)
+            with metrics.stage("bm25_index_load"):
+                bm25_idx = bm25_search.get_or_build_index(collection)
             if bm25_idx is not None:
-                sparse_ids, _ = bm25_idx.search(user_query, top_k=search_k)
+                with metrics.stage("retrieval_bm25"):
+                    sparse_ids, _ = bm25_idx.search(user_query, top_k=search_k)
                 fused_ids = bm25_search.rrf(results['ids'], sparse_ids, k=config.RRF_K)
                 id_to_doc = dict(zip(results['ids'], results['documents']))
                 id_to_meta = dict(zip(results['ids'], results['metadatas']))
@@ -439,14 +443,16 @@ def retrieve_context(
         import colbert_rerank
         dense_sims = [1.0 - d for d in dists]  # cosine distance -> similarity
         colbert_top_k = min(len(docs), config.MAX_CONTEXT_CHUNKS * 3)
-        docs, metas, dists = colbert_rerank.rerank(
-            user_query, docs, metas, dense_sims,
-            top_k=colbert_top_k, weight=config.COLBERT_WEIGHT)
+        with metrics.stage("rerank_colbert"):
+            docs, metas, dists = colbert_rerank.rerank(
+                user_query, docs, metas, dense_sims,
+                top_k=colbert_top_k, weight=config.COLBERT_WEIGHT)
 
     if config.USE_RERANKER and docs:
         import rerank
-        docs, metas, scores = rerank.rerank(
-            user_query, docs, metas, top_k=config.MAX_CONTEXT_CHUNKS)
+        with metrics.stage("rerank_cross_encoder"):
+            docs, metas, scores = rerank.rerank(
+                user_query, docs, metas, top_k=config.MAX_CONTEXT_CHUNKS)
         dists = scores
 
     # Format context for LLM
@@ -905,7 +911,8 @@ def _run_faithfulness(answer: str, chunks: List[str], metadatas: List[Dict] = No
     """
     try:
         import verify
-        results = verify.check_claims(answer, chunks, metadatas)
+        with metrics.stage("nli_verify"):
+            results = verify.check_claims(answer, chunks, metadatas)
         for r in results:
             if not r["grounded"]:
                 logger.warning(f"Ungrounded claim (score={r['support']:.2f}): {r['claim'][:120]}")

--- a/reindex.py
+++ b/reindex.py
@@ -20,7 +20,7 @@ Usage
 -----
     python reindex.py --check          # report drift, change nothing
     python reindex.py --dry-run        # show what a rebuild would do
-    python reindex.py                  # rebuild into the live collection
+    python reindex.py --yes            # rebuild into the live collection (destructive)
     python reindex.py --into staging   # rebuild into a different collection first
 """
 
@@ -116,7 +116,8 @@ def _drift_report(events: list) -> list:
     return problems
 
 
-def reindex(collection_name: str, dry_run: bool, batch_size: int) -> int:
+def reindex(collection_name: str, dry_run: bool, batch_size: int,
+            confirm: bool = False) -> int:
     import bm25_search
     import embeddings
     import persistence
@@ -142,6 +143,14 @@ def reindex(collection_name: str, dry_run: bool, batch_size: int) -> int:
                         e["paper_id"], len(e["chunks"]), e["embed_model"] or "unknown model")
         logger.info("Dry run — nothing written.")
         return 0
+
+    # reset=True wipes whatever is there, and the default target is the live
+    # collection — so destroying production must be typed out, not defaulted into.
+    if collection_name == config.COLLECTION_NAME and not confirm:
+        logger.error("Refusing to reset the LIVE collection '%s' without --yes. "
+                     "Build into a staging collection with --into NAME, or pass "
+                     "--yes if you really mean to replace it.", collection_name)
+        return 2
 
     # Rebuild into a fresh collection. reset=True because a replay must produce
     # exactly the logged contents: merging into an existing collection would keep
@@ -182,6 +191,8 @@ def main() -> int:
     ap.add_argument("--check", action="store_true",
                     help="report drift between the log and the current config, then exit")
     ap.add_argument("--batch-size", type=int, default=64)
+    ap.add_argument("--yes", action="store_true",
+                    help="confirm resetting the live collection")
     ap.add_argument("--backfill-log", action="store_true",
                     help="rebuild the ingest log from chunks already in the collection")
     args = ap.parse_args()
@@ -191,9 +202,8 @@ def main() -> int:
     if args.backfill_log:
         return 0 if backfill_log_from_collection(args.into or config.COLLECTION_NAME) else 2
 
-    events = persistence.get_ingest_events()
-
     if args.check:
+        events = persistence.get_ingest_events()
         if not events:
             logger.warning("Ingest log is empty — nothing recorded yet.")
             return 1
@@ -206,7 +216,8 @@ def main() -> int:
             logger.info("No drift: the log agrees with the current configuration.")
         return 1 if problems else 0
 
-    return reindex(args.into or config.COLLECTION_NAME, args.dry_run, args.batch_size)
+    return reindex(args.into or config.COLLECTION_NAME, args.dry_run, args.batch_size,
+                   confirm=args.yes)
 
 
 if __name__ == "__main__":

--- a/reindex.py
+++ b/reindex.py
@@ -33,6 +33,56 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger("reindex")
 
 
+def backfill_log_from_collection(collection_name: str) -> int:
+    """Reconstruct ingest-log rows from chunks already in the collection.
+
+    For corpora indexed before the log existed, or indexed by a run that wrote the
+    chunks but died before recording them — which is exactly what a bulk upsert
+    timing out after a successful write produced. Everything the log stores
+    (chunk text, metadata, ids, provenance) is already on the chunks themselves,
+    so this recovers replayability without re-embedding.
+
+    Not a substitute for logging at ingest time: content_hash and source_path are
+    not recoverable from the collection and are left empty.
+    """
+    from datetime import datetime, timezone
+    import persistence
+    import vector_store
+
+    collection = vector_store.get_or_create_collection(collection_name)
+    got = vector_store._chroma_call(collection.get, include=["documents", "metadatas"],
+                                    timeout=config.CHROMA_WRITE_TIMEOUT_S)
+    ids, docs, metas = got.get("ids", []), got.get("documents", []), got.get("metadatas", [])
+    if not ids:
+        logger.error("Collection '%s' is empty — nothing to backfill.", collection_name)
+        return 0
+
+    papers = {}
+    for cid, doc, meta in zip(ids, docs, metas):
+        pid = (meta or {}).get("paper_id")
+        if not pid:
+            continue
+        papers.setdefault(pid, {"ids": [], "chunks": [], "metadatas": []})
+        papers[pid]["ids"].append(cid)
+        papers[pid]["chunks"].append(doc)
+        papers[pid]["metadatas"].append(meta)
+
+    now = datetime.now(timezone.utc).isoformat()
+    for pid, p in papers.items():
+        first = p["metadatas"][0]
+        persistence.record_ingest(
+            event_id=pid, paper_id=pid, content_hash="", title=first.get("title", ""),
+            source_path="", chunks=p["chunks"], metadatas=p["metadatas"], ids=p["ids"],
+            embed_model=first.get("embed_model") or "",
+            chunker_version=first.get("chunker_version") or 0,
+            created_at=now, embed_backend=first.get("embed_backend"),
+        )
+        logger.info("  backfilled %-28s %4d chunks", pid, len(p["chunks"]))
+    logger.info("Backfilled %d papers / %d chunks into the ingest log.",
+                len(papers), sum(len(p["chunks"]) for p in papers.values()))
+    return len(papers)
+
+
 def _drift_report(events: list) -> list:
     """Differences between what the log recorded and what is configured now."""
     problems = []
@@ -132,9 +182,15 @@ def main() -> int:
     ap.add_argument("--check", action="store_true",
                     help="report drift between the log and the current config, then exit")
     ap.add_argument("--batch-size", type=int, default=64)
+    ap.add_argument("--backfill-log", action="store_true",
+                    help="rebuild the ingest log from chunks already in the collection")
     args = ap.parse_args()
 
     import persistence
+
+    if args.backfill_log:
+        return 0 if backfill_log_from_collection(args.into or config.COLLECTION_NAME) else 2
+
     events = persistence.get_ingest_events()
 
     if args.check:

--- a/reindex.py
+++ b/reindex.py
@@ -49,6 +49,15 @@ def _drift_report(events: list) -> list:
         problems.append(f"corpus was chunked by MIXED chunker versions: {sorted(chunkers)}")
 
     import vector_store
+    backends = {e.get("embed_backend") for e in events if e.get("embed_backend")}
+    if len(backends) > 1:
+        problems.append(f"corpus was embedded by MIXED backends: {sorted(backends)} — "
+                        "int8 and fp32 output for the same model are not comparable")
+    current_backend = vector_store._embed_backend()
+    if backends and current_backend not in ("unloaded", "unknown") and current_backend not in backends:
+        problems.append(f"configured embedding backend {current_backend!r} differs from the "
+                        f"indexed one(s) {sorted(backends)} — a replay will re-embed")
+
     if chunkers and vector_store.CHUNKER_VERSION not in chunkers:
         problems.append(
             f"configured chunker version {vector_store.CHUNKER_VERSION} differs from the "

--- a/reindex.py
+++ b/reindex.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Rebuild the search indexes by replaying the ingest log.
+
+The vector store, the BM25 index and the figure store are derived views. The
+ingest log (see persistence.record_ingest) is the system of record: it holds the
+chunk text and metadata each ingestion produced.
+
+Before it existed, rebuilding meant re-parsing every PDF and re-calling the VLM
+captioner — hours of work, not reproducible, and impossible once a source file
+had moved. That made changing the embedding model or the chunking strategy
+expensive enough that it never happened, which is how a corpus ends up
+permanently married to whatever model first indexed it.
+
+Replay re-embeds recorded chunks. It does NOT re-chunk: chunk boundaries are
+what the log recorded. So this is the right tool for an EMBEDDING model change
+and the wrong one for a CHUNKER change — a chunker change needs a real
+re-ingest from the PDFs, and --check says so when that is the case.
+
+Usage
+-----
+    python reindex.py --check          # report drift, change nothing
+    python reindex.py --dry-run        # show what a rebuild would do
+    python reindex.py                  # rebuild into the live collection
+    python reindex.py --into staging   # rebuild into a different collection first
+"""
+
+import argparse
+import logging
+
+import config
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger("reindex")
+
+
+def _drift_report(events: list) -> list:
+    """Differences between what the log recorded and what is configured now."""
+    problems = []
+    models = {e["embed_model"] for e in events if e["embed_model"]}
+    chunkers = {e["chunker_version"] for e in events if e["chunker_version"] is not None}
+
+    if len(models) > 1:
+        problems.append(f"corpus was indexed with MIXED embedding models: {sorted(models)} "
+                        "— vectors from different spaces are not comparable")
+    if models and config.EMBEDDING_MODEL_NAME not in models:
+        problems.append(f"configured embedding model {config.EMBEDDING_MODEL_NAME!r} differs "
+                        f"from the indexed one(s) {sorted(models)} — a replay will re-embed")
+    if len(chunkers) > 1:
+        problems.append(f"corpus was chunked by MIXED chunker versions: {sorted(chunkers)}")
+
+    import vector_store
+    if chunkers and vector_store.CHUNKER_VERSION not in chunkers:
+        problems.append(
+            f"configured chunker version {vector_store.CHUNKER_VERSION} differs from the "
+            f"recorded one(s) {sorted(chunkers)}. Replay CANNOT fix this — it reuses the "
+            "recorded chunk boundaries. Re-ingest from the PDFs instead.")
+    return problems
+
+
+def reindex(collection_name: str, dry_run: bool, batch_size: int) -> int:
+    import bm25_search
+    import embeddings
+    import persistence
+    import vector_store
+
+    events = persistence.get_ingest_events()
+    if not events:
+        logger.error("The ingest log is empty — nothing to replay. Papers ingested "
+                     "before the log existed are not replayable; re-ingest them from "
+                     "the PDFs in %s.", config.PAPERS_DIR)
+        return 2
+
+    total_chunks = sum(len(e["chunks"]) for e in events)
+    logger.info("Replaying %d papers / %d chunks into '%s'",
+                len(events), total_chunks, collection_name)
+
+    for problem in _drift_report(events):
+        logger.warning("DRIFT: %s", problem)
+
+    if dry_run:
+        for e in events:
+            logger.info("  would replay %-28s %4d chunks  (%s)",
+                        e["paper_id"], len(e["chunks"]), e["embed_model"] or "unknown model")
+        logger.info("Dry run — nothing written.")
+        return 0
+
+    # Rebuild into a fresh collection. reset=True because a replay must produce
+    # exactly the logged contents: merging into an existing collection would keep
+    # chunks the log no longer accounts for, which is the drift this exists to end.
+    collection = vector_store.get_or_create_collection(collection_name, reset=True)
+
+    done = 0
+    for e in events:
+        chunks, metas, ids = e["chunks"], e["metadatas"], e["ids"]
+        for start in range(0, len(chunks), batch_size):
+            sl = slice(start, start + batch_size)
+            vecs = embeddings.embed_passages(chunks[sl])
+            vector_store.add_documents(
+                texts=chunks[sl], embeddings=vecs,
+                metadatas=metas[sl], ids=ids[sl], collection=collection)
+        done += len(chunks)
+        logger.info("  %-28s %4d chunks  (%d/%d)", e["paper_id"], len(chunks), done, total_chunks)
+
+    # The lexical index is derived too — leaving the old one would keep serving
+    # chunks from the collection that was just replaced.
+    bm25_search.invalidate()
+    logger.info("Rebuilt %d chunks into '%s'. BM25 will rebuild on the next query.",
+                done, collection_name)
+
+    if collection_name != config.COLLECTION_NAME:
+        logger.info("Built into '%s', not the live collection '%s'. Point "
+                    "COLLECTION_NAME at it once you have verified retrieval quality.",
+                    collection_name, config.COLLECTION_NAME)
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--into", default=None,
+                    help="collection to build into (default: the configured one)")
+    ap.add_argument("--dry-run", action="store_true", help="report what would happen")
+    ap.add_argument("--check", action="store_true",
+                    help="report drift between the log and the current config, then exit")
+    ap.add_argument("--batch-size", type=int, default=64)
+    args = ap.parse_args()
+
+    import persistence
+    events = persistence.get_ingest_events()
+
+    if args.check:
+        if not events:
+            logger.warning("Ingest log is empty — nothing recorded yet.")
+            return 1
+        problems = _drift_report(events)
+        logger.info("%d papers / %d chunks recorded in the ingest log",
+                    len(events), sum(len(e["chunks"]) for e in events))
+        for p in problems:
+            logger.warning("DRIFT: %s", p)
+        if not problems:
+            logger.info("No drift: the log agrees with the current configuration.")
+        return 1 if problems else 0
+
+    return reindex(args.into or config.COLLECTION_NAME, args.dry_run, args.batch_size)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/routes/agent.py
+++ b/routes/agent.py
@@ -88,6 +88,46 @@ class AgentQueryResponse(BaseModel):
     query_id: str = ""
 
 
+# What each graph node is actually doing, in the user's terms. Node names are an
+# implementation detail; "tool_executor" means nothing to someone waiting for an
+# answer. A node with no label here simply produces no progress line, so adding a
+# node to the graph cannot leak a raw internal name into the UI.
+_NODE_LABELS = {
+    "query_planner": "Planning the query",
+    "tool_selector": "Choosing tools",
+    "tool_executor": "Searching the corpus",
+    "answer_generator": "Writing the answer",
+    "reflexion_evaluator": "Checking the answer against sources",
+    "finalizer": "Finishing up",
+}
+
+
+def _sources_preview(contexts: list, limit: int = 8) -> list:
+    """Distinct papers from retrieved contexts, for the mid-run evidence preview.
+
+    Deliberately not the final citation list: numbering is only decided after the
+    answer exists and its markers are compacted. This is "what was retrieved",
+    shown early so the wait has visible content, and the done event replaces it
+    with the authoritative cited set.
+    """
+    seen, out = set(), []
+    for ctx in contexts or []:
+        title = (ctx.get("title") or "").strip()
+        if not title or title in seen or title in ("Unknown", "No results"):
+            continue
+        seen.add(title)
+        out.append({
+            "number": len(out) + 1,
+            "title": title,
+            "section": ctx.get("section", ""),
+            "year": ctx.get("year", ""),
+            "authors": ctx.get("authors", ""),
+        })
+        if len(out) >= limit:
+            break
+    return out
+
+
 @router.post("/agent/query", response_model=AgentQueryResponse, tags=["Agent"])
 @limiter.limit("10/minute")
 async def agent_query(
@@ -284,22 +324,70 @@ async def agent_stream(
     )
 
     async def _run_and_stream():
-        # --- Phase 1: run the agent pipeline ---
-        thinking_msg = json.dumps({"type": "thinking", "text": "Running agent pipeline…"})
-        yield f"data: {thinking_msg}\n\n"
+        # --- Phase 1: run the agent pipeline, reporting progress as it goes ---
+        #
+        # This used to be a single invoke() behind run_in_threadpool: one
+        # "Running agent pipeline…" line, then total silence for as long as the
+        # run took (measured: 145s, of which ~85s showed the client nothing but a
+        # caret). A wait that reports nothing is indistinguishable from a hang.
+        #
+        # graph.stream(stream_mode="updates") yields {node: delta} as each node
+        # finishes, which is real progress rather than a spinner. AgentState is a
+        # plain TypedDict with no reducers, so replaying the deltas with
+        # dict.update() reproduces exactly what invoke() would have returned.
+        q: asyncio.Queue = asyncio.Queue(maxsize=64)
+        loop = asyncio.get_running_loop()
 
+        def _enqueue(item):
+            # Block until there is room, so a terminal event is never dropped.
+            asyncio.run_coroutine_threadsafe(q.put(item), loop).result(timeout=30)
+
+        def _run_graph():
+            merged = dict(initial_state)
+            try:
+                for update in _get_agent_graph().stream(initial_state, stream_mode="updates"):
+                    for node, delta in (update or {}).items():
+                        if isinstance(delta, dict):
+                            merged.update(delta)
+                        _enqueue(("node", node, dict(merged)))
+                _enqueue(("done", None, merged))
+            except Exception as exc:  # mirrors the old except-Exception path
+                _enqueue(("error", str(exc)[:200], None))
+
+        threading.Thread(target=_run_graph, daemon=True, name="agent-graph").start()
+
+        result = None
+        sources_sent = False
+        deadline = time.monotonic() + float(config.AGENT_TIMEOUT)
         try:
-            result = await asyncio.wait_for(
-                run_in_threadpool(_get_agent_graph().invoke, initial_state),
-                timeout=float(config.AGENT_TIMEOUT),
-            )
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise asyncio.TimeoutError
+                kind, payload, state = await asyncio.wait_for(q.get(), timeout=remaining)
+
+                if kind == "error":
+                    yield f"data: {json.dumps({'type': 'error', 'message': payload})}\n\n"
+                    yield "data: [DONE]\n\n"
+                    return
+                if kind == "done":
+                    result = state
+                    break
+
+                label = _NODE_LABELS.get(payload)
+                if label:
+                    yield f"data: {json.dumps({'type': 'progress', 'node': payload, 'text': label})}\n\n"
+
+                # Retrieval finishes long before the answer is written, so send the
+                # sources as soon as they exist and let the evidence rail fill during
+                # generation instead of staying blank for the whole wait.
+                if not sources_sent and state and state.get("retrieved_contexts"):
+                    preview = _sources_preview(state["retrieved_contexts"])
+                    if preview:
+                        sources_sent = True
+                        yield f"data: {json.dumps({'type': 'sources_preview', 'sources': preview})}\n\n"
         except asyncio.TimeoutError:
             err = json.dumps({"type": "error", "message": "Agent pipeline timed out."})
-            yield f"data: {err}\n\n"
-            yield "data: [DONE]\n\n"
-            return
-        except Exception as e:
-            err = json.dumps({"type": "error", "message": str(e)[:200]})
             yield f"data: {err}\n\n"
             yield "data: [DONE]\n\n"
             return

--- a/routes/agent.py
+++ b/routes/agent.py
@@ -209,6 +209,7 @@ async def agent_query(
     final_answer = result["final_answer"]
     cited_titles: set[str] = set()
     title_to_num: dict[str, int] = {}
+    cits: list = []
     try:
         metas = [{"title": c.get("title", "Unknown"), "section": c.get("section", "body")}
                  for c in all_contexts]
@@ -225,7 +226,7 @@ async def agent_query(
     except Exception:
         pass  # fall through to dedup-only logic below
 
-    _append_session_messages(session_id, body.question, final_answer, owner)
+    _append_session_messages(session_id, body.question, final_answer, owner, cits)
     processing_time = time.time() - start_time
 
     logger.info(
@@ -409,6 +410,7 @@ async def agent_stream(
         all_contexts = result.get("retrieved_contexts", [])
         cited_titles: set = set()
         title_to_num: dict = {}
+        cits: list = []
         try:
             metas = [{"title": c.get("title", "Unknown"), "section": c.get("section", "body")}
                      for c in all_contexts]
@@ -421,7 +423,7 @@ async def agent_stream(
         except Exception:
             pass
 
-        _append_session_messages(session_id, body.question, final_answer, owner)
+        _append_session_messages(session_id, body.question, final_answer, owner, cits)
 
         # --- Phase 3b: stream the final answer in chunks ---
         chunk_size = 80  # characters per SSE chunk

--- a/routes/agent.py
+++ b/routes/agent.py
@@ -19,7 +19,10 @@ import persistence
 import rag
 from agent.state import AgentState
 from agent.nodes.finalizer import citation_coverage
-from deps import limiter, verify_api_key, _get_or_create_session, _append_session_messages
+from deps import (
+    limiter, verify_api_key, current_owner,
+    _get_or_create_session, _append_session_messages,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -91,13 +94,18 @@ async def agent_query(
     request: Request,
     body: AgentQueryRequest,
     authenticated: bool = Depends(verify_api_key),
+    owner: Optional[str] = Depends(current_owner),
 ):
     """
     Answer a question using the agentic IndicRAG pipeline with reflexion loops.
     Supports the same 10+ languages as /query and /chat.
     """
     start_time = time.time()
-    session_id, messages = _get_or_create_session(body.session_id)
+    try:
+        session_id, messages = _get_or_create_session(body.session_id, owner)
+    except PermissionError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail=f"Session '{body.session_id}' not found.")
 
     initial_state = AgentState(
         original_query=body.question,
@@ -177,7 +185,7 @@ async def agent_query(
     except Exception:
         pass  # fall through to dedup-only logic below
 
-    _append_session_messages(session_id, body.question, final_answer)
+    _append_session_messages(session_id, body.question, final_answer, owner)
     processing_time = time.time() - start_time
 
     logger.info(
@@ -216,6 +224,7 @@ async def agent_query(
             confidence=result.get("answer_confidence") or 0.0,
             coverage=citation_coverage(final_answer),
             created_at=datetime.now(timezone.utc).isoformat(),
+            owner=owner,
         )
     except Exception:
         logger.warning("Failed to log query for feedback correlation", exc_info=True)
@@ -241,6 +250,7 @@ async def agent_stream(
     request: Request,
     body: AgentQueryRequest,
     authenticated: bool = Depends(verify_api_key),
+    owner: Optional[str] = Depends(current_owner),
 ):
     """Stream agentic query results as Server-Sent Events.
 
@@ -248,7 +258,11 @@ async def agent_stream(
     along with metadata events for sources, tool calls, and timing.
     """
     start_time = time.time()
-    session_id, messages = _get_or_create_session(body.session_id)
+    try:
+        session_id, messages = _get_or_create_session(body.session_id, owner)
+    except PermissionError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail=f"Session '{body.session_id}' not found.")
 
     initial_state = AgentState(
         original_query=body.question,
@@ -319,7 +333,7 @@ async def agent_stream(
         except Exception:
             pass
 
-        _append_session_messages(session_id, body.question, final_answer)
+        _append_session_messages(session_id, body.question, final_answer, owner)
 
         # --- Phase 3b: stream the final answer in chunks ---
         chunk_size = 80  # characters per SSE chunk
@@ -358,6 +372,7 @@ async def agent_stream(
                 confidence=result.get("answer_confidence") or 0.0,
                 coverage=citation_coverage(final_answer),
                 created_at=datetime.now(timezone.utc).isoformat(),
+                owner=owner,
             )
         except Exception:
             pass

--- a/routes/agent.py
+++ b/routes/agent.py
@@ -21,7 +21,7 @@ from agent.state import AgentState
 from agent.nodes.finalizer import citation_coverage
 from deps import (
     limiter, verify_api_key, current_owner,
-    _get_or_create_session, _append_session_messages,
+    _get_or_create_session, _append_session_messages, session_turn_lock,
 )
 
 logger = logging.getLogger(__name__)
@@ -141,92 +141,96 @@ async def agent_query(
     Supports the same 10+ languages as /query and /chat.
     """
     start_time = time.time()
-    try:
-        session_id, messages = _get_or_create_session(body.session_id, owner)
-    except PermissionError:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
-                            detail=f"Session '{body.session_id}' not found.")
+    # One turn at a time per session: agent and chat traffic share the same
+    # history, so a concurrent turn must not generate from a history that
+    # omits the turn running beside it.
+    async with session_turn_lock(body.session_id):
+        try:
+            session_id, messages = _get_or_create_session(body.session_id, owner)
+        except PermissionError:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                                detail=f"Session '{body.session_id}' not found.")
 
-    initial_state = AgentState(
-        original_query=body.question,
-        detected_language="",
-        query_plan=[],
-        tool_calls_requested=[],
-        retrieved_contexts=[],
-        draft_answer=None,
-        final_answer=None,
-        reflexion_count=0,
-        reflexion_history=[],
-        tool_calls_log=[],
-        conversation_history=list(messages),
-        session_id=session_id,
-        strategy=body.strategy,
-        start_time=time.monotonic(),
-        requested_model=body.model,
-        requested_provider=body.provider,
-    )
+        initial_state = AgentState(
+            original_query=body.question,
+            detected_language="",
+            query_plan=[],
+            tool_calls_requested=[],
+            retrieved_contexts=[],
+            draft_answer=None,
+            final_answer=None,
+            reflexion_count=0,
+            reflexion_history=[],
+            tool_calls_log=[],
+            conversation_history=list(messages),
+            session_id=session_id,
+            strategy=body.strategy,
+            start_time=time.monotonic(),
+            requested_model=body.model,
+            requested_provider=body.provider,
+        )
 
-    try:
-        result = await asyncio.wait_for(
-            run_in_threadpool(_get_agent_graph().invoke, initial_state),
-            timeout=float(config.AGENT_TIMEOUT),
-        )
-    except asyncio.TimeoutError:
-        logger.warning(
-            "Agent timed out after %ds: strategy=%s, question_len=%d",
-            config.AGENT_TIMEOUT, body.strategy, len(body.question),
-        )
-        raise HTTPException(
-            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
-            detail={"error": "Agent pipeline timed out. Try a simpler query or use Standard RAG mode.", "code": "AGENT_TIMEOUT"},
-        )
-    except Exception as e:
-        err_str = str(e)
-        is_llm_unavailable = (
-            "503" in err_str or "429" in err_str
-            or "UNAVAILABLE" in err_str
-            or "RESOURCE_EXHAUSTED" in err_str
-            or "high demand" in err_str.lower()
-            or "unreachable" in err_str.lower()
-        )
-        if is_llm_unavailable:
-            logger.warning(f"LLM service unavailable for agent query: {err_str[:200]}")
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail={
-                    "error": "The AI model is temporarily unavailable due to high demand. "
-                             "Please try again in a few seconds.",
-                    "code": "LLM_UNAVAILABLE",
-                },
+        try:
+            result = await asyncio.wait_for(
+                run_in_threadpool(_get_agent_graph().invoke, initial_state),
+                timeout=float(config.AGENT_TIMEOUT),
             )
-        logger.error(f"Agent error: {e}", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"error": "Agent pipeline failed. Please try again later.", "code": "AGENT_ERROR"},
-        )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Agent timed out after %ds: strategy=%s, question_len=%d",
+                config.AGENT_TIMEOUT, body.strategy, len(body.question),
+            )
+            raise HTTPException(
+                status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                detail={"error": "Agent pipeline timed out. Try a simpler query or use Standard RAG mode.", "code": "AGENT_TIMEOUT"},
+            )
+        except Exception as e:
+            err_str = str(e)
+            is_llm_unavailable = (
+                "503" in err_str or "429" in err_str
+                or "UNAVAILABLE" in err_str
+                or "RESOURCE_EXHAUSTED" in err_str
+                or "high demand" in err_str.lower()
+                or "unreachable" in err_str.lower()
+            )
+            if is_llm_unavailable:
+                logger.warning(f"LLM service unavailable for agent query: {err_str[:200]}")
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail={
+                        "error": "The AI model is temporarily unavailable due to high demand. "
+                                 "Please try again in a few seconds.",
+                        "code": "LLM_UNAVAILABLE",
+                    },
+                )
+            logger.error(f"Agent error: {e}", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail={"error": "Agent pipeline failed. Please try again later.", "code": "AGENT_ERROR"},
+            )
 
-    all_contexts = result.get("retrieved_contexts", [])
-    final_answer = result["final_answer"]
-    cited_titles: set[str] = set()
-    title_to_num: dict[str, int] = {}
-    cits: list = []
-    try:
-        metas = [{"title": c.get("title", "Unknown"), "section": c.get("section", "body")}
-                 for c in all_contexts]
-        # The context numbers every retrieved paper, but the panel below keeps
-        # only the cited ones — so an answer citing papers 1 and 4 of 4 read
-        # "[1] … [4]" beside a two-entry panel. compact_citations renumbers the
-        # answer's markers and the citations together to a dense 1..M.
-        final_answer, cits = rag.compact_citations(
-            final_answer, metas, visible_chunks=result.get("context_chunks_used"))
-        for cit in cits:
-            title = cit["title"].strip()
-            cited_titles.add(title)
-            title_to_num[title] = int(cit["number"])
-    except Exception:
-        pass  # fall through to dedup-only logic below
+        all_contexts = result.get("retrieved_contexts", [])
+        final_answer = result["final_answer"]
+        cited_titles: set[str] = set()
+        title_to_num: dict[str, int] = {}
+        cits: list = []
+        try:
+            metas = [{"title": c.get("title", "Unknown"), "section": c.get("section", "body")}
+                     for c in all_contexts]
+            # The context numbers every retrieved paper, but the panel below keeps
+            # only the cited ones — so an answer citing papers 1 and 4 of 4 read
+            # "[1] … [4]" beside a two-entry panel. compact_citations renumbers the
+            # answer's markers and the citations together to a dense 1..M.
+            final_answer, cits = rag.compact_citations(
+                final_answer, metas, visible_chunks=result.get("context_chunks_used"))
+            for cit in cits:
+                title = cit["title"].strip()
+                cited_titles.add(title)
+                title_to_num[title] = int(cit["number"])
+        except Exception:
+            pass  # fall through to dedup-only logic below
 
-    _append_session_messages(session_id, body.question, final_answer, owner, cits)
+        _append_session_messages(session_id, body.question, final_answer, owner, cits)
     processing_time = time.time() - start_time
 
     logger.info(
@@ -299,11 +303,20 @@ async def agent_stream(
     along with metadata events for sources, tool calls, and timing.
     """
     start_time = time.time()
+    # Same turn lock as the non-streaming path, acquired manually: the turn ends
+    # when the generator appends the answer, so the generator's `finally` is what
+    # releases it and a client disconnect mid-stream cannot strand it.
+    lock = session_turn_lock(body.session_id)
+    await lock.acquire()
     try:
         session_id, messages = _get_or_create_session(body.session_id, owner)
     except PermissionError:
+        lock.release()
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
                             detail=f"Session '{body.session_id}' not found.")
+    except BaseException:
+        lock.release()
+        raise
 
     initial_state = AgentState(
         original_query=body.question,
@@ -325,160 +338,170 @@ async def agent_stream(
     )
 
     async def _run_and_stream():
-        # --- Phase 1: run the agent pipeline, reporting progress as it goes ---
-        #
-        # This used to be a single invoke() behind run_in_threadpool: one
-        # "Running agent pipeline…" line, then total silence for as long as the
-        # run took (measured: 145s, of which ~85s showed the client nothing but a
-        # caret). A wait that reports nothing is indistinguishable from a hang.
-        #
-        # graph.stream(stream_mode="updates") yields {node: delta} as each node
-        # finishes, which is real progress rather than a spinner. AgentState is a
-        # plain TypedDict with no reducers, so replaying the deltas with
-        # dict.update() reproduces exactly what invoke() would have returned.
-        q: asyncio.Queue = asyncio.Queue(maxsize=64)
-        loop = asyncio.get_running_loop()
+        stop = threading.Event()   # read by the graph worker below
+        try:
+            # --- Phase 1: run the agent pipeline, reporting progress as it goes ---
+            #
+            # This used to be a single invoke() behind run_in_threadpool: one
+            # "Running agent pipeline…" line, then total silence for as long as the
+            # run took (measured: 145s, of which ~85s showed the client nothing but a
+            # caret). A wait that reports nothing is indistinguishable from a hang.
+            #
+            # graph.stream(stream_mode="updates") yields {node: delta} as each node
+            # finishes, which is real progress rather than a spinner. AgentState is a
+            # plain TypedDict with no reducers, so replaying the deltas with
+            # dict.update() reproduces exactly what invoke() would have returned.
+            q: asyncio.Queue = asyncio.Queue(maxsize=64)
+            loop = asyncio.get_running_loop()
 
-        def _enqueue(item):
-            # Block until there is room, so a terminal event is never dropped.
-            asyncio.run_coroutine_threadsafe(q.put(item), loop).result(timeout=30)
+            def _enqueue(item):
+                # Block until there is room, so a terminal event is never dropped.
+                asyncio.run_coroutine_threadsafe(q.put(item), loop).result(timeout=30)
 
-        def _run_graph():
-            merged = dict(initial_state)
+            def _run_graph():
+                merged = dict(initial_state)
+                try:
+                    for update in _get_agent_graph().stream(initial_state, stream_mode="updates"):
+                        if stop.is_set():
+                            return
+                        for node, delta in (update or {}).items():
+                            if isinstance(delta, dict):
+                                merged.update(delta)
+                            _enqueue(("node", node, dict(merged)))
+                    _enqueue(("done", None, merged))
+                except Exception as exc:  # mirrors the old except-Exception path
+                    _enqueue(("error", str(exc)[:200], None))
+
+            threading.Thread(target=_run_graph, daemon=True, name="agent-graph").start()
+
+            result = None
+            sources_sent = False
+            deadline = time.monotonic() + float(config.AGENT_TIMEOUT)
             try:
-                for update in _get_agent_graph().stream(initial_state, stream_mode="updates"):
-                    for node, delta in (update or {}).items():
-                        if isinstance(delta, dict):
-                            merged.update(delta)
-                        _enqueue(("node", node, dict(merged)))
-                _enqueue(("done", None, merged))
-            except Exception as exc:  # mirrors the old except-Exception path
-                _enqueue(("error", str(exc)[:200], None))
+                while True:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise asyncio.TimeoutError
+                    kind, payload, state = await asyncio.wait_for(q.get(), timeout=remaining)
 
-        threading.Thread(target=_run_graph, daemon=True, name="agent-graph").start()
+                    if kind == "error":
+                        yield f"data: {json.dumps({'type': 'error', 'message': payload})}\n\n"
+                        yield "data: [DONE]\n\n"
+                        return
+                    if kind == "done":
+                        result = state
+                        break
 
-        result = None
-        sources_sent = False
-        deadline = time.monotonic() + float(config.AGENT_TIMEOUT)
-        try:
-            while True:
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    raise asyncio.TimeoutError
-                kind, payload, state = await asyncio.wait_for(q.get(), timeout=remaining)
+                    label = _NODE_LABELS.get(payload)
+                    if label:
+                        yield f"data: {json.dumps({'type': 'progress', 'node': payload, 'text': label})}\n\n"
 
-                if kind == "error":
-                    yield f"data: {json.dumps({'type': 'error', 'message': payload})}\n\n"
-                    yield "data: [DONE]\n\n"
-                    return
-                if kind == "done":
-                    result = state
-                    break
+                    # Retrieval finishes long before the answer is written, so send the
+                    # sources as soon as they exist and let the evidence rail fill during
+                    # generation instead of staying blank for the whole wait.
+                    if not sources_sent and state and state.get("retrieved_contexts"):
+                        preview = _sources_preview(state["retrieved_contexts"])
+                        if preview:
+                            sources_sent = True
+                            yield f"data: {json.dumps({'type': 'sources_preview', 'sources': preview})}\n\n"
+            except asyncio.TimeoutError:
+                err = json.dumps({"type": "error", "message": "Agent pipeline timed out."})
+                yield f"data: {err}\n\n"
+                yield "data: [DONE]\n\n"
+                return
 
-                label = _NODE_LABELS.get(payload)
-                if label:
-                    yield f"data: {json.dumps({'type': 'progress', 'node': payload, 'text': label})}\n\n"
+            processing_time = time.time() - start_time
 
-                # Retrieval finishes long before the answer is written, so send the
-                # sources as soon as they exist and let the evidence rail fill during
-                # generation instead of staying blank for the whole wait.
-                if not sources_sent and state and state.get("retrieved_contexts"):
-                    preview = _sources_preview(state["retrieved_contexts"])
-                    if preview:
-                        sources_sent = True
-                        yield f"data: {json.dumps({'type': 'sources_preview', 'sources': preview})}\n\n"
-        except asyncio.TimeoutError:
-            err = json.dumps({"type": "error", "message": "Agent pipeline timed out."})
-            yield f"data: {err}\n\n"
+            # --- Phase 2: stream tool calls as thinking events ---
+            for tc in result.get("tool_calls_log", []):
+                tool_msg = json.dumps({
+                    "type": "thinking",
+                    "text": f"Tool: {tc.get('tool', '?')} ({tc.get('latency_ms', 0):.0f}ms)",
+                })
+                yield f"data: {tool_msg}\n\n"
+
+            # --- Phase 3: resolve citations BEFORE streaming ---
+            # The markers have to be compacted before the first chunk goes out, or
+            # the client renders [1],[4] against a two-entry panel.
+            final_answer = result["final_answer"] or ""
+            all_contexts = result.get("retrieved_contexts", [])
+            cited_titles: set = set()
+            title_to_num: dict = {}
+            cits: list = []
+            try:
+                metas = [{"title": c.get("title", "Unknown"), "section": c.get("section", "body")}
+                         for c in all_contexts]
+                final_answer, cits = rag.compact_citations(
+                    final_answer, metas, visible_chunks=result.get("context_chunks_used"))
+                for cit in cits:
+                    title = cit["title"].strip()
+                    cited_titles.add(title)
+                    title_to_num[title] = int(cit["number"])
+            except Exception:
+                pass
+
+            _append_session_messages(session_id, body.question, final_answer, owner, cits)
+
+            # --- Phase 3b: stream the final answer in chunks ---
+            chunk_size = 80  # characters per SSE chunk
+            for i in range(0, len(final_answer), chunk_size):
+                chunk = final_answer[i:i + chunk_size]
+                yield f"data: {json.dumps({'type': 'chunk', 'text': chunk})}\n\n"
+
+            # --- Phase 4: build sources list ---
+            seen_titles: set = set()
+            sources = []
+            for ctx in all_contexts:
+                title = ctx.get("title", "").strip()
+                if not title or title in seen_titles or title in ("Unknown", "No results"):
+                    continue
+                if cited_titles and title not in cited_titles:
+                    continue
+                seen_titles.add(title)
+                sources.append({
+                    "number": title_to_num.get(title, len(sources) + 1),
+                    "title": title,
+                    "source": ctx.get("source", ""),
+                    "section": ctx.get("section", ""),
+                    "pdf_url": ctx.get("pdf_url", ""),
+                    "year": ctx.get("year", ""),
+                    "authors": ctx.get("authors", ""),
+                })
+            sources.sort(key=lambda s: s["number"])
+
+            # --- Phase 5: done event with full metadata ---
+            query_id = str(uuid.uuid4())
+            try:
+                persistence.log_query(
+                    query_id=query_id, question=body.question, answer=final_answer,
+                    mode=f"agent_{body.strategy}", model=body.model or "default",
+                    language=result.get("detected_language", "en"),
+                    confidence=result.get("answer_confidence") or 0.0,
+                    coverage=citation_coverage(final_answer),
+                    created_at=datetime.now(timezone.utc).isoformat(),
+                    owner=owner,
+                )
+            except Exception:
+                pass
+
+            done_payload = {
+                "type": "done",
+                "citations": sources,
+                "language": result.get("detected_language", "en"),
+                "session_id": session_id,
+                "query_id": query_id,
+                "processing_time": processing_time,
+                "model": body.model or "default",
+                "reflexion_iterations": result.get("reflexion_count", 0),
+                "tool_calls": result.get("tool_calls_log", []),
+            }
+            yield f"data: {json.dumps(done_payload)}\n\n"
             yield "data: [DONE]\n\n"
-            return
-
-        processing_time = time.time() - start_time
-
-        # --- Phase 2: stream tool calls as thinking events ---
-        for tc in result.get("tool_calls_log", []):
-            tool_msg = json.dumps({
-                "type": "thinking",
-                "text": f"Tool: {tc.get('tool', '?')} ({tc.get('latency_ms', 0):.0f}ms)",
-            })
-            yield f"data: {tool_msg}\n\n"
-
-        # --- Phase 3: resolve citations BEFORE streaming ---
-        # The markers have to be compacted before the first chunk goes out, or
-        # the client renders [1],[4] against a two-entry panel.
-        final_answer = result["final_answer"] or ""
-        all_contexts = result.get("retrieved_contexts", [])
-        cited_titles: set = set()
-        title_to_num: dict = {}
-        cits: list = []
-        try:
-            metas = [{"title": c.get("title", "Unknown"), "section": c.get("section", "body")}
-                     for c in all_contexts]
-            final_answer, cits = rag.compact_citations(
-                final_answer, metas, visible_chunks=result.get("context_chunks_used"))
-            for cit in cits:
-                title = cit["title"].strip()
-                cited_titles.add(title)
-                title_to_num[title] = int(cit["number"])
-        except Exception:
-            pass
-
-        _append_session_messages(session_id, body.question, final_answer, owner, cits)
-
-        # --- Phase 3b: stream the final answer in chunks ---
-        chunk_size = 80  # characters per SSE chunk
-        for i in range(0, len(final_answer), chunk_size):
-            chunk = final_answer[i:i + chunk_size]
-            yield f"data: {json.dumps({'type': 'chunk', 'text': chunk})}\n\n"
-
-        # --- Phase 4: build sources list ---
-        seen_titles: set = set()
-        sources = []
-        for ctx in all_contexts:
-            title = ctx.get("title", "").strip()
-            if not title or title in seen_titles or title in ("Unknown", "No results"):
-                continue
-            if cited_titles and title not in cited_titles:
-                continue
-            seen_titles.add(title)
-            sources.append({
-                "number": title_to_num.get(title, len(sources) + 1),
-                "title": title,
-                "source": ctx.get("source", ""),
-                "section": ctx.get("section", ""),
-                "pdf_url": ctx.get("pdf_url", ""),
-                "year": ctx.get("year", ""),
-                "authors": ctx.get("authors", ""),
-            })
-        sources.sort(key=lambda s: s["number"])
-
-        # --- Phase 5: done event with full metadata ---
-        query_id = str(uuid.uuid4())
-        try:
-            persistence.log_query(
-                query_id=query_id, question=body.question, answer=final_answer,
-                mode=f"agent_{body.strategy}", model=body.model or "default",
-                language=result.get("detected_language", "en"),
-                confidence=result.get("answer_confidence") or 0.0,
-                coverage=citation_coverage(final_answer),
-                created_at=datetime.now(timezone.utc).isoformat(),
-                owner=owner,
-            )
-        except Exception:
-            pass
-
-        done_payload = {
-            "type": "done",
-            "citations": sources,
-            "language": result.get("detected_language", "en"),
-            "session_id": session_id,
-            "query_id": query_id,
-            "processing_time": processing_time,
-            "model": body.model or "default",
-            "reflexion_iterations": result.get("reflexion_count", 0),
-            "tool_calls": result.get("tool_calls_log", []),
-        }
-        yield f"data: {json.dumps(done_payload)}\n\n"
-        yield "data: [DONE]\n\n"
+        finally:
+            # The graph worker outlives this generator otherwise — on a timeout
+            # or a client disconnect it would keep burning LLM calls with nobody
+            # left to read them.
+            stop.set()
+            lock.release()
 
     return StreamingResponse(_run_and_stream(), media_type="text/event-stream")

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -64,6 +64,8 @@ class ChatResponse(BaseModel):
     citations: List[Citation]
     processing_time: float
     timestamp: str
+    # 'sparse_only' when the dense retrieval leg was unavailable — see QueryResponse.
+    degraded: Optional[str] = None
 
 
 @router.post("/chat", response_model=ChatResponse, tags=["Chat"])
@@ -134,6 +136,7 @@ async def chat(
         citations=[Citation(**c) for c in result["citations"]],
         processing_time=processing_time,
         timestamp=datetime.now(timezone.utc).isoformat(),
+        degraded=result.get("degraded"),
     )
 
 
@@ -191,7 +194,8 @@ async def chat_stream(
             async for event in sse_stream(prepared["prompt"], prepared["metadatas"], prepared["detected_lang"],
                                            strategy=body.strategy, query_id=query_id,
                                            model=body.model, provider=body.provider,
-                                           visible_chunks=prepared["chunks_used"]):
+                                           visible_chunks=prepared["chunks_used"],
+                                           degraded=prepared.get("degraded")):
                 if event.startswith('data: {"type": "error"'):
                     hit_error = True
                 if event.startswith('data: {"type": "done"'):

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -13,7 +13,10 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 
 import rag
-from deps import limiter, verify_api_key, _get_or_create_session, _append_session_messages
+from deps import (
+    limiter, verify_api_key, current_owner, owns_session, session_turn_lock,
+    _get_or_create_session, _append_session_messages,
+)
 from routes.query import Citation, build_paper_filter, build_tags_filter, combine_filters
 from sse_utils import sse_stream
 
@@ -69,6 +72,7 @@ async def chat(
     request: Request,
     body: ChatRequest,
     authenticated: bool = Depends(verify_api_key),
+    owner: Optional[str] = Depends(current_owner),
 ):
     """
     Send a message in a multi-turn conversation.
@@ -83,28 +87,35 @@ async def chat(
     if top_k is not None:
         top_k = max(1, min(top_k, 20))
 
-    session_id, messages = _get_or_create_session(body.session_id)
-    turn_index = len(messages) // 2  # number of completed user+assistant pairs
+    # The lock spans read-history -> generate -> append: concurrent turns on one
+    # session must not each answer from a history that omits the other's turn.
+    async with session_turn_lock(body.session_id or "new"):
+        try:
+            session_id, messages = _get_or_create_session(body.session_id, owner)
+        except PermissionError:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                                detail=f"Session '{body.session_id}' not found.")
+        turn_index = len(messages) // 2  # number of completed user+assistant pairs
 
-    full_messages = list(messages) + [{"role": "user", "content": body.message}]
+        full_messages = list(messages) + [{"role": "user", "content": body.message}]
 
-    try:
-        result = await run_in_threadpool(
-            rag.answer_with_history,
-            messages=full_messages,
-            strategy=body.strategy,
-            top_k=top_k,
-            filter_dict=combine_filters(build_paper_filter(body.paper_ids), build_tags_filter(body.tags)),
-            model=body.model,
-            provider=body.provider,
-        )
-    except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail={"error": str(e), "code": "VALIDATION_ERROR"})
-    except Exception as e:
-        logger.error(f"Error in /chat: {e}", exc_info=True)
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail={"error": "Internal server error. Please try again.", "code": "INTERNAL_ERROR"})
+        try:
+            result = await run_in_threadpool(
+                rag.answer_with_history,
+                messages=full_messages,
+                strategy=body.strategy,
+                top_k=top_k,
+                filter_dict=combine_filters(build_paper_filter(body.paper_ids), build_tags_filter(body.tags)),
+                model=body.model,
+                provider=body.provider,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail={"error": str(e), "code": "VALIDATION_ERROR"})
+        except Exception as e:
+            logger.error(f"Error in /chat: {e}", exc_info=True)
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail={"error": "Internal server error. Please try again.", "code": "INTERNAL_ERROR"})
 
-    _append_session_messages(session_id, body.message, result["answer"])
+        _append_session_messages(session_id, body.message, result["answer"], owner)
 
     processing_time = time.time() - start_time
     logger.info(
@@ -132,54 +143,78 @@ async def chat_stream(
     request: Request,
     body: ChatRequest,
     authenticated: bool = Depends(verify_api_key),
+    owner: Optional[str] = Depends(current_owner),
 ):
     """Stream a multi-turn chat answer as Server-Sent Events."""
     top_k = body.top_k
     if top_k is not None:
         top_k = max(1, min(top_k, 20))
 
-    session_id, messages = _get_or_create_session(body.session_id)
-    full_messages = list(messages) + [{"role": "user", "content": body.message}]
+    # Same turn lock as POST /chat, but it has to be acquired manually: the turn
+    # is not finished when this function returns — it ends when the generator
+    # below appends the answer. The generator's `finally` is what releases it,
+    # so a client disconnect mid-stream can't strand the lock.
+    lock = session_turn_lock(body.session_id or "new")
+    await lock.acquire()
+    try:
+        try:
+            session_id, messages = _get_or_create_session(body.session_id, owner)
+        except PermissionError:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                                detail=f"Session '{body.session_id}' not found.")
+        full_messages = list(messages) + [{"role": "user", "content": body.message}]
 
-    prepared = await run_in_threadpool(rag.prepare_chat_for_stream, full_messages, body.strategy, top_k,
-                                       combine_filters(build_paper_filter(body.paper_ids), build_tags_filter(body.tags)))
-    query_id = str(uuid.uuid4())
+        prepared = await run_in_threadpool(rag.prepare_chat_for_stream, full_messages, body.strategy, top_k,
+                                           combine_filters(build_paper_filter(body.paper_ids), build_tags_filter(body.tags)))
+        query_id = str(uuid.uuid4())
 
-    if prepared["chunks_used"] == 0:
-        async def _no_docs():
-            yield f"data: {json.dumps({'type': 'chunk', 'text': prepared['no_docs_msg']})}\n\n"
-            yield f"data: {json.dumps({'type': 'done', 'citations': [], 'language': prepared['detected_lang'], 'session_id': session_id, 'query_id': query_id})}\n\n"
-            yield "data: [DONE]\n\n"
-        _append_session_messages(session_id, body.message, prepared["no_docs_msg"])
-        return StreamingResponse(_no_docs(), media_type="text/event-stream")
+        if prepared["chunks_used"] == 0:
+            async def _no_docs():
+                yield f"data: {json.dumps({'type': 'chunk', 'text': prepared['no_docs_msg']})}\n\n"
+                yield f"data: {json.dumps({'type': 'done', 'citations': [], 'language': prepared['detected_lang'], 'session_id': session_id, 'query_id': query_id})}\n\n"
+                yield "data: [DONE]\n\n"
+            # The turn is already complete on this branch (nothing streams from the
+            # model), so release here rather than handing the lock to a generator
+            # that has no answer left to append.
+            _append_session_messages(session_id, body.message, prepared["no_docs_msg"], owner)
+            lock.release()
+            return StreamingResponse(_no_docs(), media_type="text/event-stream")
+    except BaseException:
+        lock.release()
+        raise
 
     async def _stream_and_save():
         full_answer: list[str] = []
         final_answer: str | None = None  # compacted answer from the done event
         hit_error = False
-        async for event in sse_stream(prepared["prompt"], prepared["metadatas"], prepared["detected_lang"],
-                                       strategy=body.strategy, query_id=query_id,
-                                       model=body.model, provider=body.provider,
-                                       visible_chunks=prepared["chunks_used"]):
-            if event.startswith('data: {"type": "error"'):
-                hit_error = True
-            if event.startswith('data: {"type": "done"'):
-                payload = json.loads(event[6:])
-                payload["session_id"] = session_id
-                final_answer = payload.get("answer")
-                yield f"data: {json.dumps(payload)}\n\n"
-            else:
-                if event.startswith('data: {"type": "chunk"'):
-                    try:
-                        full_answer.append(json.loads(event[6:])["text"])
-                    except Exception:
-                        pass
-                yield event
-        if not hit_error:
-            # Persist the compacted answer, not the raw streamed chunks — otherwise
-            # the follow-up turns inherit gapped and dangling [N] markers.
-            _append_session_messages(
-                session_id, body.message, final_answer or "".join(full_answer))
+        try:
+            async for event in sse_stream(prepared["prompt"], prepared["metadatas"], prepared["detected_lang"],
+                                           strategy=body.strategy, query_id=query_id,
+                                           model=body.model, provider=body.provider,
+                                           visible_chunks=prepared["chunks_used"]):
+                if event.startswith('data: {"type": "error"'):
+                    hit_error = True
+                if event.startswith('data: {"type": "done"'):
+                    payload = json.loads(event[6:])
+                    payload["session_id"] = session_id
+                    final_answer = payload.get("answer")
+                    yield f"data: {json.dumps(payload)}\n\n"
+                else:
+                    if event.startswith('data: {"type": "chunk"'):
+                        try:
+                            full_answer.append(json.loads(event[6:])["text"])
+                        except Exception:
+                            pass
+                    yield event
+            if not hit_error:
+                # Persist the compacted answer, not the raw streamed chunks — otherwise
+                # the follow-up turns inherit gapped and dangling [N] markers.
+                _append_session_messages(
+                    session_id, body.message, final_answer or "".join(full_answer), owner)
+        finally:
+            # Runs on normal completion, on an error, and on GeneratorExit when the
+            # client disconnects mid-stream — the turn is over in all three cases.
+            lock.release()
 
     return StreamingResponse(_stream_and_save(), media_type="text/event-stream")
 
@@ -202,13 +237,20 @@ class ChatHistoryResponse(BaseModel):
 
 
 @router.get("/chat", response_model=List[ChatSessionSummary], tags=["Chat"])
-async def list_sessions(authenticated: bool = Depends(verify_api_key)):
-    """List saved chat sessions, most-recent first. Global — no per-user isolation."""
+async def list_sessions(authenticated: bool = Depends(verify_api_key),
+                        owner: Optional[str] = Depends(current_owner)):
+    """List the caller's saved chat sessions, most-recent first.
+
+    Scoped by API-key fingerprint. This listing used to be global, so any valid
+    key could read every other user's conversation previews.
+    """
     from deps import _sessions, _sessions_lock, _evict_stale_sessions
     summaries: List[ChatSessionSummary] = []
     with _sessions_lock:
         _evict_stale_sessions()
         for sid, s in _sessions.items():
+            if not owns_session(s, owner):
+                continue
             msgs = s.get("messages", [])
             if not msgs:  # skip empty sessions (created but never used)
                 continue
@@ -225,12 +267,16 @@ async def list_sessions(authenticated: bool = Depends(verify_api_key)):
 
 
 @router.get("/chat/{session_id}", response_model=ChatHistoryResponse, tags=["Chat"])
-async def get_session_history(session_id: str, authenticated: bool = Depends(verify_api_key)):
-    """Return a session's full message history so the UI can reopen the conversation."""
+async def get_session_history(session_id: str, authenticated: bool = Depends(verify_api_key),
+                              owner: Optional[str] = Depends(current_owner)):
+    """Return a session's full message history so the UI can reopen the conversation.
+
+    Another key's session reads as 404, not 403 — a 403 would confirm the id exists.
+    """
     from deps import _sessions, _sessions_lock
     with _sessions_lock:
         s = _sessions.get(session_id)
-        if s is None:
+        if not owns_session(s, owner):
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Session '{session_id}' not found.")
         return ChatHistoryResponse(
             session_id=session_id,
@@ -244,12 +290,13 @@ async def get_session_history(session_id: str, authenticated: bool = Depends(ver
 async def delete_session(
     session_id: str,
     authenticated: bool = Depends(verify_api_key),
+    owner: Optional[str] = Depends(current_owner),
 ):
-    """Delete a chat session and its history."""
+    """Delete a chat session and its history. Only the owning key may delete."""
     import persistence
     from deps import _sessions, _sessions_lock
     with _sessions_lock:
-        if session_id not in _sessions:
+        if not owns_session(_sessions.get(session_id), owner):
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Session '{session_id}' not found.")
         del _sessions[session_id]
         persistence.delete_session(session_id)

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -117,7 +117,8 @@ async def chat(
             logger.error(f"Error in /chat: {e}", exc_info=True)
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail={"error": "Internal server error. Please try again.", "code": "INTERNAL_ERROR"})
 
-        _append_session_messages(session_id, body.message, result["answer"], owner)
+        _append_session_messages(session_id, body.message, result["answer"], owner,
+                                 result.get("citations"))
 
     processing_time = time.time() - start_time
     logger.info(
@@ -189,6 +190,7 @@ async def chat_stream(
     async def _stream_and_save():
         full_answer: list[str] = []
         final_answer: str | None = None  # compacted answer from the done event
+        final_cites: list = []           # its citations, stored with the turn
         hit_error = False
         try:
             async for event in sse_stream(prepared["prompt"], prepared["metadatas"], prepared["detected_lang"],
@@ -202,6 +204,9 @@ async def chat_stream(
                     payload = json.loads(event[6:])
                     payload["session_id"] = session_id
                     final_answer = payload.get("answer")
+                    # The done event already carries the resolved citations; keep
+                    # them so reopening this turn from history can redraw sources.
+                    final_cites = payload.get("citations") or []
                     yield f"data: {json.dumps(payload)}\n\n"
                 else:
                     if event.startswith('data: {"type": "chunk"'):
@@ -214,7 +219,8 @@ async def chat_stream(
                 # Persist the compacted answer, not the raw streamed chunks — otherwise
                 # the follow-up turns inherit gapped and dangling [N] markers.
                 _append_session_messages(
-                    session_id, body.message, final_answer or "".join(full_answer), owner)
+                    session_id, body.message, final_answer or "".join(full_answer), owner,
+                    final_cites)
         finally:
             # Runs on normal completion, on an error, and on GeneratorExit when the
             # client disconnects mid-stream — the turn is over in all three cases.

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -91,7 +91,7 @@ async def chat(
 
     # The lock spans read-history -> generate -> append: concurrent turns on one
     # session must not each answer from a history that omits the other's turn.
-    async with session_turn_lock(body.session_id or "new"):
+    async with session_turn_lock(body.session_id):
         try:
             session_id, messages = _get_or_create_session(body.session_id, owner)
         except PermissionError:
@@ -158,7 +158,7 @@ async def chat_stream(
     # is not finished when this function returns — it ends when the generator
     # below appends the answer. The generator's `finally` is what releases it,
     # so a client disconnect mid-stream can't strand the lock.
-    lock = session_turn_lock(body.session_id or "new")
+    lock = session_turn_lock(body.session_id)
     await lock.acquire()
     try:
         try:

--- a/routes/feedback.py
+++ b/routes/feedback.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field, field_validator
 
 import config
 import persistence
-from deps import verify_api_key
+from deps import verify_api_key, current_owner
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -38,12 +38,13 @@ class FeedbackResponse(BaseModel):
 async def submit_feedback(
     body: FeedbackRequest,
     authenticated: bool = Depends(verify_api_key),
+    owner: Optional[str] = Depends(current_owner),
 ):
     """Record thumbs up/down feedback for a previously returned answer."""
     feedback_id = str(uuid.uuid4())
     persistence.save_feedback(
         feedback_id, body.query_id, body.rating, body.comment or "",
-        datetime.now(timezone.utc).isoformat(),
+        datetime.now(timezone.utc).isoformat(), owner,
     )
     return FeedbackResponse(status="recorded", feedback_id=feedback_id)
 
@@ -53,15 +54,22 @@ async def list_feedback(
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     authenticated: bool = Depends(verify_api_key),
+    owner: Optional[str] = Depends(current_owner),
 ):
-    """Return feedback entries joined with their query context, newest first."""
-    return persistence.get_feedback_with_context(limit, offset)
+    """Return the caller's feedback entries joined with their query context, newest first.
+
+    Scoped by API-key fingerprint: the joined `query_log` rows carry the original
+    question and answer text, so an unscoped listing handed every user's queries
+    to anyone holding any valid key.
+    """
+    return persistence.get_feedback_with_context(limit, offset, owner=owner)
 
 
 @router.get("/feedback/stats", tags=["Feedback"])
-async def get_feedback_stats(authenticated: bool = Depends(verify_api_key)):
-    """Aggregate feedback totals and per-language approval rates."""
-    return persistence.feedback_stats()
+async def get_feedback_stats(authenticated: bool = Depends(verify_api_key),
+                             owner: Optional[str] = Depends(current_owner)):
+    """Aggregate feedback totals and per-language approval rates for the caller."""
+    return persistence.feedback_stats(owner=owner)
 
 
 class PrefsRequest(BaseModel):
@@ -79,14 +87,28 @@ def _require_enabled():
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User preferences are not enabled")
 
 
+def _prefs_key(user_id: str, owner: Optional[str]) -> str:
+    """Storage key for a user's preferences.
+
+    When auth is on, prefs are stored against the API-key fingerprint, not the
+    `{user_id}` in the path — otherwise anyone could read or overwrite anyone
+    else's preferences just by typing their id into the URL. The path segment
+    stays in the response so existing clients keep working.
+    """
+    return owner if owner is not None else user_id
+
+
 @router.get("/prefs/{user_id}", response_model=PrefsResponse, tags=["Preferences"])
-async def get_user_prefs(user_id: str, authenticated: bool = Depends(verify_api_key)):
+async def get_user_prefs(user_id: str, authenticated: bool = Depends(verify_api_key),
+                         owner: Optional[str] = Depends(current_owner)):
     _require_enabled()
-    return PrefsResponse(user_id=user_id, prefs=persistence.get_prefs(user_id))
+    return PrefsResponse(user_id=user_id, prefs=persistence.get_prefs(_prefs_key(user_id, owner)))
 
 
 @router.put("/prefs/{user_id}", response_model=PrefsResponse, tags=["Preferences"])
-async def put_user_prefs(user_id: str, body: PrefsRequest, authenticated: bool = Depends(verify_api_key)):
+async def put_user_prefs(user_id: str, body: PrefsRequest, authenticated: bool = Depends(verify_api_key),
+                         owner: Optional[str] = Depends(current_owner)):
     _require_enabled()
-    persistence.save_prefs(user_id, body.prefs, datetime.now(timezone.utc).isoformat())
+    persistence.save_prefs(_prefs_key(user_id, owner), body.prefs,
+                           datetime.now(timezone.utc).isoformat())
     return PrefsResponse(user_id=user_id, prefs=body.prefs)

--- a/routes/feedback.py
+++ b/routes/feedback.py
@@ -102,13 +102,17 @@ def _prefs_key(user_id: str, owner: Optional[str]) -> str:
 async def get_user_prefs(user_id: str, authenticated: bool = Depends(verify_api_key),
                          owner: Optional[str] = Depends(current_owner)):
     _require_enabled()
-    return PrefsResponse(user_id=user_id, prefs=persistence.get_prefs(_prefs_key(user_id, owner)))
+    # Echo the key actually read, not the path segment: with auth on those differ,
+    # and returning the path id makes a response about your own prefs look like a
+    # response about someone else's.
+    key = _prefs_key(user_id, owner)
+    return PrefsResponse(user_id=key, prefs=persistence.get_prefs(key))
 
 
 @router.put("/prefs/{user_id}", response_model=PrefsResponse, tags=["Preferences"])
 async def put_user_prefs(user_id: str, body: PrefsRequest, authenticated: bool = Depends(verify_api_key),
                          owner: Optional[str] = Depends(current_owner)):
     _require_enabled()
-    persistence.save_prefs(_prefs_key(user_id, owner), body.prefs,
-                           datetime.now(timezone.utc).isoformat())
-    return PrefsResponse(user_id=user_id, prefs=body.prefs)
+    key = _prefs_key(user_id, owner)
+    persistence.save_prefs(key, body.prefs, datetime.now(timezone.utc).isoformat())
+    return PrefsResponse(user_id=key, prefs=body.prefs)

--- a/routes/ingest.py
+++ b/routes/ingest.py
@@ -17,7 +17,8 @@ from pydantic import BaseModel, Field, field_validator
 import config
 from agent.tool_executor import execute_arxiv_search, execute_open_access_search
 from cache_refresh import _post_ingest_refresh
-from deps import limiter, verify_api_key, _jobs, _jobs_lock, _update_job
+from deps import (limiter, verify_api_key, _jobs, _jobs_lock, _update_job,
+                  touch_job_lease)
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -223,6 +224,9 @@ def _make_progress_cb(job_id: str):
                 job["progress_current"] = current
                 job["progress_total"] = total
                 job["progress_message"] = message
+        # Keep the SQLite lease alive: without this a long run is reaped as
+        # abandoned while it is still making progress.
+        touch_job_lease(job_id)
     return _cb
 
 

--- a/routes/query.py
+++ b/routes/query.py
@@ -200,7 +200,8 @@ async def health_check(deep: bool = False):
 async def query_question(
     request: Request,
     body: QueryRequest,
-    authenticated: bool = Depends(verify_api_key)
+    authenticated: bool = Depends(verify_api_key),
+    owner: Optional[str] = Depends(current_owner),
 ):
     """
     Answer a question in any language using the RAG system.
@@ -255,6 +256,7 @@ async def query_question(
                 language=result['language'], confidence=result.get('answer_confidence', 0.0),
                 coverage=citation_coverage(result['answer']),
                 created_at=datetime.now(timezone.utc).isoformat(),
+                owner=owner,
             )
         except Exception:
             logger.warning("Failed to log query for feedback correlation", exc_info=True)

--- a/routes/query.py
+++ b/routes/query.py
@@ -113,6 +113,10 @@ class QueryResponse(BaseModel):
     timestamp: str
     confidence: float = 0.0
     evidence: List[dict] = []
+    # None on the normal path. 'sparse_only' means the dense retrieval leg was
+    # unavailable and this answer came from BM25 alone — lower quality, and the
+    # client should say so rather than presenting it as a normal answer.
+    degraded: Optional[str] = None
 
 
 class HealthResponse(BaseModel):
@@ -272,6 +276,7 @@ async def query_question(
             timestamp=datetime.now(timezone.utc).isoformat(),
             confidence=result.get('answer_confidence', 0.0),
             evidence=result.get('faithfulness', []),
+            degraded=result.get('degraded'),
         )
 
     except ValueError as e:
@@ -318,7 +323,8 @@ async def query_stream(
         sse_stream(prepared["prompt"], prepared["metadatas"], prepared["detected_lang"],
                    strategy=body.strategy, query_id=query_id,
                    model=body.model, provider=body.provider,
-                   visible_chunks=prepared["chunks_used"]),
+                   visible_chunks=prepared["chunks_used"],
+                   degraded=prepared.get("degraded")),
         media_type="text/event-stream",
     )
 

--- a/routes/report.py
+++ b/routes/report.py
@@ -13,12 +13,12 @@ from typing import Optional
 import logging
 import uuid
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, Field
 
 import config
 import persistence
-from deps import verify_api_key, _jobs, _jobs_lock, _update_job
+from deps import limiter, verify_api_key, current_owner, _jobs, _jobs_lock, _update_job
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -67,8 +67,12 @@ def _make_progress_cb(job_id: str):
     return _cb
 
 
-def _run_report_job(job_id: str, topic: str, language: str):
-    """Background worker: build the report and store the Markdown on the job."""
+def _run_report_job(job_id: str, topic: str, language: str, owner: Optional[str] = None):
+    """Background worker: build the report and store the Markdown on the job.
+
+    `owner` is carried through so the persisted artifact is scoped to the key that
+    requested it — GET /reports filters on it.
+    """
     import report_runner
     _update_job(job_id, status="running")
     try:
@@ -85,7 +89,7 @@ def _run_report_job(job_id: str, topic: str, language: str):
         persistence.save_report(
             report_id=job_id, watch_id="", topic=topic, language=language,
             markdown=result["markdown"], citation_count=result["citation_count"],
-            created_at=completed_at,
+            created_at=completed_at, owner=owner,
         )
         logger.info(f"[Report] job {job_id} finished ({len(result['sections'])} sections)")
     except Exception as e:
@@ -95,45 +99,58 @@ def _run_report_job(job_id: str, topic: str, language: str):
 
 
 @router.post("/report", response_model=ReportJobResponse, status_code=202, tags=["Report"])
-async def create_report(body: ReportRequest, background_tasks: BackgroundTasks,
-                        authenticated: bool = Depends(verify_api_key)):
-    """Start a literature-review report job. Returns 202 with a job_id to poll."""
+@limiter.limit("5/minute")
+async def create_report(request: Request, body: ReportRequest, background_tasks: BackgroundTasks,
+                        authenticated: bool = Depends(verify_api_key),
+                        owner: Optional[str] = Depends(current_owner)):
+    """Start a literature-review report job. Returns 202 with a job_id to poll.
+
+    Rate-limited: each call decomposes a topic and synthesizes every section, so
+    an unbounded loop here drains the shared LLM quota for every other user.
+    """
     _require_enabled()
     job_id = str(uuid.uuid4())
     with _jobs_lock:
         _jobs[job_id] = {
-            "job_id": job_id, "status": "pending",
+            "job_id": job_id, "status": "pending", "owner": owner,
             "topic": body.topic, "language": body.language,
             "sections": None, "citation_count": None, "markdown": None, "error": None,
             "submitted_at": datetime.now(timezone.utc).isoformat(), "completed_at": None,
             "progress_current": 0, "progress_total": None, "progress_message": "Queued",
         }
-    background_tasks.add_task(_run_report_job, job_id, body.topic, body.language)
+    background_tasks.add_task(_run_report_job, job_id, body.topic, body.language, owner)
     logger.info(f"[Report] job {job_id} queued topic={body.topic!r}")
     return ReportJobResponse(job_id=job_id, status="pending",
                              message="Report started. Poll /report/status/{job_id}.")
 
 
-def _get_report_job(job_id: str) -> dict:
+def _get_report_job(job_id: str, owner: Optional[str] = None) -> dict:
     with _jobs_lock:
         job = _jobs.get(job_id)
     if job is None or "topic" not in job:  # 'topic' distinguishes a report job from an ingest job
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Report job '{job_id}' not found.")
+    # 404 rather than 403 on an ownership mismatch, matching the ingest-job rule in
+    # routes/query.py — a 403 would confirm the job id exists.
+    if owner is not None and job.get("owner") != owner:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Report job '{job_id}' not found.")
     return job
 
 
 @router.get("/report/status/{job_id}", response_model=ReportStatusResponse, tags=["Report"])
-async def get_report_status(job_id: str, authenticated: bool = Depends(verify_api_key)):
+async def get_report_status(job_id: str, authenticated: bool = Depends(verify_api_key),
+                            owner: Optional[str] = Depends(current_owner)):
     _require_enabled()
-    job = _get_report_job(job_id)
-    return ReportStatusResponse(**{k: v for k, v in job.items() if k != "markdown"})
+    job = _get_report_job(job_id, owner)
+    return ReportStatusResponse(**{k: v for k, v in job.items()
+                                   if k not in ("markdown", "owner")})
 
 
 @router.get("/report/{job_id}/download", tags=["Report"])
-async def download_report(job_id: str, authenticated: bool = Depends(verify_api_key)):
+async def download_report(job_id: str, authenticated: bool = Depends(verify_api_key),
+                          owner: Optional[str] = Depends(current_owner)):
     """Download the finished report as a Markdown attachment."""
     _require_enabled()
-    job = _get_report_job(job_id)
+    job = _get_report_job(job_id, owner)
     if job.get("status") != "success" or not job.get("markdown"):
         raise HTTPException(status_code=status.HTTP_409_CONFLICT,
                             detail=f"Report not ready (status: {job.get('status')}).")
@@ -145,19 +162,24 @@ async def download_report(job_id: str, authenticated: bool = Depends(verify_api_
 
 
 @router.get("/reports", tags=["Report"])
-async def list_persisted_reports(watch_id: str = None, authenticated: bool = Depends(verify_api_key)):
+async def list_persisted_reports(watch_id: str = None, authenticated: bool = Depends(verify_api_key),
+                                 owner: Optional[str] = Depends(current_owner)):
     """List durably-stored reports (survives restart), newest first.
 
     Distinct from GET /report/status/{job_id}: that's the in-memory job store
     for a report still being generated; this is the persisted artifact,
     including watch-owned living reviews that get regenerated in place.
+
+    Scoped to the caller's own reports — a report body is generated from that
+    user's topic and corpus and is not shared across keys.
     """
-    return persistence.list_reports(watch_id)
+    return persistence.list_reports(watch_id, owner=owner)
 
 
 @router.get("/reports/{report_id}", tags=["Report"])
-async def get_persisted_report(report_id: str, authenticated: bool = Depends(verify_api_key)):
-    report = persistence.get_report(report_id)
+async def get_persisted_report(report_id: str, authenticated: bool = Depends(verify_api_key),
+                               owner: Optional[str] = Depends(current_owner)):
+    report = persistence.get_report(report_id, owner=owner)
     if report is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Report '{report_id}' not found.")
     return report

--- a/routes/report.py
+++ b/routes/report.py
@@ -18,7 +18,8 @@ from pydantic import BaseModel, Field
 
 import config
 import persistence
-from deps import limiter, verify_api_key, current_owner, _jobs, _jobs_lock, _update_job
+from deps import (limiter, verify_api_key, current_owner, _jobs, _jobs_lock, _update_job,
+                  touch_job_lease)
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -64,6 +65,9 @@ def _make_progress_cb(job_id: str):
                 job["progress_current"] = current
                 job["progress_total"] = total
                 job["progress_message"] = message
+        # Keep the SQLite lease alive: without this a long run is reaped as
+        # abandoned while it is still making progress.
+        touch_job_lease(job_id)
     return _cb
 
 

--- a/routes/watch.py
+++ b/routes/watch.py
@@ -12,13 +12,13 @@ from typing import Optional
 import logging
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field, field_validator
 
 import config
 import persistence
-from deps import verify_api_key
+from deps import limiter, verify_api_key, current_owner
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -73,8 +73,14 @@ def _to_response(w: dict) -> WatchResponse:
 
 
 @router.post("/watch", response_model=WatchResponse, tags=["Watch"])
-async def create_watch(body: WatchCreateRequest, authenticated: bool = Depends(verify_api_key)):
-    """Register a topic watch. Runs on POST /watch/{id}/run (or the schedule loop)."""
+async def create_watch(body: WatchCreateRequest, authenticated: bool = Depends(verify_api_key),
+                       owner: Optional[str] = Depends(current_owner)):
+    """Register a topic watch. Runs on POST /watch/{id}/run (or the schedule loop).
+
+    `user_id` is a caller-chosen display label only. Authorization is the API-key
+    fingerprint stored in `owner`; it used to be `user_id`, which the caller
+    supplies and can therefore set to anyone's.
+    """
     _require_enabled()
     now = datetime.now(timezone.utc)
     cadence = body.cadence or config.WATCH_DEFAULT_CADENCE
@@ -83,6 +89,7 @@ async def create_watch(body: WatchCreateRequest, authenticated: bool = Depends(v
     watch = {
         "id": str(uuid.uuid4()),
         "user_id": body.user_id,
+        "owner": owner,
         "topic": body.topic,
         "language": body.language,
         "cadence": cadence,
@@ -97,29 +104,49 @@ async def create_watch(body: WatchCreateRequest, authenticated: bool = Depends(v
     return _to_response(watch)
 
 
+def _owned_watch_or_404(watch_id: str, owner: Optional[str]) -> dict:
+    """Fetch a watch the caller owns, or raise 404.
+
+    404 rather than 403 on a mismatch: a 403 would confirm the id exists.
+    """
+    w = persistence.get_watch(watch_id)
+    if not persistence.owns_watch(w, owner):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Watch not found")
+    return w
+
+
 @router.get("/watch", response_model=list[WatchResponse], tags=["Watch"])
-async def list_watches(user_id: Optional[str] = None, authenticated: bool = Depends(verify_api_key)):
-    """List all watches, or just one user's when user_id is supplied."""
+async def list_watches(user_id: Optional[str] = None, authenticated: bool = Depends(verify_api_key),
+                       owner: Optional[str] = Depends(current_owner)):
+    """List the caller's watches, optionally narrowed to one of their user_id labels.
+
+    `user_id` filters within what the caller already owns — it is not a way to
+    read another key's watches, which is what it used to be.
+    """
     _require_enabled()
-    return [_to_response(w) for w in persistence.list_watches(user_id)]
+    return [_to_response(w) for w in persistence.list_watches(user_id, owner=owner)]
 
 
 @router.get("/watch/{watch_id}", response_model=WatchResponse, tags=["Watch"])
-async def get_watch(watch_id: str, authenticated: bool = Depends(verify_api_key)):
+async def get_watch(watch_id: str, authenticated: bool = Depends(verify_api_key),
+                    owner: Optional[str] = Depends(current_owner)):
     _require_enabled()
-    w = persistence.get_watch(watch_id)
-    if w is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Watch not found")
-    return _to_response(w)
+    return _to_response(_owned_watch_or_404(watch_id, owner))
 
 
 @router.post("/watch/{watch_id}/run", tags=["Watch"])
-async def run_watch_now(watch_id: str, authenticated: bool = Depends(verify_api_key)):
+@limiter.limit("5/minute")
+async def run_watch_now(request: Request, watch_id: str,
+                        authenticated: bool = Depends(verify_api_key),
+                        owner: Optional[str] = Depends(current_owner)):
     """Run a watch immediately: search the topic, ingest new papers, refresh the digest.
 
     Synchronous — ingest blocks, so it runs in a threadpool to keep the event loop free.
+    Rate-limited because each call spends LLM budget (digest generation) and can
+    trigger ingestion; unlimited, it drains the shared quota for every other user.
     """
     _require_enabled()
+    _owned_watch_or_404(watch_id, owner)
     import watch_runner  # lazy: keeps arxiv/ingest imports off the request-path cold start
     try:
         return await run_in_threadpool(watch_runner.run_watch, watch_id)
@@ -128,19 +155,18 @@ async def run_watch_now(watch_id: str, authenticated: bool = Depends(verify_api_
 
 
 @router.get("/watch/{watch_id}/digest", tags=["Watch"])
-async def get_watch_digest(watch_id: str, authenticated: bool = Depends(verify_api_key)):
+async def get_watch_digest(watch_id: str, authenticated: bool = Depends(verify_api_key),
+                           owner: Optional[str] = Depends(current_owner)):
     """Return the watch's latest stored digest (persists between runs)."""
     _require_enabled()
-    w = persistence.get_watch(watch_id)
-    if w is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Watch not found")
+    w = _owned_watch_or_404(watch_id, owner)
     return {"watch_id": watch_id, "digest": w.get("latest_digest"), "last_run": w.get("last_run")}
 
 
 @router.delete("/watch/{watch_id}", tags=["Watch"])
-async def delete_watch(watch_id: str, authenticated: bool = Depends(verify_api_key)):
+async def delete_watch(watch_id: str, authenticated: bool = Depends(verify_api_key),
+                       owner: Optional[str] = Depends(current_owner)):
     _require_enabled()
-    if persistence.get_watch(watch_id) is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Watch not found")
+    _owned_watch_or_404(watch_id, owner)
     persistence.delete_watch(watch_id)
     return {"status": "deleted", "id": watch_id}

--- a/sse_utils.py
+++ b/sse_utils.py
@@ -23,7 +23,7 @@ INTERRUPTED_NOTE = (
 async def sse_stream(prompt: str, metadatas: list, language: str, strategy: str = "A",
                       max_tokens: int = None, query_id: str = None,
                       model: str = None, provider: str = None,
-                      visible_chunks: int = None):
+                      visible_chunks: int = None, degraded: str = None):
     """Async SSE generator: bridges sync llm_generate_stream via asyncio.Queue.
 
     Strategy B + Indic target language: buffers all chunks, translates the full
@@ -104,7 +104,9 @@ async def sse_stream(prompt: str, metadatas: list, language: str, strategy: str 
                 pass  # fall back to English
             yield f"data: {json.dumps({'type': 'chunk', 'text': compacted})}\n\n"
 
-        yield f"data: {json.dumps({'type': 'done', 'answer': compacted, 'citations': citations, 'language': language, 'query_id': query_id})}\n\n"
+        # `degraded` rides on the done event so a streaming client learns the answer
+        # came from a reduced pipeline — it has no other way to find out.
+        yield f"data: {json.dumps({'type': 'done', 'answer': compacted, 'citations': citations, 'language': language, 'query_id': query_id, 'degraded': degraded})}\n\n"
         yield "data: [DONE]\n\n"
     finally:
         stop_event.set()

--- a/static/index.html
+++ b/static/index.html
@@ -334,8 +334,12 @@ table.tbl tbody tr:hover{background:var(--paper-2);}
 .scrim{position:fixed;inset:0;background:rgba(20,22,31,.4);backdrop-filter:blur(0px);
   display:flex;opacity:0;visibility:hidden;z-index:100;align-items:flex-start;
   justify-content:center;padding-top:12vh;
+  pointer-events:none;
   transition:opacity .2s ease,backdrop-filter .2s ease,visibility 0s .2s;}
-.scrim.on{opacity:1;visibility:visible;backdrop-filter:blur(3px);transition-delay:0s,0s,0s;}
+/* Two independent guards (visibility + pointer-events): the scrim covers the
+   whole viewport, so a single failed guard would make the app unclickable. */
+.scrim.on{opacity:1;visibility:visible;pointer-events:auto;backdrop-filter:blur(3px);
+  transition-delay:0s,0s,0s;}
 /* Closest single curve to a critically-damped spring (damping 1.0, response ~.3) */
 .scrim>*{transform:scale(.97) translateY(-6px);transition:transform .3s cubic-bezier(.32,.72,0,1);}
 .scrim.on>*{transform:none;}
@@ -963,7 +967,11 @@ $('#evBtn').addEventListener('click', () => {
 
 // ══ COMMAND PALETTE ════════════════════════════════════════
 const scrim = $('#scrim');
-function openPal() { scrim.classList.add('on'); $('#palInput').focus(); }
+function openPal() {
+  scrim.classList.add('on');
+  // Next frame: focusing inside a still-hidden ancestor is ignored.
+  requestAnimationFrame(() => $('#palInput').focus());
+}
 function closePal() { scrim.classList.remove('on'); $('#palInput').value = ''; }
 $('#palBtn').addEventListener('click', openPal);
 scrim.addEventListener('click', e => { if (e.target === scrim) closePal(); });

--- a/static/index.html
+++ b/static/index.html
@@ -63,6 +63,29 @@ a{color:var(--indigo);text-decoration:none;}
 ::-webkit-scrollbar-track{background:transparent;}
 
 
+/* ── AGENT PROGRESS ───────────────────────────────────── */
+/* An agentic run takes 1-3 minutes. It previously showed a bare caret for most
+   of that, which is indistinguishable from a hang. These steps arrive from the
+   graph as each node finishes, so the wait reports what is actually happening. */
+.agent-progress{border:1px solid var(--rule);border-radius:11px;padding:12px 14px;background:var(--paper-2);}
+.ap-head{display:flex;align-items:center;gap:9px;margin-bottom:9px;}
+.ap-label{font-size:13px;font-weight:500;color:var(--ink);flex:1;}
+.ap-time{font-size:11px;color:var(--ink-4);font-variant-numeric:tabular-nums;}
+.ap-steps{display:flex;flex-direction:column;gap:5px;}
+.ap-step{display:flex;align-items:center;gap:8px;font-size:12.5px;color:var(--ink-3);}
+.ap-step .dot{width:6px;height:6px;border-radius:50%;background:var(--rule-hard);flex-shrink:0;
+  transition:background .2s ease;}
+.ap-step.done{color:var(--ink-2);}
+.ap-step.done .dot{background:var(--patina);}
+.ap-step.active{color:var(--indigo);font-weight:500;}
+.ap-step.active .dot{background:var(--indigo);}
+.ap-note{margin-top:10px;padding-top:9px;border-top:1px dashed var(--rule);
+  font-size:11px;color:var(--ink-4);line-height:1.4;}
+/* Bounded, non-vestibular: a slow pulse rather than a spinner that implies
+   imminent completion. 1.4s is well clear of the ~0.2Hz discomfort range. */
+.ap-spin{width:9px;height:9px;border-radius:50%;background:var(--indigo);flex-shrink:0;
+  animation:pulse 1.4s ease-in-out infinite;}
+
 /* ── PRESS FEEDBACK ───────────────────────────────────── */
 /* Feedback belongs on the press, not the release: waiting for :hover or a
    completed click reads as "the computer answered my request" rather than
@@ -1245,6 +1268,28 @@ function clearEvidence() {
   currentRunId = null;
 }
 
+function renderSourcePreview(sources) {
+  // Mid-run preview: what retrieval found, shown while the answer is still being
+  // written. Deliberately NOT the final list — citation numbers are only decided
+  // once the answer exists, and some of these may not end up cited at all. So no
+  // scores and no spectrum here: inventing a relevance number for a provisional
+  // list would be worse than showing none. updateEvidenceSources() replaces this
+  // wholesale on the done event.
+  if (!sources.length) return;
+  $('#evSrcCount').textContent = sources.length;
+  $('#chunksList').innerHTML =
+    '<div class="ap-note" style="margin:0 0 8px;padding:0;border:none">Retrieved — ' +
+    'still checking which are cited</div>' +
+    sources.map(s =>
+      '<div class="chunk" style="opacity:.72">' +
+        '<div class="chunk-top">' +
+          '<span class="chunk-n">' + esc(String(s.number)) + '</span>' +
+          '<span class="chunk-src">' + esc(s.title || '') +
+            (s.section ? ' · ' + esc(s.section) : '') + '</span>' +
+        '</div>' +
+      '</div>').join('');
+}
+
 function updateEvidenceSources(cites, data) {
   // Sources
   const srcCount = cites.length;
@@ -1443,8 +1488,12 @@ function fbButtons(qid) {
   return '<button class="tact good" title="Accurate" onclick="sendFeedback(\'' + qid + '\',\'up\',this)"><svg viewBox="0 0 24 24"><path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.3a2 2 0 0 0 2-1.7l1.4-9a2 2 0 0 0-2-2.3z"/><path d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/></svg></button><button class="tact bad" title="Not supported" onclick="sendFeedback(\'' + qid + '\',\'down\',this)"><svg viewBox="0 0 24 24"><path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.7a2 2 0 0 0-2 1.7l-1.4 9a2 2 0 0 0 2 2.3z"/><path d="M17 2h3a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2h-3"/></svg></button>';
 }
 
+let agentProgressTimer = null;
+function stopAgentTimer() { if (agentProgressTimer) { clearInterval(agentProgressTimer); agentProgressTimer = null; } }
+
 async function sendMessage() {
   if (isLoading) return;
+  stopAgentTimer();   // a previous run's timer must never outlive its turn
   const input = $('#ta');
   const text = input.value.trim();
   if (!text) return;
@@ -1471,9 +1520,28 @@ async function sendMessage() {
       // Build streaming turn
       const turnDiv = document.createElement('div');
       turnDiv.className = 'turn-asst';
-      turnDiv.innerHTML = '<div class="asst-meta"><span class="pill ag">Agentic</span><span class="pill">Streaming</span></div><div class="asst-body" id="streamBody"><span style="opacity:.35">▍</span></div>';
+      turnDiv.innerHTML = '<div class="asst-meta"><span class="pill ag">Agentic</span><span class="pill">Streaming</span></div>' +
+        '<div class="asst-body" id="streamBody">' +
+        '<div class="agent-progress" id="agentProgress" role="status" aria-live="polite">' +
+          '<div class="ap-head"><span class="ap-spin"></span>' +
+            '<span class="ap-label" id="apLabel">Starting the agent…</span>' +
+            '<span class="ap-time mono" id="apTime">0s</span></div>' +
+          '<div class="ap-steps" id="apSteps"></div>' +
+          '<div class="ap-note">Agentic mode plans the query, searches your corpus and external sources, ' +
+            'then checks the answer against what it found. This usually takes 1&ndash;3 minutes.</div>' +
+        '</div></div>';
       $('#threadContent').appendChild(turnDiv);
       scrollThread();
+
+      // An unbounded wait is far worse than a long one. The elapsed counter turns
+      // "is this broken?" into "it has been running 40 seconds", which the note
+      // above gives the user a scale for.
+      const runStart = Date.now();
+      agentProgressTimer = setInterval(() => {
+        const el = document.getElementById('apTime');
+        if (el) el.textContent = Math.round((Date.now() - runStart) / 1000) + 's';
+      }, 1000);
+      const stopTimer = stopAgentTimer;
 
       let acc = '', buf = '';
       const reader = res.body.getReader(), dec = new TextDecoder();
@@ -1487,19 +1555,43 @@ async function sendMessage() {
           const raw = ln.slice(6);
           if (raw === '[DONE]') break outer;
           let evt; try { evt = JSON.parse(raw); } catch { continue; }
-          if (evt.type === 'thinking') {
+          if (evt.type === 'progress') {
+            // One line per graph node, as it finishes. The previous step is marked
+            // done so the list reads as a route travelled, not a spinner.
+            const steps = document.getElementById('apSteps');
+            const label = document.getElementById('apLabel');
+            if (steps) {
+              const prev = steps.querySelector('.ap-step.active');
+              if (prev) { prev.classList.remove('active'); prev.classList.add('done'); }
+              const row = document.createElement('div');
+              row.className = 'ap-step active';
+              row.innerHTML = '<span class="dot"></span><span></span>';
+              row.lastChild.textContent = evt.text;
+              steps.appendChild(row);
+              scrollThread();
+            }
+            if (label) label.textContent = evt.text;
+          } else if (evt.type === 'sources_preview') {
+            // Retrieval is done well before the answer is written; showing what was
+            // found turns dead waiting time into something the user can read.
+            renderSourcePreview(evt.sources || []);
+          } else if (evt.type === 'thinking') {
             // Show thinking as a subtle indicator
             const thinkEl = turnDiv.querySelector('.asst-meta');
             if (thinkEl && !thinkEl.querySelector('.pill.think')) {
               thinkEl.innerHTML += '<span class="pill think" style="opacity:.7">' + esc(evt.text) + '</span>';
             }
           } else if (evt.type === 'chunk') {
+            // First real token: the progress panel has done its job, replace it.
             acc += evt.text;
+            stopTimer();
             $('#streamBody').innerHTML = renderContent(acc) + '<span style="opacity:.35">▍</span>';
             scrollThread();
           } else if (evt.type === 'error') {
+            stopTimer();
             throw new Error(evt.message);
           } else if (evt.type === 'done') {
+            stopTimer();
             const cites = evt.citations || [];
             if (evt.session_id) sessionId = evt.session_id;
             // Streamed chunks can carry the model's raw [N] markers; when the done
@@ -1582,6 +1674,9 @@ async function sendMessage() {
     $('#threadContent').appendChild(errDiv);
     scrollThread();
   } finally {
+    // Covers every exit: done, error, and the Stop button (AbortError returns
+    // from the catch above without reaching the rest of the happy path).
+    stopAgentTimer();
     resetSendBtn();
     input.focus();
   }

--- a/static/index.html
+++ b/static/index.html
@@ -1119,15 +1119,28 @@ window.openSession = async function (sid) {
     sessionId = sid;
     $('#threadContent').innerHTML = '';
     clearEvidence();
+    let lastCitations = null;
     for (const msg of (data.messages || [])) {
       if (msg.role === 'user') { appendUserTurn(msg.content || ''); }
       else if (msg.role === 'assistant') {
+        const cites = msg.citations || [];
+        if (cites.length) lastCitations = cites;
         const div = document.createElement('div');
         div.className = 'turn-asst';
-        div.innerHTML = '<div class="asst-meta"><span class="pill">History</span><span class="turn-acts">' + COPY_BTN + '</span></div>' +
+        div.innerHTML = '<div class="asst-meta"><span class="pill">History</span>' +
+          (cites.length ? '<span class="pill">' + cites.length + ' source' + (cites.length > 1 ? 's' : '') + '</span>' : '') +
+          '<span class="turn-acts">' + COPY_BTN + '</span></div>' +
           '<div class="asst-body">' + renderContent(msg.content || '') + '</div>';
         $('#threadContent').appendChild(div);
       }
+    }
+    // Reopening a conversation used to leave the evidence panel blank: the panel
+    // was cleared above and nothing repopulated it, because citations were never
+    // stored with the turn. They are now, so redraw from the most recent answer
+    // that had any — matching what the panel showed when that turn was live.
+    if (lastCitations) {
+      lastCites = lastCitations;
+      updateEvidenceSources(lastCitations, {});
     }
     scrollThread();
   } catch (e) { showToast('Could not load conversation', 'error'); }

--- a/static/index.html
+++ b/static/index.html
@@ -45,7 +45,10 @@
 }
 *{margin:0;padding:0;box-sizing:border-box;}
 html,body{height:100%;}
-body{font-family:'IBM Plex Sans','IBM Plex Sans Devanagari',system-ui,sans-serif;background:var(--paper);color:var(--ink);font-size:14px;line-height:1.55;display:flex;overflow:hidden;-webkit-font-smoothing:antialiased;}
+/* Respect the user's browser text size: a fixed 14px body ignored it entirely.
+   Type is rem so it scales; layout stays px so the shell geometry holds. */
+html{font-size:100%;}
+body{font-family:'IBM Plex Sans','IBM Plex Sans Devanagari',system-ui,sans-serif;background:var(--paper);color:var(--ink);font-size:.875rem;line-height:1.55;display:flex;overflow:hidden;-webkit-font-smoothing:antialiased;}
 :where(:lang(hi),:lang(mr),:lang(ne),.deva){font-family:'IBM Plex Sans Devanagari','IBM Plex Sans',sans-serif;}
 button,input,select,textarea{font:inherit;color:inherit;}
 button{background:none;border:none;cursor:pointer;}
@@ -58,6 +61,26 @@ a{color:var(--indigo);text-decoration:none;}
 ::-webkit-scrollbar{width:9px;height:9px;}
 ::-webkit-scrollbar-thumb{background:var(--rule-hard);border-radius:5px;border:2px solid var(--paper);}
 ::-webkit-scrollbar-track{background:transparent;}
+
+
+/* ── PRESS FEEDBACK ───────────────────────────────────── */
+/* Feedback belongs on the press, not the release: waiting for :hover or a
+   completed click reads as "the computer answered my request" rather than
+   "the thing I touched moved". Transform-only, so it composites. */
+.btn:active,.rail-btn:active,.send:active,.rb:active,.tact:active,
+.iconbtn:active,.ev-tab:active,.searchbtn:active,.cite:active{
+  transform:scale(.97);
+  transition:transform 90ms ease-out;
+}
+/* Large surfaces scale less — the same ratio on a big card reads rubbery. */
+.seed:active,.rb-drop-item:active{transform:scale(.993);transition:transform 90ms ease-out;}
+.degraded-note{
+  display:flex;align-items:flex-start;gap:8px;margin-bottom:14px;padding:9px 11px;
+  border:1px solid var(--amber);background:var(--amber-soft);border-radius:9px;
+  font-size:12.5px;line-height:1.45;color:var(--amber);
+}
+.degraded-note svg{width:15px;height:15px;flex-shrink:0;margin-top:1px;fill:none;
+  stroke:currentColor;stroke-width:1.9;stroke-linecap:round;stroke-linejoin:round;}
 
 /* ── NAV RAIL ─────────────────────────────────────────── */
 .rail{width:var(--rail-w);flex-shrink:0;background:var(--paper-2);border-right:1px solid var(--rule);display:flex;flex-direction:column;align-items:center;padding:10px 0 8px;gap:2px;z-index:40;}
@@ -97,7 +120,7 @@ a{color:var(--indigo);text-decoration:none;}
 .page{flex:1;overflow-y:auto;}
 .page-in{max-width:1080px;margin:0 auto;padding:30px 32px 72px;}
 .page-head{display:flex;align-items:flex-end;gap:16px;margin-bottom:6px;}
-.page-title{font-family:'Instrument Serif',Georgia,serif;font-size:35px;line-height:1.05;letter-spacing:-.4px;}
+.page-title{font-family:'Instrument Serif',Georgia,serif;font-size:clamp(1.75rem,3.2vw,2.19rem);line-height:1.05;letter-spacing:-.012em;}
 .page-sub{color:var(--ink-3);font-size:13.5px;max-width:66ch;margin-bottom:26px;}
 .eyebrow{font-family:'IBM Plex Mono',monospace;font-size:10px;font-weight:500;letter-spacing:1.4px;text-transform:uppercase;color:var(--ink-4);display:flex;align-items:center;gap:9px;margin-bottom:12px;}
 .eyebrow::after{content:'';flex:1;height:1px;background:var(--rule);}
@@ -118,26 +141,26 @@ select.fld{cursor:pointer;padding-right:26px;}
 .thread{flex:1;overflow-y:auto;padding:26px 0 20px;}
 .thread-in{max-width:730px;margin:0 auto;padding:0 28px;}
 .opener{max-width:640px;margin:min(9vh,80px) auto 0;padding:0 28px;}
-.opener h1{font-family:'Instrument Serif',Georgia,serif;font-size:42px;line-height:1.08;letter-spacing:-.6px;margin-bottom:10px;}
+.opener h1{font-family:'Instrument Serif',Georgia,serif;font-size:clamp(2rem,4vw,2.625rem);line-height:1.08;letter-spacing:-.014em;margin-bottom:10px;}
 .opener h1 em{font-style:italic;color:var(--indigo);}
-.opener p{color:var(--ink-3);font-size:14px;max-width:52ch;margin-bottom:26px;}
+.opener p{color:var(--ink-3);font-size:.875rem;max-width:52ch;margin-bottom:26px;}
 .seed-grid{display:grid;grid-template-columns:1fr 1fr;gap:9px;}
 .seed{text-align:left;border:1px solid var(--rule);border-radius:11px;padding:12px 13px;transition:border-color .15s,background .15s;}
 .seed:hover{border-color:var(--indigo-line);background:var(--indigo-soft);}
 .seed .sk{font-family:'IBM Plex Mono',monospace;font-size:9.5px;letter-spacing:1px;text-transform:uppercase;color:var(--ink-4);display:block;margin-bottom:5px;}
 .seed .sv{font-size:13px;color:var(--ink-2);line-height:1.4;}
 .turn-user{display:flex;justify-content:flex-end;margin:0 0 22px;}
-.turn-user .q{background:var(--indigo);color:#fff;padding:9px 14px;border-radius:13px 13px 3px 13px;font-size:14px;max-width:82%;box-shadow:var(--shadow-sm);word-break:break-word;}
+.turn-user .q{background:var(--indigo);color:#fff;padding:9px 14px;border-radius:13px 13px 3px 13px;font-size:.875rem;max-width:82%;box-shadow:var(--shadow-sm);word-break:break-word;}
 .turn-asst{margin-bottom:32px;}
 .asst-meta{display:flex;align-items:center;gap:8px;margin-bottom:11px;flex-wrap:wrap;font-family:'IBM Plex Mono',monospace;font-size:10px;letter-spacing:.7px;text-transform:uppercase;color:var(--ink-4);}
 .asst-meta .pill{border:1px solid var(--rule);border-radius:20px;padding:1.5px 7px;letter-spacing:.5px;color:var(--ink-3);}
 .asst-meta .pill.ag{color:var(--indigo);border-color:var(--indigo-line);background:var(--indigo-soft);}
 .asst-body{border-left:2px solid var(--rule);padding-left:18px;position:relative;}
-.asst-body p{margin-bottom:12px;font-size:14.5px;line-height:1.68;color:var(--ink);}
+.asst-body p{margin-bottom:12px;font-size:.906rem;line-height:1.68;color:var(--ink);}
 .asst-body p:last-child{margin-bottom:0;}
 .asst-body h4{font-family:'IBM Plex Mono',monospace;font-size:10px;letter-spacing:1.3px;text-transform:uppercase;color:var(--ink-4);font-weight:500;margin:20px 0 9px;}
 .asst-body ul{margin:0 0 12px 17px;}
-.asst-body li{margin-bottom:5px;font-size:14.5px;line-height:1.6;}
+.asst-body li{margin-bottom:5px;font-size:.906rem;line-height:1.6;}
 .asst-body pre{background:var(--paper-3);border-radius:6px;padding:10px 12px;font-family:'IBM Plex Mono',monospace;font-size:12px;overflow-x:auto;margin-bottom:12px;color:var(--ink-2);}
 .asst-body code{font-family:'IBM Plex Mono',monospace;font-size:12.5px;background:var(--paper-3);padding:1px 4px;border-radius:3px;}
 .asst-body pre code{background:none;padding:0;}
@@ -149,7 +172,7 @@ select.fld{cursor:pointer;padding-right:26px;}
 .groundbar{display:flex;align-items:center;gap:9px;margin-top:16px;padding-top:13px;border-top:1px dashed var(--rule);flex-wrap:wrap;}
 .groundbar .gl{font-family:'IBM Plex Mono',monospace;font-size:9.5px;letter-spacing:1.1px;text-transform:uppercase;color:var(--ink-4);}
 .gmeter{flex:1;max-width:130px;height:4px;border-radius:2px;background:var(--paper-3);overflow:hidden;}
-.gmeter i{display:block;height:100%;background:var(--patina);border-radius:2px;}
+.gmeter i{display:block;height:100%;background:var(--patina);border-radius:2px;transition:width .5s cubic-bezier(.32,.72,0,1);}
 .gval{font-family:'IBM Plex Mono',monospace;font-size:11.5px;font-weight:600;color:var(--patina);}
 .turn-acts{display:flex;gap:2px;margin-left:auto;}
 .tact{width:26px;height:26px;border-radius:6px;display:grid;place-items:center;color:var(--ink-4);transition:background .13s,color .13s;}
@@ -182,7 +205,7 @@ select.fld{cursor:pointer;padding-right:26px;}
 .rb-drop-sep{height:1px;background:var(--rule);margin:4px 6px;}
 .inputbox{border:1px solid var(--rule-hard);border-radius:14px;background:var(--paper);box-shadow:var(--shadow-sm);transition:border-color .16s,box-shadow .16s;display:flex;align-items:flex-end;gap:8px;padding:8px 8px 8px 12px;}
 .inputbox:focus-within{border-color:var(--indigo);box-shadow:0 0 0 3px var(--indigo-soft);}
-.inputbox textarea{flex:1;border:none;background:none;resize:none;outline:none;font-size:14.5px;line-height:1.55;max-height:150px;padding:5px 0;}
+.inputbox textarea{flex:1;border:none;background:none;resize:none;outline:none;font-size:.906rem;line-height:1.55;max-height:150px;padding:5px 0;}
 .inputbox textarea::placeholder{color:var(--ink-4);}
 .send{width:32px;height:32px;border-radius:9px;background:var(--indigo);color:#fff;display:grid;place-items:center;flex-shrink:0;transition:background .14s;}
 .send:hover{background:var(--indigo-2);}
@@ -190,8 +213,15 @@ select.fld{cursor:pointer;padding-right:26px;}
 .foot-note{text-align:center;font-size:10.5px;color:var(--ink-4);margin-top:7px;font-family:'IBM Plex Mono',monospace;letter-spacing:.4px;}
 
 /* ── EVIDENCE RAIL ────────────────────────────────────── */
-.evidence{width:var(--evidence-w);flex-shrink:0;border-left:1px solid var(--rule);background:var(--paper-2);display:flex;flex-direction:column;overflow:hidden;transition:width .2s ease;}
+/* width animates layout on every frame. transform composites — but collapsing
+   must still reclaim the space, so width stays the mechanism and only the
+   *contents* slide, which is the part the eye follows. */
+.evidence{width:var(--evidence-w);flex-shrink:0;border-left:1px solid var(--rule);
+  background:var(--paper-2);display:flex;flex-direction:column;overflow:hidden;
+  transition:width .28s cubic-bezier(.32,.72,0,1);}
+.evidence>*{transition:transform .28s cubic-bezier(.32,.72,0,1),opacity .18s ease;}
 .evidence.ev-collapsed{width:0;border-left:none;}
+.evidence.ev-collapsed>*{transform:translateX(24px);opacity:0;}
 .ev-tabs{display:flex;border-bottom:1px solid var(--rule);flex-shrink:0;padding:0 6px;}
 .ev-tab{padding:11px 10px 9px;font-size:11.5px;font-weight:500;color:var(--ink-3);border-bottom:2px solid transparent;margin-bottom:-1px;transition:color .14s;display:flex;align-items:center;gap:5px;}
 .ev-tab:hover{color:var(--ink);}
@@ -299,8 +329,16 @@ table.tbl tbody tr:hover{background:var(--paper-2);}
 .num{font-family:'IBM Plex Mono',monospace;font-size:12.5px;text-align:right;}
 
 /* ── COMMAND PALETTE ──────────────────────────────────── */
-.scrim{position:fixed;inset:0;background:rgba(20,22,31,.4);backdrop-filter:blur(3px);display:none;z-index:100;align-items:flex-start;justify-content:center;padding-top:12vh;}
-.scrim.on{display:flex;}
+/* display isn't animatable, so the dialog used to pop. Blur and scale animate
+   together (§ materialize, don't just fade) so the surface reads as arriving. */
+.scrim{position:fixed;inset:0;background:rgba(20,22,31,.4);backdrop-filter:blur(0px);
+  display:flex;opacity:0;visibility:hidden;z-index:100;align-items:flex-start;
+  justify-content:center;padding-top:12vh;
+  transition:opacity .2s ease,backdrop-filter .2s ease,visibility 0s .2s;}
+.scrim.on{opacity:1;visibility:visible;backdrop-filter:blur(3px);transition-delay:0s,0s,0s;}
+/* Closest single curve to a critically-damped spring (damping 1.0, response ~.3) */
+.scrim>*{transform:scale(.97) translateY(-6px);transition:transform .3s cubic-bezier(.32,.72,0,1);}
+.scrim.on>*{transform:none;}
 [data-theme="dark"] .scrim{background:rgba(0,0,0,.6);}
 .pal{width:min(560px,92vw);background:var(--paper);border:1px solid var(--rule-hard);border-radius:14px;box-shadow:var(--shadow-lg);overflow:hidden;}
 .pal-in{display:flex;align-items:center;gap:10px;padding:13px 16px;border-bottom:1px solid var(--rule);}
@@ -348,8 +386,26 @@ table.tbl tbody tr:hover{background:var(--paper-2);}
   .crumb,.searchbtn{display:none;}
   .tbl-wrap{overflow-x:auto;}
 }
+/* Reduced motion means gentler, not none: opacity and colour changes still aid
+   comprehension, so only the vestibular ones (transform, spring, loops) go. */
 @media(prefers-reduced-motion:reduce){
-  *,*::before,*::after{animation-duration:.01ms !important;transition-duration:.01ms !important;}
+  *,*::before,*::after{
+    animation-duration:.01ms !important;
+    animation-iteration-count:1 !important;
+    transition-property:opacity,background-color,border-color,color,box-shadow !important;
+    transition-duration:150ms !important;
+  }
+  .btn:active,.rail-btn:active,.send:active,.rb:active,.tact:active,
+  .iconbtn:active,.seed:active,.scrim>*,.evidence>*{transform:none !important;}
+  .evidence{transition:none !important;}
+}
+@media(prefers-reduced-transparency:reduce){
+  .scrim{backdrop-filter:none !important;background:rgba(20,22,31,.72);}
+  [data-theme="dark"] .scrim{background:rgba(0,0,0,.8);}
+}
+@media(prefers-contrast:more){
+  .btn,.fld,.rb,.seed,.searchbtn{border-color:var(--ink-3);}
+  .asst-meta .pill{border-color:var(--ink-4);}
 }
 </style>
 </head>
@@ -830,8 +886,17 @@ function saveKey() {
   showToast(k ? 'API key saved' : 'API key cleared', 'success');
 }
 // Reopen the key modal on any 401 so the user can fix a wrong/missing key.
+// Also names a 429, which v2.5 made reachable by rate-limiting the endpoints
+// that spend LLM budget (/report, /watch/{id}/run). Without this the user sees
+// a generic failure and retries immediately, which is the worst response.
 function handle401(res) {
   if (res && res.status === 401) { openKeyModal(); showToast('Invalid or missing API key', 'error'); return true; }
+  if (res && res.status === 429) {
+    const retry = res.headers && res.headers.get && res.headers.get('Retry-After');
+    showToast(retry ? ('Rate limit reached — try again in ' + retry + 's')
+                    : 'Rate limit reached — please wait a moment', 'error');
+    return true;
+  }
   return false;
 }
 $('#keyBtn').addEventListener('click', openKeyModal);
@@ -1105,6 +1170,16 @@ function appendAssistantTurn(data) {
   metaParts.push('<span style="margin-left:auto">' + (data.processing_time || 0).toFixed(1) + 's' + (isAgent ? '' : ' · ' + (data.chunks_used || 0) + ' chunks') + '</span>');
 
   const groundedness = data.groundedness || data.grounding_score;
+  // v2.5: the backend flags an answer produced without the dense retrieval leg.
+  // A degraded answer that looks identical to a normal one is worse than an
+  // error, because nothing tells the reader to trust it less.
+  let degradedNote = '';
+  if (data.degraded === 'sparse_only') {
+    degradedNote = '<div class="degraded-note" role="status">' +
+      '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 9v4m0 4h.01M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg>' +
+      '<span>Keyword search only — semantic retrieval was unavailable, so these results may be less relevant.</span></div>';
+  }
+
   let groundbar = '';
   if (groundedness != null) {
     const pct = Math.round(groundedness * 100);
@@ -1129,7 +1204,7 @@ function appendAssistantTurn(data) {
   div.className = 'turn-asst';
   div.innerHTML = '<div class="asst-meta">' + metaParts.join('') +
     '<span class="turn-acts"><button class="tact" title="Copy" onclick="copyAnswer(this)"><svg viewBox="0 0 24 24"><rect x="9" y="9" width="12" height="12" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></span></div>' +
-    '<div class="asst-body">' + renderContent(data.answer || '') + toolsHtml + sourcesList + groundbar + '</div>';
+    '<div class="asst-body">' + degradedNote + renderContent(data.answer || '') + toolsHtml + sourcesList + groundbar + '</div>';
   $('#threadContent').appendChild(div);
 
   // Wire citation hover

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,11 @@
-"""Test isolation: point SQLite session/job persistence at a throwaway file.
+"""Test isolation: point on-disk state at throwaway locations.
 
-Must run before any test module imports config/persistence/deps/api_server,
-so this sets the env var at conftest module level (pytest imports conftest.py
+Must run before any test module imports config/persistence/deps/api_server, so
+this sets the env vars at conftest module level (pytest imports conftest.py
 files before collecting test modules) — a fixture would run too late.
 """
 
+import glob
 import os
 import tempfile
 
@@ -15,4 +16,18 @@ for suffix in ("", "-wal", "-shm"):
     try:
         os.remove(_tmp_db + suffix)
     except FileNotFoundError:
+        pass
+
+# The BM25 index cache defaults to chroma_db/, i.e. real data. Tests build
+# indexes from fake collections, so without this they write fixture-derived
+# files next to the live vector store — including one named after the real
+# collection, which a later server start would happily load.
+_tmp_bm25 = os.path.join(tempfile.gettempdir(), "indicrag_test_bm25")
+os.makedirs(_tmp_bm25, exist_ok=True)
+os.environ["BM25_CACHE_DIR"] = _tmp_bm25
+
+for _stale in glob.glob(os.path.join(_tmp_bm25, "bm25_*")):
+    try:
+        os.remove(_stale)
+    except OSError:
         pass

--- a/tests/integration/test_pipeline_seams.py
+++ b/tests/integration/test_pipeline_seams.py
@@ -1,0 +1,287 @@
+"""Integration tests across the real retrieval pipeline.
+
+Every one of the unit-test files mocks the LLM, the vector store and the
+embeddings, so the seams BETWEEN stages were never exercised — prompt assembly,
+context formatting, citation compaction, chunk truncation, cache population, the
+argument shape one stage hands the next. That is exactly where this codebase's
+shipped bugs came from. From the v2.4 patch notes alone:
+
+  * verify.check_claims was handed (index, text) tuples instead of chunk text,
+    so every answer reported confidence 0.0;
+  * the retrieval cache never populated, because cacheability was checked after
+    the collection was materialized;
+  * the answer generator used the configured default instead of the requested
+    model.
+
+None of those is catchable by a mock that returns whatever the test author
+assumed the real thing returns.
+
+Real here: ChromaDB (a genuine on-disk collection), the BM25 index, RRF fusion,
+format_context, citation extraction and compaction, and the TTL caches.
+
+Stubbed, and why: the embedding model and the LLM. Those are true external
+boundaries — a 2.5 GB model download would make this suite unrunnable in CI, and
+it is not our code under test. The stub embedder returns real vectors of a real
+dimension through the real Chroma code path, so everything on our side of that
+boundary is genuinely exercised.
+
+Marked `integration`: slower than the unit suite and excluded by CI's default
+selector.
+"""
+
+import numpy as np
+import pytest
+
+import bm25_search
+import cache
+import config
+import embeddings
+import rag
+import vector_store
+
+pytestmark = pytest.mark.integration
+
+
+CORPUS = [
+    # (paper_id, title, section, text)
+    ("antenna_ml", "Machine Learning for Antenna Design", "abstract",
+     "We apply machine learning to antenna design, optimizing patch antenna "
+     "geometry with neural networks for wideband performance."),
+    ("antenna_ml", "Machine Learning for Antenna Design", "methods",
+     "The tandem neural network uses a smooth thresholding function to force "
+     "discrete pixel values in the antenna geometry during optimization."),
+    ("antenna_ml", "Machine Learning for Antenna Design", "results",
+     "The optimized antennas are 50 percent more compact while maintaining "
+     "gain and radiation efficiency across the band."),
+    ("qubit_ec", "Surface Codes for Qubit Error Correction", "abstract",
+     "Surface codes provide fault tolerant quantum error correction for "
+     "superconducting qubit arrays with high threshold."),
+    ("qubit_ec", "Surface Codes for Qubit Error Correction", "methods",
+     "Syndrome extraction circuits measure stabilizers on the qubit lattice "
+     "without collapsing the encoded logical state."),
+    ("protein_fold", "Transformers for Protein Folding", "abstract",
+     "Transformer architectures predict protein tertiary structure from amino "
+     "acid sequence using attention over residue pairs."),
+]
+
+
+def _fake_embed(texts):
+    """Deterministic bag-of-words vectors.
+
+    Not a random stub: texts sharing vocabulary land near each other, so cosine
+    distance is meaningful and the dense leg actually ranks. That is what lets
+    these tests assert on retrieval ORDER rather than merely on plumbing.
+    """
+    dim = 64
+    out = np.zeros((len(texts), dim), dtype=np.float32)
+    for i, t in enumerate(texts):
+        for tok in str(t).lower().split():
+            out[i, hash(tok) % dim] += 1.0
+        norm = np.linalg.norm(out[i])
+        if norm:
+            out[i] /= norm
+    return out
+
+
+@pytest.fixture
+def pipeline(tmp_path, monkeypatch):
+    """A real ChromaDB collection loaded with the corpus above."""
+    monkeypatch.setattr(config, "CHROMA_DB_DIR", tmp_path / "chroma")
+    monkeypatch.setattr(config, "BM25_CACHE_DIR", tmp_path / "bm25")
+    monkeypatch.setattr(config, "COLLECTION_NAME", "seams")
+    monkeypatch.setattr(config, "USE_RERANKER", False)      # avoids a model download
+    monkeypatch.setattr(config, "USE_HYBRID_SEARCH", True)
+    monkeypatch.setattr(vector_store, "_chroma_client", None)
+
+    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, **k: _fake_embed(texts))
+    monkeypatch.setattr(embeddings, "embed_query", lambda q: _fake_embed([q])[0])
+    monkeypatch.setattr(embeddings, "embed_passages", lambda p, **k: _fake_embed(p))
+    monkeypatch.setattr(rag.embeddings, "embed_query", lambda q: _fake_embed([q])[0])
+
+    bm25_search.invalidate()
+    cache.retrieval_cache.invalidate()
+
+    collection = vector_store.get_or_create_collection("seams", reset=True)
+    texts = [c[3] for c in CORPUS]
+    metas = [{"paper_id": p, "title": t, "section": s, "chunk_index": i}
+             for i, (p, t, s, _) in enumerate(CORPUS)]
+    ids = [f"{p}_{i}" for i, (p, _, _, _) in enumerate(CORPUS)]
+    vector_store.add_documents(texts, _fake_embed(texts), metas, ids, collection=collection)
+
+    yield collection
+
+    bm25_search.invalidate()
+    cache.retrieval_cache.invalidate()
+    vector_store._chroma_client = None
+
+
+# --------------------------------------------------------------------------
+# Retrieval through the real store
+# --------------------------------------------------------------------------
+def test_retrieval_returns_the_relevant_paper_first(pipeline):
+    out = rag.retrieve_context("antenna design neural network", top_k=3, collection=pipeline)
+    assert out["chunks_used"] > 0
+    assert out["metadatas"][0]["paper_id"] == "antenna_ml"
+
+
+def test_retrieval_is_stamped_with_provenance_end_to_end(pipeline):
+    """The stamp must survive the round trip through Chroma, not merely be
+    present on the dict handed to upsert."""
+    out = rag.retrieve_context("antenna", top_k=1, collection=pipeline)
+    assert out["metadatas"][0]["embed_model"] == config.EMBEDDING_MODEL_NAME
+    assert vector_store.check_index_compatibility(pipeline) is None
+
+
+def test_hybrid_retrieval_finds_a_lexical_match(pipeline):
+    """Exercises dense + BM25 + RRF together. 'syndrome' is a rare term lexical
+    search nails; assert BM25 saw it too, so a broken RRF can't pass on the
+    dense leg alone."""
+    idx = bm25_search.get_or_build_index(pipeline)
+    sparse_ids, _ = idx.search("syndrome stabilizers", top_k=3)
+    assert any("qubit_ec" in i for i in sparse_ids)
+
+    out = rag.retrieve_context("syndrome extraction stabilizers", top_k=3, collection=pipeline)
+    assert "qubit_ec" in {m["paper_id"] for m in out["metadatas"]}
+
+
+# --------------------------------------------------------------------------
+# The seams the mocks never covered
+# --------------------------------------------------------------------------
+def test_format_context_and_citation_numbering_agree(pipeline):
+    """citation_number_map, format_context and extract_citations each number
+    papers independently. If they disagree, an answer's [N] resolves to the
+    wrong source — a silent correctness bug with no exception to catch it."""
+    out = rag.retrieve_context("antenna qubit protein", top_k=6, collection=pipeline)
+    metas = out["metadatas"]
+    context = out["formatted_context"]
+
+    num_to_meta = rag.citation_number_map(metas)
+    for num, meta in num_to_meta.items():
+        # Every number the map hands out must appear in the text the model sees.
+        assert f"[{num}]" in context or f"Cite:{num}" in context, \
+            f"citation {num} ({meta['title']}) missing from formatted context"
+
+    answer = "Antennas shrink by half [1]."
+    cites = rag.extract_citations(answer, metas, visible_chunks=out["chunks_used"])
+    assert cites and cites[0]["title"] == num_to_meta[1]["title"]
+
+
+def test_compact_citations_renumbers_and_rewrites_together(pipeline):
+    """The answer text and the citation panel must be renumbered as one unit.
+    Renumbering only the panel is how [1]...[4] ends up beside a two-entry list."""
+    out = rag.retrieve_context("antenna qubit protein", top_k=6, collection=pipeline)
+    metas = out["metadatas"]
+    n = len(rag.citation_number_map(metas))
+    assert n >= 3, "need >=3 distinct papers to test sparse citation renumbering"
+
+    answer = f"First claim [1]. Third claim [{n}]."
+    rewritten, cites = rag.compact_citations(answer, metas, out.get("chunks"),
+                                             visible_chunks=out["chunks_used"])
+    assert [c["number"] for c in cites] == ["1", "2"]   # dense 1..M
+    assert "[1]" in rewritten and "[2]" in rewritten
+    assert f"[{n}]" not in rewritten                    # old numbering is gone
+
+
+def test_dangling_citation_is_dropped_not_left_in_the_answer(pipeline):
+    """A number the model invented past the context must not survive — it would
+    read as a real source that was never shown."""
+    out = rag.retrieve_context("antenna", top_k=2, collection=pipeline)
+    rewritten, cites = rag.compact_citations("Claim with a bogus source [99].",
+                                             out["metadatas"], out.get("chunks"),
+                                             visible_chunks=out["chunks_used"])
+    assert "[99]" not in rewritten
+    assert all(c["number"] != "99" for c in cites)
+
+
+def test_faithfulness_receives_chunk_text_not_indices(pipeline, monkeypatch):
+    """Regression for the v2.4 bug: _run_faithfulness passed (index, text) tuples
+    into the NLI model, so every call raised and every answer reported
+    confidence 0.0. Assert the seam carries real strings."""
+    seen = {}
+
+    def _capture(answer, chunks, metadatas=None):
+        seen["chunks"] = chunks
+        return [{"claim": "c", "support": 0.9, "grounded": True}]
+
+    import verify
+    monkeypatch.setattr(verify, "check_claims", _capture)
+
+    out = rag.retrieve_context("antenna design", top_k=2, collection=pipeline)
+    rag._run_faithfulness("Antennas shrink [1].", out["chunks"], out["metadatas"])
+
+    if "chunks" in seen:  # skipped entirely when faithfulness is disabled by config
+        assert seen["chunks"], "faithfulness ran with no chunks"
+        assert all(isinstance(c, str) for c in seen["chunks"]), \
+            f"expected chunk text, got {[type(c).__name__ for c in seen['chunks']]}"
+
+
+def test_an_explicit_collection_is_deliberately_not_cached(pipeline):
+    """`cacheable = collection is None and filter_dict is None`. The cache key
+    does not include the collection, so caching a caller-supplied one would let
+    a result from one collection be served for another. Pinned so the condition
+    is not "simplified" away later."""
+    cache.retrieval_cache.invalidate()
+    rag.retrieve_context("antenna design neural network", top_k=3, collection=pipeline)
+    assert cache.retrieval_cache.stats["size"] == 0
+
+
+def test_retrieval_cache_actually_populates(pipeline):
+    """Regression for the v2.4 bug where the cacheability check ran after the
+    collection was materialized, so nothing was ever stored.
+
+    Goes through the default-collection path, which is the one that caches — the
+    fixture has already pointed COLLECTION_NAME and CHROMA_DB_DIR at the
+    temporary corpus.
+    """
+    cache.retrieval_cache.invalidate()
+    before = cache.retrieval_cache.stats["size"]
+    out = rag.retrieve_context("antenna design neural network", top_k=3)
+    assert out["chunks_used"] > 0, "default-collection path retrieved nothing"
+    assert cache.retrieval_cache.stats["size"] > before, "retrieval cache did not store anything"
+
+
+def test_cached_entry_cannot_be_mutated_by_a_caller(pipeline):
+    """Cached results are handed out by reference unless copied — one caller
+    trimming its list would corrupt every later hit."""
+    cache.retrieval_cache.invalidate()
+    q = "antenna design neural network"
+    first = rag.retrieve_context(q, top_k=3)
+    assert first["metadatas"]
+    first["metadatas"].clear()
+    second = rag.retrieve_context(q, top_k=3)
+    assert second["metadatas"], "a caller mutating its result corrupted the cache"
+
+
+# --------------------------------------------------------------------------
+# Ingest / delete consistency across both indexes
+# --------------------------------------------------------------------------
+def test_deleting_a_paper_removes_it_from_both_indexes(pipeline):
+    """Chroma and BM25 are two indexes over one corpus. A delete reaching only
+    one keeps citing the deleted paper from the other."""
+    bm25_search.get_or_build_index(pipeline)          # build before deleting
+    removed = vector_store.delete_by_paper_id("qubit_ec", collection=pipeline)
+    assert removed > 0
+
+    idx = bm25_search._indices.get("seams")
+    assert idx is not None
+    sparse_ids, _ = idx.search("syndrome stabilizers", top_k=5)
+    assert not any("qubit_ec" in i for i in sparse_ids), "BM25 still serves deleted chunks"
+
+    out = rag.retrieve_context("syndrome extraction", top_k=5, collection=pipeline)
+    assert "qubit_ec" not in {m["paper_id"] for m in out["metadatas"]}
+
+
+def test_newly_ingested_chunks_are_searchable_without_a_rebuild(pipeline):
+    """The incremental BM25 path: an ingest must not require dropping the index."""
+    bm25_search.get_or_build_index(pipeline)
+    text = "Photonic crystal waveguides confine light in periodic dielectric lattices."
+    vector_store.add_documents(
+        [text], _fake_embed([text]),
+        [{"paper_id": "photonics", "title": "Photonic Crystals", "section": "abstract",
+          "chunk_index": 0}],
+        ["photonics_0"], collection=pipeline)
+    assert bm25_search.add_to_index(["photonics_0"], [text]) is True
+
+    idx = bm25_search._indices["seams"]
+    ids, _ = idx.search("photonic crystal waveguides", top_k=3)
+    assert "photonics_0" in ids

--- a/tests/integration/test_pipeline_seams.py
+++ b/tests/integration/test_pipeline_seams.py
@@ -29,6 +29,8 @@ Marked `integration`: slower than the unit suite and excluded by CI's default
 selector.
 """
 
+import zlib
+
 import numpy as np
 import pytest
 
@@ -76,7 +78,10 @@ def _fake_embed(texts):
     out = np.zeros((len(texts), dim), dtype=np.float32)
     for i, t in enumerate(texts):
         for tok in str(t).lower().split():
-            out[i, hash(tok) % dim] += 1.0
+            # crc32, not hash(): str hashing is salted per process, so bucket
+            # collisions — and with them the ranking these tests assert on —
+            # would change from run to run.
+            out[i, zlib.crc32(tok.encode("utf-8")) % dim] += 1.0
         norm = np.linalg.norm(out[i])
         if norm:
             out[i] /= norm
@@ -209,10 +214,13 @@ def test_faithfulness_receives_chunk_text_not_indices(pipeline, monkeypatch):
     out = rag.retrieve_context("antenna design", top_k=2, collection=pipeline)
     rag._run_faithfulness("Antennas shrink [1].", out["chunks"], out["metadatas"])
 
-    if "chunks" in seen:  # skipped entirely when faithfulness is disabled by config
-        assert seen["chunks"], "faithfulness ran with no chunks"
-        assert all(isinstance(c, str) for c in seen["chunks"]), \
-            f"expected chunk text, got {[type(c).__name__ for c in seen['chunks']]}"
+    # check_claims itself is patched, so the seam is exercised whatever the
+    # faithfulness config says — a conditional assert here would let the
+    # regression back in silently.
+    assert "chunks" in seen, "faithfulness never reached verify.check_claims"
+    assert seen["chunks"], "faithfulness ran with no chunks"
+    assert all(isinstance(c, str) for c in seen["chunks"]), \
+        f"expected chunk text, got {[type(c).__name__ for c in seen['chunks']]}"
 
 
 def test_an_explicit_collection_is_deliberately_not_cached(pipeline):
@@ -298,7 +306,9 @@ def test_reindex_replays_the_log_into_a_working_collection(pipeline, monkeypatch
         assert rc == 0
 
         rebuilt = vector_store.get_or_create_collection("replayed")
-        assert rebuilt.count() == len(chunks)
+        # Only this paper's rows: the ingest log is process-wide, so a total count
+        # would depend on whatever else earlier tests recorded.
+        assert len(rebuilt.get(where={"paper_id": pid}).get("ids", [])) == len(chunks)
 
         # The rebuilt collection must actually retrieve, not merely hold rows.
         out = rag.retrieve_context("antenna design neural network", top_k=3,

--- a/tests/integration/test_pipeline_seams.py
+++ b/tests/integration/test_pipeline_seams.py
@@ -271,6 +271,46 @@ def test_deleting_a_paper_removes_it_from_both_indexes(pipeline):
     assert "qubit_ec" not in {m["paper_id"] for m in out["metadatas"]}
 
 
+def test_reindex_replays_the_log_into_a_working_collection(pipeline, monkeypatch):
+    """The whole justification for the ingest log: rebuild the vector store from
+    recorded chunks, with no PDFs and no re-captioning, and get a collection that
+    retrieves the same way.
+
+    This is what makes an embedding-model change a routine operation instead of
+    an hours-long non-reproducible one.
+    """
+    import uuid
+    import persistence
+    import reindex
+
+    pid = "replay_" + uuid.uuid4().hex[:8]
+    chunks = [c[3] for c in CORPUS if c[0] == "antenna_ml"]
+    persistence.record_ingest(
+        event_id=pid, paper_id=pid, content_hash="h", title="Replayed Antennas",
+        source_path="", chunks=chunks,
+        metadatas=[{"paper_id": pid, "title": "Replayed Antennas",
+                    "section": "abstract", "chunk_index": i} for i in range(len(chunks))],
+        ids=[f"{pid}_{i}" for i in range(len(chunks))],
+        embed_model=config.EMBEDDING_MODEL_NAME, chunker_version=vector_store.CHUNKER_VERSION,
+        created_at="2026-01-01T00:00:00+00:00")
+    try:
+        rc = reindex.reindex("replayed", dry_run=False, batch_size=8)
+        assert rc == 0
+
+        rebuilt = vector_store.get_or_create_collection("replayed")
+        assert rebuilt.count() == len(chunks)
+
+        # The rebuilt collection must actually retrieve, not merely hold rows.
+        out = rag.retrieve_context("antenna design neural network", top_k=3,
+                                   collection=rebuilt)
+        assert out["chunks_used"] > 0
+        assert out["metadatas"][0]["paper_id"] == pid
+        # And it is stamped with the model that just re-embedded it.
+        assert vector_store.check_index_compatibility(rebuilt) is None
+    finally:
+        persistence.delete_ingest_events(pid)
+
+
 def test_newly_ingested_chunks_are_searchable_without_a_rebuild(pipeline):
     """The incremental BM25 path: an ingest must not require dropping the index."""
     bm25_search.get_or_build_index(pipeline)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -431,9 +431,13 @@ def test_bm25_per_collection_isolation():
     assert idx_a is not idx_b
     assert idx_a.n_docs == 2
     assert idx_b.n_docs == 1
-    # Cache hit — collection.get not called a second time
+    # Cache hit — a second call must not touch the collection at all. Asserted as
+    # a delta rather than a fixed total: building an index may legitimately read
+    # the collection more than once (ids for the staleness check, then documents),
+    # and this test is about the in-memory hit, not the build's call pattern.
+    before = coll_a.get.call_count
     assert bm25_search.get_or_build_index(coll_a) is idx_a
-    assert coll_a.get.call_count == 1
+    assert coll_a.get.call_count == before
 
 
 def test_bm25_invalidate_clears_all_collections():

--- a/tests/test_bm25_search.py
+++ b/tests/test_bm25_search.py
@@ -223,6 +223,12 @@ class _Coll:
         return {"ids": list(self._docs), "documents": list(self._docs.values())}
 
 
+def _simulate_restart():
+    """Drop in-memory indices only. invalidate() also deletes the saved cache
+    (it means "the corpus moved"), which is the opposite of a restart."""
+    bm25_search._indices = {}
+
+
 @pytest.fixture
 def _cache_dir(tmp_path, monkeypatch):
     import config
@@ -239,7 +245,7 @@ def test_index_is_persisted_and_reloaded_without_rereading_the_corpus(_cache_dir
     bm25_search.get_or_build_index(coll)
     assert coll.doc_fetches == 1
 
-    bm25_search.invalidate()          # simulate a process restart
+    _simulate_restart()               # the process restarts; the file stays
     idx = bm25_search.get_or_build_index(coll)
 
     # Served from disk: the id set is re-read to prove the cache still matches
@@ -256,7 +262,7 @@ def test_reloaded_index_ranks_identically_to_a_freshly_built_one(_cache_dir):
     }
     coll = _Coll(docs)
     fresh = bm25_search.get_or_build_index(coll).search("antenna arrays", 3)
-    bm25_search.invalidate()
+    _simulate_restart()
     reloaded = bm25_search.get_or_build_index(coll).search("antenna arrays", 3)
     assert reloaded[0] == fresh[0]
     assert reloaded[1] == pytest.approx(fresh[1])
@@ -267,7 +273,7 @@ def test_stale_cache_is_ignored_when_the_corpus_changed(_cache_dir):
     trusted — serving a stale index is worse than paying for a rebuild."""
     coll = _Coll({"a": "antenna"})
     bm25_search.get_or_build_index(coll)
-    bm25_search.invalidate()
+    _simulate_restart()
 
     coll._docs["b"] = "newly ingested qubit paper"
     idx = bm25_search.get_or_build_index(coll)
@@ -279,7 +285,7 @@ def test_stale_cache_is_ignored_when_the_corpus_changed(_cache_dir):
 def test_corrupt_cache_falls_back_to_rebuild(_cache_dir):
     coll = _Coll({"a": "antenna"})
     bm25_search.get_or_build_index(coll)
-    bm25_search.invalidate()
+    _simulate_restart()
 
     bm25_search._cache_path(coll.name).write_bytes(b"not a gzip file at all")
     idx = bm25_search.get_or_build_index(coll)
@@ -293,7 +299,7 @@ def test_cache_from_an_older_format_is_ignored(_cache_dir):
     import json
     coll = _Coll({"a": "antenna"})
     bm25_search.get_or_build_index(coll)
-    bm25_search.invalidate()
+    _simulate_restart()
 
     path = bm25_search._cache_path(coll.name)
     with gzip.open(path, "rt", encoding="utf-8") as f:
@@ -330,19 +336,22 @@ def test_persistence_can_be_turned_off(tmp_path, monkeypatch):
         bm25_search.invalidate()
 
 
-def test_tombstones_survive_a_save_reload_cycle(_cache_dir):
-    """A deleted paper must stay deleted across a restart, or restarting would
-    resurrect it into the lexical index."""
+def test_a_cache_that_no_longer_matches_the_collection_is_rejected(_cache_dir):
+    """The saved index holds one live doc while Chroma still holds both, so the
+    file must be thrown away and rebuilt rather than served."""
     coll = _Coll({"a": "antenna design", "b": "antenna optimization"})
     idx = bm25_search.get_or_build_index(coll)
     idx.remove_documents(["a"])
     bm25_search.save_index(coll.name)
-    bm25_search.invalidate()
+    _simulate_restart()
 
     # count() still reports 2 rows in Chroma but the index holds 1 live doc, so
     # the staleness check correctly rejects it and rebuilds.
     reloaded = bm25_search.get_or_build_index(coll)
     assert reloaded is not None
+    # Rebuilt from the collection, so "a" is back — the point is that what gets
+    # served matches Chroma, not that the stale tombstone survives.
+    assert reloaded.search("antenna design", 5)[0][:1] == ["a"]
 
 
 def test_get_or_build_index_caches_per_collection():
@@ -369,7 +378,7 @@ def test_cache_is_rejected_when_content_changed_but_count_did_not(_cache_dir):
     differs. Loading that cache serves deleted text and misses its replacement."""
     coll = _Coll({"a1": "antenna design", "a2": "antenna results"})
     bm25_search.get_or_build_index(coll)
-    bm25_search.invalidate()
+    _simulate_restart()
 
     coll._docs = {"b1": "qubit surface codes", "b2": "qubit syndrome"}   # same count
     idx = bm25_search.get_or_build_index(coll)
@@ -381,10 +390,22 @@ def test_cache_is_rejected_when_content_changed_but_count_did_not(_cache_dir):
 def test_removing_documents_persists_the_index(_cache_dir):
     """A delete mutates the in-memory index; leaving the disk copy untouched is
     how it diverges from the collection across a restart."""
-    bm25_search.invalidate()
+    _simulate_restart()
     bm25_search._indices["persist"] = _index({"a": "antenna", "b": "qubit"})
     try:
         bm25_search.remove_from_index(["a"], "persist")
         assert bm25_search._cache_path("persist").exists()
     finally:
-        bm25_search.invalidate()
+        _simulate_restart()
+
+
+def test_invalidate_drops_the_saved_cache_too(_cache_dir):
+    """Chunk ids are positional (paper_id_section_N), so re-ingesting a changed
+    paper reuses them and the id fingerprint alone cannot spot the new text.
+    invalidate() therefore has to take the file with it."""
+    coll = _Coll({"a": "antenna"})
+    bm25_search.get_or_build_index(coll)
+    assert bm25_search._cache_path(coll.name).exists()
+
+    bm25_search.invalidate()
+    assert not bm25_search._cache_path(coll.name).exists()

--- a/tests/test_bm25_search.py
+++ b/tests/test_bm25_search.py
@@ -208,12 +208,18 @@ class _Coll:
         self.name = name
         self._docs = docs
         self.get_calls = 0
+        self.doc_fetches = 0
 
     def count(self):
         return len(self._docs)
 
     def get(self, include=None):
         self.get_calls += 1
+        # The staleness check fetches ids only (include=[]); a rebuild fetches
+        # documents. Counted apart, because "did not re-read the corpus" is about
+        # the text payload, not about touching the collection at all.
+        if include:
+            self.doc_fetches += 1
         return {"ids": list(self._docs), "documents": list(self._docs.values())}
 
 
@@ -231,12 +237,14 @@ def test_index_is_persisted_and_reloaded_without_rereading_the_corpus(_cache_dir
     """The point of persisting: a restart must not re-read every document."""
     coll = _Coll({"a": "antenna optimization", "b": "protein folding"})
     bm25_search.get_or_build_index(coll)
-    assert coll.get_calls == 1
+    assert coll.doc_fetches == 1
 
     bm25_search.invalidate()          # simulate a process restart
     idx = bm25_search.get_or_build_index(coll)
 
-    assert coll.get_calls == 1        # served from disk, corpus not re-read
+    # Served from disk: the id set is re-read to prove the cache still matches
+    # the collection, but the documents — the expensive part — are not.
+    assert coll.doc_fetches == 1
     assert idx.search("antenna", 5)[0] == ["a"]
 
 
@@ -264,7 +272,7 @@ def test_stale_cache_is_ignored_when_the_corpus_changed(_cache_dir):
     coll._docs["b"] = "newly ingested qubit paper"
     idx = bm25_search.get_or_build_index(coll)
 
-    assert coll.get_calls == 2               # rebuilt from the corpus
+    assert coll.doc_fetches == 2             # rebuilt from the corpus
     assert idx.search("qubit", 5)[0] == ["b"]
 
 
@@ -281,7 +289,8 @@ def test_corrupt_cache_falls_back_to_rebuild(_cache_dir):
 
 
 def test_cache_from_an_older_format_is_ignored(_cache_dir):
-    import gzip, json
+    import gzip
+    import json
     coll = _Coll({"a": "antenna"})
     bm25_search.get_or_build_index(coll)
     bm25_search.invalidate()
@@ -294,7 +303,7 @@ def test_cache_from_an_older_format_is_ignored(_cache_dir):
         json.dump(payload, f)
 
     assert bm25_search.get_or_build_index(coll) is not None
-    assert coll.get_calls == 2               # ignored the future-format file
+    assert coll.doc_fetches == 2             # ignored the future-format file
 
 
 def test_persisted_cache_is_not_pickle(_cache_dir):
@@ -352,3 +361,30 @@ def test_get_or_build_index_caches_per_collection():
     second = bm25_search.get_or_build_index(coll)
     assert first is second  # rebuilt once, then served from cache
     bm25_search.invalidate()
+
+
+def test_cache_is_rejected_when_content_changed_but_count_did_not(_cache_dir):
+    """The count-only check could not see this: delete one paper and ingest
+    another of the same size and the count is identical while every chunk
+    differs. Loading that cache serves deleted text and misses its replacement."""
+    coll = _Coll({"a1": "antenna design", "a2": "antenna results"})
+    bm25_search.get_or_build_index(coll)
+    bm25_search.invalidate()
+
+    coll._docs = {"b1": "qubit surface codes", "b2": "qubit syndrome"}   # same count
+    idx = bm25_search.get_or_build_index(coll)
+
+    assert idx.search("antenna", 5)[0] == [], "stale cache served deleted content"
+    assert set(idx.search("qubit", 5)[0]) == {"b1", "b2"}
+
+
+def test_removing_documents_persists_the_index(_cache_dir):
+    """A delete mutates the in-memory index; leaving the disk copy untouched is
+    how it diverges from the collection across a restart."""
+    bm25_search.invalidate()
+    bm25_search._indices["persist"] = _index({"a": "antenna", "b": "qubit"})
+    try:
+        bm25_search.remove_from_index(["a"], "persist")
+        assert bm25_search._cache_path("persist").exists()
+    finally:
+        bm25_search.invalidate()

--- a/tests/test_bm25_search.py
+++ b/tests/test_bm25_search.py
@@ -201,6 +201,141 @@ def test_remove_from_index_updates_a_live_index():
         bm25_search.invalidate()
 
 
+class _Coll:
+    """Minimal stand-in for a ChromaDB collection."""
+
+    def __init__(self, docs, name="persist"):
+        self.name = name
+        self._docs = docs
+        self.get_calls = 0
+
+    def count(self):
+        return len(self._docs)
+
+    def get(self, include=None):
+        self.get_calls += 1
+        return {"ids": list(self._docs), "documents": list(self._docs.values())}
+
+
+@pytest.fixture
+def _cache_dir(tmp_path, monkeypatch):
+    import config
+    monkeypatch.setattr(config, "BM25_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(config, "BM25_PERSIST", True)
+    bm25_search.invalidate()
+    yield tmp_path
+    bm25_search.invalidate()
+
+
+def test_index_is_persisted_and_reloaded_without_rereading_the_corpus(_cache_dir):
+    """The point of persisting: a restart must not re-read every document."""
+    coll = _Coll({"a": "antenna optimization", "b": "protein folding"})
+    bm25_search.get_or_build_index(coll)
+    assert coll.get_calls == 1
+
+    bm25_search.invalidate()          # simulate a process restart
+    idx = bm25_search.get_or_build_index(coll)
+
+    assert coll.get_calls == 1        # served from disk, corpus not re-read
+    assert idx.search("antenna", 5)[0] == ["a"]
+
+
+def test_reloaded_index_ranks_identically_to_a_freshly_built_one(_cache_dir):
+    docs = {
+        "a": "antenna optimization using machine learning",
+        "b": "protein folding with transformers",
+        "c": "millimetre wave radar antenna arrays",
+    }
+    coll = _Coll(docs)
+    fresh = bm25_search.get_or_build_index(coll).search("antenna arrays", 3)
+    bm25_search.invalidate()
+    reloaded = bm25_search.get_or_build_index(coll).search("antenna arrays", 3)
+    assert reloaded[0] == fresh[0]
+    assert reloaded[1] == pytest.approx(fresh[1])
+
+
+def test_stale_cache_is_ignored_when_the_corpus_changed(_cache_dir):
+    """A saved index that no longer matches the corpus must be rebuilt, not
+    trusted — serving a stale index is worse than paying for a rebuild."""
+    coll = _Coll({"a": "antenna"})
+    bm25_search.get_or_build_index(coll)
+    bm25_search.invalidate()
+
+    coll._docs["b"] = "newly ingested qubit paper"
+    idx = bm25_search.get_or_build_index(coll)
+
+    assert coll.get_calls == 2               # rebuilt from the corpus
+    assert idx.search("qubit", 5)[0] == ["b"]
+
+
+def test_corrupt_cache_falls_back_to_rebuild(_cache_dir):
+    coll = _Coll({"a": "antenna"})
+    bm25_search.get_or_build_index(coll)
+    bm25_search.invalidate()
+
+    bm25_search._cache_path(coll.name).write_bytes(b"not a gzip file at all")
+    idx = bm25_search.get_or_build_index(coll)
+
+    assert idx is not None                   # degraded to a rebuild, did not raise
+    assert idx.search("antenna", 5)[0] == ["a"]
+
+
+def test_cache_from_an_older_format_is_ignored(_cache_dir):
+    import gzip, json
+    coll = _Coll({"a": "antenna"})
+    bm25_search.get_or_build_index(coll)
+    bm25_search.invalidate()
+
+    path = bm25_search._cache_path(coll.name)
+    with gzip.open(path, "rt", encoding="utf-8") as f:
+        payload = json.load(f)
+    payload["format"] = bm25_search._CACHE_FORMAT + 1
+    with gzip.open(path, "wt", encoding="utf-8") as f:
+        json.dump(payload, f)
+
+    assert bm25_search.get_or_build_index(coll) is not None
+    assert coll.get_calls == 2               # ignored the future-format file
+
+
+def test_persisted_cache_is_not_pickle(_cache_dir):
+    """Regression: this file is read back and trusted at startup, so it must not
+    be a format that can execute code on load."""
+    import gzip
+    coll = _Coll({"a": "antenna"})
+    bm25_search.get_or_build_index(coll)
+    raw = bm25_search._cache_path(coll.name).read_bytes()
+    assert raw[:2] == b"\x1f\x8b"            # gzip magic
+    assert gzip.decompress(raw).lstrip().startswith(b"{")   # JSON object
+
+
+def test_persistence_can_be_turned_off(tmp_path, monkeypatch):
+    import config
+    monkeypatch.setattr(config, "BM25_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(config, "BM25_PERSIST", False)
+    bm25_search.invalidate()
+    try:
+        coll = _Coll({"a": "antenna"}, name="nopersist")
+        bm25_search.get_or_build_index(coll)
+        assert list(tmp_path.iterdir()) == []
+    finally:
+        bm25_search.invalidate()
+
+
+def test_tombstones_survive_a_save_reload_cycle(_cache_dir):
+    """A deleted paper must stay deleted across a restart, or restarting would
+    resurrect it into the lexical index."""
+    coll = _Coll({"a": "antenna design", "b": "antenna optimization"})
+    idx = bm25_search.get_or_build_index(coll)
+    idx.remove_documents(["a"])
+    bm25_search.save_index(coll.name)
+    bm25_search.invalidate()
+
+    # count() still reports 2 rows in Chroma but the index holds 1 live doc, so
+    # the staleness check correctly rejects it and rebuilds.
+    reloaded = bm25_search.get_or_build_index(coll)
+    assert reloaded is not None
+
+
 def test_get_or_build_index_caches_per_collection():
     class _Collection:
         name = "cached"

--- a/tests/test_bm25_search.py
+++ b/tests/test_bm25_search.py
@@ -1,0 +1,219 @@
+"""Coverage for the BM25 lexical index.
+
+This module had no dedicated test — it was only reached incidentally through
+test_agent.py — which matters because it is the half of hybrid retrieval that is
+next in line to be rewritten (inverted index, incremental updates, disk
+persistence). These tests pin the behavior that must survive that rewrite:
+ranking order, Unicode/Indic tokenization, RRF fusion, and index invalidation.
+"""
+
+import pytest
+
+import bm25_search
+
+
+def _index(docs: dict) -> bm25_search.BM25Index:
+    idx = bm25_search.BM25Index()
+    idx.build(list(docs.keys()), list(docs.values()))
+    return idx
+
+
+def test_ranks_the_document_that_actually_contains_the_term():
+    idx = _index({
+        "a": "quantum entanglement in superconducting qubits",
+        "b": "antenna design for millimetre wave radar",
+        "c": "a survey of antenna optimization using machine learning",
+    })
+    ids, scores = idx.search("antenna optimization", top_k=3)
+    assert ids[0] == "c"          # matches both query terms
+    assert scores[0] > scores[1]
+    assert "a" not in ids[:2]     # matches neither
+
+
+def test_rarer_term_outweighs_common_one():
+    """IDF must actually discriminate: a term in every doc carries no signal."""
+    idx = _index({
+        "a": "machine learning applied to antenna design",
+        "b": "machine learning applied to protein folding",
+        "c": "machine learning applied to weather models",
+    })
+    ids, _ = idx.search("machine antenna", top_k=3)
+    assert ids[0] == "a"  # 'antenna' is rare, 'machine' is in all three
+
+
+def test_empty_index_returns_empty_not_error():
+    idx = bm25_search.BM25Index()
+    idx.build([], [])
+    assert idx.search("anything", top_k=5) == ([], [])
+
+
+def test_no_query_term_matches_returns_zero_scores():
+    idx = _index({"a": "antenna design"})
+    ids, scores = idx.search("thermodynamics", top_k=5)
+    assert scores == [0.0] * len(ids)
+
+
+def test_tokenizer_handles_devanagari_and_tamil():
+    """The Unicode-aware tokenizer is why Indic lexical search works at all —
+    an ASCII/whitespace tokenizer would drop these scripts entirely."""
+    tok = bm25_search.BM25Index._tokenize
+    assert tok("यंत्र अधिगम") == ["यंत्र", "अधिगम"]
+    assert tok("இயந்திர கற்றல்") == ["இயந்திர", "கற்றல்"]
+    # Combining marks stay attached to their base character, not split off.
+    assert tok("हिन्दी") == ["हिन्दी"]
+
+
+def test_tokenizer_strips_punctuation_and_casefolds():
+    assert bm25_search.BM25Index._tokenize("Antenna-Design, v2.0!") == [
+        "antenna", "design", "v2", "0"
+    ]
+
+
+def test_indic_query_retrieves_indic_document():
+    idx = _index({
+        "hi": "यंत्र अधिगम का उपयोग करके एंटीना अनुकूलन",
+        "en": "antenna optimization using machine learning",
+    })
+    ids, _ = idx.search("एंटीना अनुकूलन", top_k=2)
+    assert ids[0] == "hi"
+
+
+def test_rrf_rewards_agreement_between_both_rankers():
+    """A doc both rankers like must beat one that only tops a single list."""
+    dense = ["x", "a", "b"]
+    sparse = ["y", "a", "c"]
+    fused = bm25_search.rrf(dense, sparse, k=60)
+    assert fused[0] == "a"
+    assert set(fused) == {"a", "b", "c", "x", "y"}
+
+
+def test_rrf_handles_one_empty_list():
+    assert bm25_search.rrf([], ["a", "b"], k=60) == ["a", "b"]
+
+
+def test_invalidate_drops_cached_indices():
+    bm25_search._indices["probe"] = _index({"a": "text"})
+    bm25_search.invalidate()
+    assert bm25_search._indices == {}
+
+
+def test_get_or_build_index_returns_none_for_empty_collection():
+    """An empty corpus must yield None, not a zero-doc index — callers branch on
+    None to skip the sparse leg entirely."""
+    class _EmptyCollection:
+        name = "empty"
+
+        def count(self):
+            return 0
+
+    bm25_search.invalidate()
+    assert bm25_search.get_or_build_index(_EmptyCollection()) is None
+
+
+def test_add_documents_makes_new_text_searchable_without_a_rebuild():
+    idx = _index({"a": "antenna design"})
+    idx.add_documents(["b"], ["quantum error correction"])
+    ids, _ = idx.search("quantum", top_k=5)
+    assert ids == ["b"]
+    assert idx.n_docs == 2
+
+
+def test_add_documents_updates_idf_not_just_the_postings():
+    """Corpus statistics have to move with the corpus, or scores drift from a
+    freshly built index the longer the process runs."""
+    idx = _index({"a": "antenna"})
+    idx.add_documents(["b", "c"], ["antenna", "unrelated"])
+    fresh = _index({"a": "antenna", "b": "antenna", "c": "unrelated"})
+    assert idx.n_docs == fresh.n_docs
+    assert idx.avg_dl == pytest.approx(fresh.avg_dl)
+    assert idx.search("antenna", 5)[1][0] == pytest.approx(fresh.search("antenna", 5)[1][0])
+
+
+def test_re_adding_an_id_replaces_it_rather_than_double_counting():
+    idx = _index({"a": "antenna design"})
+    idx.add_documents(["a"], ["antenna design revised"])
+    ids, _ = idx.search("antenna", top_k=5)
+    assert ids == ["a"]        # one hit, not two
+    assert idx.n_docs == 1
+
+
+def test_removed_documents_stop_being_retrieved():
+    """A deleted paper must not keep getting cited."""
+    idx = _index({"a": "antenna design", "b": "antenna optimization"})
+    assert idx.remove_documents(["a"]) == 1
+    ids, _ = idx.search("antenna", top_k=5)
+    assert ids == ["b"]
+    assert idx.n_docs == 1
+
+
+def test_removing_everything_leaves_a_valid_empty_index():
+    idx = _index({"a": "antenna", "b": "qubit"})
+    idx.remove_documents(["a", "b"])
+    assert idx.n_docs == 0
+    assert idx.search("antenna", top_k=5) == ([], [])
+    assert idx.avg_dl == 1.0  # no ZeroDivisionError
+
+
+def test_remove_is_idempotent():
+    idx = _index({"a": "antenna"})
+    assert idx.remove_documents(["a"]) == 1
+    assert idx.remove_documents(["a"]) == 0
+    assert idx.remove_documents(["never-existed"]) == 0
+
+
+def test_incremental_result_matches_a_full_rebuild():
+    """The whole justification for incremental updates: identical ranking."""
+    docs = {
+        "a": "antenna optimization using machine learning",
+        "b": "protein folding with transformers",
+        "c": "millimetre wave radar antenna arrays",
+    }
+    incremental = _index({"a": docs["a"]})
+    incremental.add_documents(["b"], [docs["b"]])
+    incremental.add_documents(["c"], [docs["c"]])
+    assert incremental.search("antenna arrays", 3)[0] == _index(docs).search("antenna arrays", 3)[0]
+
+
+def test_add_to_index_reports_when_there_is_no_index_yet():
+    """False tells the caller to leave it alone and let the next query build it,
+    rather than forcing a rebuild it doesn't need."""
+    bm25_search.invalidate()
+    assert bm25_search.add_to_index(["a"], ["text"]) is False
+
+
+def test_add_to_index_updates_a_live_index():
+    bm25_search.invalidate()
+    bm25_search._indices["live"] = _index({"a": "antenna"})
+    try:
+        assert bm25_search.add_to_index(["b"], ["qubit entanglement"]) is True
+        assert bm25_search._indices["live"].search("qubit", 5)[0] == ["b"]
+    finally:
+        bm25_search.invalidate()
+
+
+def test_remove_from_index_updates_a_live_index():
+    bm25_search.invalidate()
+    bm25_search._indices["live"] = _index({"a": "antenna", "b": "qubit"})
+    try:
+        assert bm25_search.remove_from_index(["a"]) is True
+        assert bm25_search._indices["live"].search("antenna", 5)[0] == []
+    finally:
+        bm25_search.invalidate()
+
+
+def test_get_or_build_index_caches_per_collection():
+    class _Collection:
+        name = "cached"
+
+        def count(self):
+            return 2
+
+        def get(self, include=None):
+            return {"ids": ["a", "b"], "documents": ["antenna", "qubit"]}
+
+    bm25_search.invalidate()
+    coll = _Collection()
+    first = bm25_search.get_or_build_index(coll)
+    second = bm25_search.get_or_build_index(coll)
+    assert first is second  # rebuilt once, then served from cache
+    bm25_search.invalidate()

--- a/tests/test_degraded_retrieval.py
+++ b/tests/test_degraded_retrieval.py
@@ -101,6 +101,9 @@ class _FakeCollection:
 
 def _install_index(monkeypatch, docs):
     import bm25_search
+    # Every fake collection is called "fake", so a persisted cache from one test
+    # would be loaded by the next one.
+    monkeypatch.setattr(config, "BM25_PERSIST", False)
     bm25_search.invalidate()
     monkeypatch.setattr(config, "USE_HYBRID_SEARCH", True)
     return _FakeCollection(docs)

--- a/tests/test_degraded_retrieval.py
+++ b/tests/test_degraded_retrieval.py
@@ -1,0 +1,153 @@
+"""Tests for the two degraded-mode fixes.
+
+1. A ChromaDB that keeps timing out used to cost every request the full 5s
+   timeout and park an uncancellable worker in the pool each time — the pool
+   drained in seconds and took down requests that never touched Chroma. It now
+   trips a circuit breaker and fails fast.
+2. An embedding failure (OOM, corrupt weights, driver fault) used to fail the
+   whole query, including ones the in-process BM25 index could answer. It now
+   degrades to sparse-only and marks the result.
+"""
+
+import pytest
+
+import config
+import rag
+import vector_store
+
+
+@pytest.fixture(autouse=True)
+def _reset_breaker():
+    """The breaker is module state; leaking a tripped one poisons later tests."""
+    vector_store._circuit_until = 0.0
+    vector_store._circuit_failures = 0
+    yield
+    vector_store._circuit_until = 0.0
+    vector_store._circuit_failures = 0
+
+
+def _hang():
+    import time
+    time.sleep(5)
+
+
+# --------------------------------------------------------------------------
+# ChromaDB circuit breaker
+# --------------------------------------------------------------------------
+def test_breaker_starts_closed():
+    assert not vector_store.chroma_circuit_open()
+
+
+def test_healthy_calls_pass_through_untouched():
+    assert vector_store._chroma_call(lambda: "ok") == "ok"
+    assert not vector_store.chroma_circuit_open()
+
+
+def test_breaker_opens_only_after_repeated_timeouts():
+    """One slow call is not an outage — the breaker must not trip on a blip."""
+    for i in range(vector_store._CIRCUIT_TRIP_AFTER - 1):
+        with pytest.raises(TimeoutError):
+            vector_store._chroma_call(_hang, timeout=0.01)
+        assert not vector_store.chroma_circuit_open(), f"tripped early after {i + 1}"
+
+    with pytest.raises(TimeoutError):
+        vector_store._chroma_call(_hang, timeout=0.01)
+    assert vector_store.chroma_circuit_open()
+
+
+def test_open_breaker_fails_fast_instead_of_waiting():
+    """The whole point: no new call is attempted, so no worker is parked."""
+    vector_store._circuit_until = float("inf")
+    called = []
+
+    with pytest.raises(vector_store.ChromaUnavailable):
+        vector_store._chroma_call(lambda: called.append(1))
+    assert called == []
+
+
+def test_a_success_clears_the_failure_streak():
+    """Consecutive means consecutive: an intervening success resets the count."""
+    with pytest.raises(TimeoutError):
+        vector_store._chroma_call(_hang, timeout=0.01)
+    assert vector_store._circuit_failures == 1
+    vector_store._chroma_call(lambda: "ok")
+    assert vector_store._circuit_failures == 0
+
+
+# --------------------------------------------------------------------------
+# Sparse-only fallback
+# --------------------------------------------------------------------------
+class _FakeCollection:
+    name = "fake"
+
+    def __init__(self, docs):
+        self._docs = docs
+
+    def count(self):
+        return len(self._docs)
+
+    def get(self, ids=None, include=None, **kwargs):
+        # Deliberately returns a DIFFERENT order than requested — Chroma makes no
+        # ordering promise, and BM25 rank is the only ranking left in this path.
+        items = list(self._docs.items()) if ids is None else [
+            (i, self._docs[i]) for i in reversed(ids) if i in self._docs
+        ]
+        return {
+            "ids": [i for i, _ in items],
+            "documents": [d for _, d in items],
+            "metadatas": [{"paper_id": i, "title": i, "section": "abstract"} for i, _ in items],
+        }
+
+
+def _install_index(monkeypatch, docs):
+    import bm25_search
+    bm25_search.invalidate()
+    monkeypatch.setattr(config, "USE_HYBRID_SEARCH", True)
+    return _FakeCollection(docs)
+
+
+def test_sparse_fallback_returns_results_and_flags_degradation(monkeypatch):
+    coll = _install_index(monkeypatch, {
+        "p1": "antenna optimization using machine learning",
+        "p2": "protein folding with transformers",
+    })
+    out = rag._sparse_only_retrieval("antenna optimization", top_k=2, collection=coll)
+    assert out is not None
+    # Never silently pass a degraded answer off as a normal one.
+    assert out["degraded"] == "sparse_only"
+    assert out["chunks_used"] >= 1
+
+
+def test_sparse_fallback_preserves_bm25_rank_order(monkeypatch):
+    """collection.get() reorders; the fallback must restore BM25 ranking."""
+    coll = _install_index(monkeypatch, {
+        "p1": "antenna optimization using machine learning",
+        "p2": "unrelated text about baking bread",
+    })
+    out = rag._sparse_only_retrieval("antenna optimization", top_k=2, collection=coll)
+    assert out["metadatas"][0]["paper_id"] == "p1"
+
+
+def test_no_fallback_when_hybrid_search_is_disabled(monkeypatch):
+    coll = _install_index(monkeypatch, {"p1": "antenna"})
+    monkeypatch.setattr(config, "USE_HYBRID_SEARCH", False)
+    assert rag._sparse_only_retrieval("antenna", 2, coll) is None
+
+
+def test_no_fallback_when_corpus_is_empty(monkeypatch):
+    """Nothing to degrade to => None, so the caller re-raises the real error
+    instead of serving a confidently empty answer."""
+    coll = _install_index(monkeypatch, {})
+    assert rag._sparse_only_retrieval("antenna", 2, coll) is None
+
+
+def test_no_fallback_when_chroma_is_also_down(monkeypatch):
+    """BM25 stores ids, not text — if Chroma can't return documents there is no
+    degraded answer to give, and pretending otherwise is worse than failing."""
+    coll = _install_index(monkeypatch, {"p1": "antenna optimization"})
+
+    def _boom(*a, **k):
+        raise TimeoutError("chroma down")
+
+    monkeypatch.setattr(vector_store, "_chroma_call", _boom)
+    assert rag._sparse_only_retrieval("antenna optimization", 2, coll) is None

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -72,6 +72,9 @@ def test_a_host_resolving_to_both_public_and_private_is_refused():
     mixed = _addr("127.0.0.1") + _addr("93.184.216.34")
     with patch("socket.getaddrinfo", return_value=mixed):
         assert _resolve_public_ip("rebind.example", 80) is None
+    # Answer order must not decide it: the public address first is the same host.
+    with patch("socket.getaddrinfo", return_value=list(reversed(mixed))):
+        assert _resolve_public_ip("rebind.example", 80) is None
 
 
 @pytest.mark.parametrize("ip", ["0.0.0.0", "224.0.0.1", "::1", "fe80::1", "192.168.1.1"])

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -232,3 +232,21 @@ def test_download_pdf_size_cap_aborts_oversized_response():
         result = download_utils.download_pdf("http://example.com/huge.pdf")
 
     assert result is None
+
+
+@pytest.mark.parametrize("bad_url", [
+    "http://example.com:99999/x.pdf",   # port out of range -> .port raises
+    "http://example.com:abc/x.pdf",     # non-numeric port  -> .port raises
+    "http://[bad/x.pdf",                # malformed IPv6    -> urlparse raises
+    "http://[::1]:70000/x.pdf",
+])
+def test_malformed_url_returns_none_instead_of_raising(bad_url):
+    """download_pdf's contract with its callers is "None on failure".
+
+    urlparse() and .port raise on malformed authorities where .hostname does not.
+    A raise here escapes the background ingest task before it can release its
+    reservation or write its terminal job update, leaving the job stuck on
+    `running` forever — so the parse must be inside the guard, not before it.
+    """
+    import download_utils
+    assert download_utils.download_pdf(bad_url) is None

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -3,52 +3,95 @@
 Regression coverage for the SSRF gap watch_runner._download_pdf had: it only
 checked the URL scheme (http/https), never the DNS-resolved IP, so a URL whose
 hostname resolves to a loopback/private/link-local address (e.g. an attacker
-pointing at http://169.254.169.254/ or a rebound DNS name) would be fetched
-by the server. download_utils adds that check.
+pointing at http://169.254.169.254/) would be fetched by the server.
+
+Second round: the resolved-IP check and urlopen()'s own lookup were two separate
+DNS queries, so a rebinding resolver could answer public for the check and
+private for the fetch. Resolution now happens once and the connection is pinned
+to that address; TLS still validates against the hostname.
 """
 
+import socket
 from unittest.mock import MagicMock, patch
 
-
-def test_is_private_ip_rejects_loopback():
-    from download_utils import _is_private_ip
-
-    with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("127.0.0.1", 0))]):
-        assert _is_private_ip("localhost") is True
+import pytest
 
 
-def test_is_private_ip_rejects_private_range():
-    from download_utils import _is_private_ip
-
-    with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("10.0.0.5", 0))]):
-        assert _is_private_ip("internal.example") is True
+def _addr(ip):
+    """One getaddrinfo entry for `ip`."""
+    return [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, 443))]
 
 
-def test_is_private_ip_rejects_link_local():
+# --------------------------------------------------------------------------
+# Address vetting
+# --------------------------------------------------------------------------
+def test_resolve_rejects_loopback():
+    from download_utils import _resolve_public_ip
+
+    with patch("socket.getaddrinfo", return_value=_addr("127.0.0.1")):
+        assert _resolve_public_ip("localhost", 80) is None
+
+
+def test_resolve_rejects_private_range():
+    from download_utils import _resolve_public_ip
+
+    with patch("socket.getaddrinfo", return_value=_addr("10.0.0.5")):
+        assert _resolve_public_ip("internal.example", 80) is None
+
+
+def test_resolve_rejects_link_local():
     """Covers the metadata-service SSRF class (169.254.169.254)."""
-    from download_utils import _is_private_ip
+    from download_utils import _resolve_public_ip
 
-    with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("169.254.169.254", 0))]):
-        assert _is_private_ip("metadata.internal") is True
-
-
-def test_is_private_ip_allows_public():
-    from download_utils import _is_private_ip
-
-    with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 0))]):
-        assert _is_private_ip("example.com") is False
+    with patch("socket.getaddrinfo", return_value=_addr("169.254.169.254")):
+        assert _resolve_public_ip("metadata.internal", 80) is None
 
 
-def test_is_private_ip_dns_failure_treated_as_safe_to_skip():
-    """A hostname that fails to resolve isn't itself an SSRF vector — download_pdf's
-    own urlopen() will fail on it separately; _is_private_ip shouldn't crash."""
-    import socket
-    from download_utils import _is_private_ip
+def test_resolve_returns_the_address_for_a_public_host():
+    """It must hand back the IP, not just a verdict — that address is what the
+    connection is pinned to, which is what closes the TOCTOU window."""
+    from download_utils import _resolve_public_ip
+
+    with patch("socket.getaddrinfo", return_value=_addr("93.184.216.34")):
+        assert _resolve_public_ip("example.com", 443) == "93.184.216.34"
+
+
+def test_resolve_dns_failure_is_not_an_error():
+    """A hostname that fails to resolve isn't itself an SSRF vector — the fetch
+    would simply fail. It must return None rather than raise."""
+    from download_utils import _resolve_public_ip
 
     with patch("socket.getaddrinfo", side_effect=socket.gaierror("no such host")):
-        assert _is_private_ip("nonexistent.invalid") is False
+        assert _resolve_public_ip("nonexistent.invalid", 80) is None
 
 
+def test_a_host_resolving_to_both_public_and_private_is_refused():
+    """That mix IS the rebinding pattern — one bad answer condemns the host."""
+    from download_utils import _resolve_public_ip
+
+    mixed = _addr("127.0.0.1") + _addr("93.184.216.34")
+    with patch("socket.getaddrinfo", return_value=mixed):
+        assert _resolve_public_ip("rebind.example", 80) is None
+
+
+@pytest.mark.parametrize("ip", ["0.0.0.0", "224.0.0.1", "::1", "fe80::1", "192.168.1.1"])
+def test_blocked_ip_families(ip):
+    import ipaddress
+    from download_utils import _is_blocked_ip
+
+    assert _is_blocked_ip(ipaddress.ip_address(ip)) is True
+
+
+def test_public_ip_is_not_blocked():
+    import ipaddress
+    from download_utils import _is_blocked_ip
+
+    assert _is_blocked_ip(ipaddress.ip_address("93.184.216.34")) is False
+
+
+# --------------------------------------------------------------------------
+# download_pdf
+# --------------------------------------------------------------------------
 def test_download_pdf_rejects_non_http_scheme():
     from download_utils import download_pdf
 
@@ -57,19 +100,24 @@ def test_download_pdf_rejects_non_http_scheme():
 
 
 def test_download_pdf_rejects_private_ip_target():
-    from download_utils import download_pdf
     import download_utils
 
-    with patch("download_utils._is_private_ip", return_value=True), \
-         patch.object(download_utils._NoRedirectOpener, "open") as mock_open:
-        result = download_pdf("http://169.254.169.254/x.pdf")
+    with patch("download_utils._resolve_public_ip", return_value=None), \
+         patch("download_utils._pinned_opener") as mock_opener:
+        result = download_utils.download_pdf("http://169.254.169.254/x.pdf")
 
     assert result is None
-    mock_open.assert_not_called()  # must reject before ever making the request
+    mock_opener.assert_not_called()  # must reject before ever making the request
 
 
-def test_download_pdf_streams_public_url(tmp_path):
-    from download_utils import download_pdf
+def _mock_opener(**open_kwargs):
+    """A _pinned_opener stand-in whose .open() behaves as configured."""
+    opener = MagicMock()
+    opener.open = MagicMock(**open_kwargs)
+    return opener
+
+
+def test_download_pdf_streams_public_url():
     import download_utils
 
     mock_resp = MagicMock()
@@ -77,42 +125,70 @@ def test_download_pdf_streams_public_url(tmp_path):
     mock_resp.__enter__ = MagicMock(return_value=mock_resp)
     mock_resp.__exit__ = MagicMock(return_value=False)
 
-    with patch("download_utils._is_private_ip", return_value=False), \
-         patch.object(download_utils._NoRedirectOpener, "open", return_value=mock_resp):
-        path = download_pdf("http://example.com/paper.pdf")
+    with patch("download_utils._resolve_public_ip", return_value="93.184.216.34"), \
+         patch("download_utils._pinned_opener", return_value=_mock_opener(return_value=mock_resp)):
+        path = download_utils.download_pdf("http://example.com/paper.pdf")
 
     assert path is not None
     with open(path, "rb") as f:
         assert f.read() == b"PDF-bytes"
 
 
+def test_connection_is_pinned_to_the_vetted_address():
+    """The resolved IP must be what the opener is built for. If the opener were
+    built without it, urlopen would resolve again and the TOCTOU hole reopens."""
+    import download_utils
+
+    mock_resp = MagicMock()
+    mock_resp.read.side_effect = [b"x", b""]
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=False)
+
+    with patch("download_utils._resolve_public_ip", return_value="93.184.216.34"), \
+         patch("download_utils._pinned_opener",
+               return_value=_mock_opener(return_value=mock_resp)) as mock_builder:
+        download_utils.download_pdf("https://example.com/paper.pdf")
+
+    mock_builder.assert_called_once_with("93.184.216.34")
+
+
+def test_tls_still_validates_against_the_hostname_not_the_ip():
+    """Pinning must not turn into cert-validation-by-IP, which would break every
+    ordinary HTTPS fetch. The connection keeps the hostname for SNI/verification."""
+    from download_utils import _PinnedHTTPSConnection
+
+    conn = _PinnedHTTPSConnection("example.com", pinned_ip="93.184.216.34")
+    assert conn.host == "example.com"
+    assert conn._pinned_ip == "93.184.216.34"
+
+
 def test_download_pdf_rejects_redirect_to_private_ip():
-    """Regression: urlopen follows redirects by default, so a public URL that
-    302s to an internal address (cloud metadata service, localhost, ...) must
-    not be silently followed — that fully defeats the private-IP guard."""
+    """urlopen follows redirects by default, so a public URL that 302s to an
+    internal address must not be silently followed — that fully defeats the guard."""
     import urllib.error
     import download_utils
 
     def fake_open(req, timeout=30):
         raise urllib.error.HTTPError(
-            req.full_url, 302, "Found", {"Location": "http://169.254.169.254/latest/meta-data/"}, None
+            req.full_url, 302, "Found",
+            {"Location": "http://169.254.169.254/latest/meta-data/"}, None,
         )
 
-    # Original host looks public and passes; the redirect target is a real
-    # link-local literal, so the real (unmocked) check correctly rejects it —
-    # only the original hostname's lookup needs faking here.
-    def fake_is_private(hostname):
-        return hostname == "169.254.169.254"
+    def fake_resolve(hostname, port):
+        # The original host looks public; the link-local redirect target is refused.
+        return None if hostname == "169.254.169.254" else "93.184.216.34"
 
-    with patch("download_utils._is_private_ip", side_effect=fake_is_private), \
-         patch.object(download_utils._NoRedirectOpener, "open", side_effect=fake_open):
+    with patch("download_utils._resolve_public_ip", side_effect=fake_resolve), \
+         patch("download_utils._pinned_opener",
+               return_value=_mock_opener(side_effect=fake_open)):
         result = download_utils.download_pdf("http://public-looking.example.com/redirect")
 
     assert result is None
 
 
-def test_download_pdf_follows_redirect_to_public_url(tmp_path):
-    """A redirect to another public URL is fine — only the private-IP hop is blocked."""
+def test_download_pdf_follows_redirect_to_public_url():
+    """A redirect to another public URL is fine — only the private hop is blocked,
+    and the new host is re-resolved and re-vetted on its own."""
     import urllib.error
     import download_utils
 
@@ -123,16 +199,19 @@ def test_download_pdf_follows_redirect_to_public_url(tmp_path):
     mock_resp.__exit__ = MagicMock(return_value=False)
 
     calls = {"n": 0}
+
     def fake_open(req, timeout=30):
         calls["n"] += 1
         if calls["n"] == 1:
             raise urllib.error.HTTPError(
-                req.full_url, 302, "Found", {"Location": "http://public2.example.com/paper.pdf"}, None
+                req.full_url, 302, "Found",
+                {"Location": "http://public2.example.com/paper.pdf"}, None,
             )
         return mock_resp
 
-    with patch("download_utils._is_private_ip", return_value=False), \
-         patch.object(download_utils._NoRedirectOpener, "open", side_effect=fake_open):
+    with patch("download_utils._resolve_public_ip", return_value="93.184.216.34"), \
+         patch("download_utils._pinned_opener",
+               return_value=_mock_opener(side_effect=fake_open)):
         path = download_utils.download_pdf("http://public1.example.com/redirect")
 
     assert path is not None
@@ -148,8 +227,8 @@ def test_download_pdf_size_cap_aborts_oversized_response():
     mock_resp.__enter__ = MagicMock(return_value=mock_resp)
     mock_resp.__exit__ = MagicMock(return_value=False)
 
-    with patch("download_utils._is_private_ip", return_value=False), \
-         patch.object(download_utils._NoRedirectOpener, "open", return_value=mock_resp):
+    with patch("download_utils._resolve_public_ip", return_value="93.184.216.34"), \
+         patch("download_utils._pinned_opener", return_value=_mock_opener(return_value=mock_resp)):
         result = download_utils.download_pdf("http://example.com/huge.pdf")
 
     assert result is None

--- a/tests/test_index_provenance.py
+++ b/tests/test_index_provenance.py
@@ -114,10 +114,39 @@ def test_unstamped_legacy_chunks_are_reported_not_assumed_compatible():
 
 def test_fingerprint_reads_back_what_was_stamped():
     coll = _Collection(metas=[{
-        "embed_model": "BAAI/bge-m3", "embed_dim": 1024,
+        "embed_model": "BAAI/bge-m3", "embed_dim": 1024, "embed_backend": "fp32",
         "chunker_version": 1, "schema_version": 1,
     }])
     assert vector_store.index_fingerprint(coll) == {
-        "embed_model": "BAAI/bge-m3", "embed_dim": 1024,
+        "embed_model": "BAAI/bge-m3", "embed_dim": 1024, "embed_backend": "fp32",
         "chunker_version": 1, "schema_version": 1,
     }
+
+
+def test_a_changed_embedding_backend_is_reported(monkeypatch):
+    """The gap the model-name check alone leaves open: int8 and fp32 BGE-M3 share
+    a model id but produce vectors that are not comparable."""
+    coll = _Collection(metas=[{
+        "embed_model": config.EMBEDDING_MODEL_NAME,
+        "embed_dim": config.EMBEDDING_DIMENSION,
+        "embed_backend": "fp32",
+        "chunker_version": vector_store.CHUNKER_VERSION,
+        "schema_version": vector_store.SCHEMA_VERSION,
+    }])
+    monkeypatch.setattr(vector_store, "_embed_backend", lambda: "onnx-int8")
+    problem = vector_store.check_index_compatibility(coll)
+    assert problem and "backend" in problem and "not comparable" in problem
+
+
+def test_backend_mismatch_is_not_reported_before_the_model_loads(monkeypatch):
+    """'unloaded' means we cannot tell yet. Warning then would fire on every
+    import and train the operator to ignore a real warning later."""
+    coll = _Collection(metas=[{
+        "embed_model": config.EMBEDDING_MODEL_NAME,
+        "embed_dim": config.EMBEDDING_DIMENSION,
+        "embed_backend": "fp32",
+        "chunker_version": vector_store.CHUNKER_VERSION,
+        "schema_version": vector_store.SCHEMA_VERSION,
+    }])
+    monkeypatch.setattr(vector_store, "_embed_backend", lambda: "unloaded")
+    assert vector_store.check_index_compatibility(coll) is None

--- a/tests/test_index_provenance.py
+++ b/tests/test_index_provenance.py
@@ -1,0 +1,123 @@
+"""Tests for embedding/chunker provenance stamps.
+
+Nothing recorded which model produced a vector, so swapping the embedding model
+— or changing the per-section chunk sizes — silently mixed incompatible vectors
+into one collection. Cosine distance between two different embedding spaces is
+meaningless but never raises, so the only symptom was retrieval quality quietly
+getting worse, which is nearly undebuggable from outside.
+"""
+
+import numpy as np
+
+import config
+import vector_store
+
+
+class _Collection:
+    name = "prov"
+
+    def __init__(self, metas=None):
+        self.upserted = None
+        self._metas = metas
+
+    def upsert(self, **kwargs):
+        self.upserted = kwargs
+
+    def count(self):
+        return len(self.upserted["ids"]) if self.upserted else 0
+
+    def peek(self, limit=1):
+        if self._metas is None:
+            return {"metadatas": []}
+        return {"metadatas": self._metas[:limit]}
+
+
+def test_every_chunk_is_stamped_on_write():
+    coll = _Collection()
+    vector_store.add_documents(
+        texts=["some text"],
+        embeddings=np.zeros((1, 4)),
+        metadatas=[{"paper_id": "p1", "title": "T"}],
+        ids=["c1"],
+        collection=coll,
+    )
+    meta = coll.upserted["metadatas"][0]
+    assert meta["embed_model"] == config.EMBEDDING_MODEL_NAME
+    assert meta["embed_dim"] == config.EMBEDDING_DIMENSION
+    assert meta["chunker_version"] == vector_store.CHUNKER_VERSION
+    assert meta["schema_version"] == vector_store.SCHEMA_VERSION
+    assert meta["paper_id"] == "p1"  # original fields survive
+
+
+def test_stamping_does_not_mutate_the_callers_metadata():
+    """add_documents receives the ingest pipeline's own dicts; stamping in place
+    would leak index bookkeeping back into the caller."""
+    coll = _Collection()
+    original = {"paper_id": "p1"}
+    vector_store.add_documents(["t"], np.zeros((1, 4)), [original], ["c1"], collection=coll)
+    assert original == {"paper_id": "p1"}
+
+
+def test_empty_collection_has_nothing_to_be_incompatible_with():
+    assert vector_store.check_index_compatibility(_Collection(metas=None)) is None
+
+
+def test_matching_provenance_reports_no_problem():
+    coll = _Collection(metas=[{
+        "embed_model": config.EMBEDDING_MODEL_NAME,
+        "embed_dim": config.EMBEDDING_DIMENSION,
+        "chunker_version": vector_store.CHUNKER_VERSION,
+        "schema_version": vector_store.SCHEMA_VERSION,
+    }])
+    assert vector_store.check_index_compatibility(coll) is None
+
+
+def test_a_changed_embedding_model_is_reported():
+    coll = _Collection(metas=[{
+        "embed_model": "some/other-model",
+        "embed_dim": config.EMBEDDING_DIMENSION,
+        "chunker_version": vector_store.CHUNKER_VERSION,
+        "schema_version": vector_store.SCHEMA_VERSION,
+    }])
+    problem = vector_store.check_index_compatibility(coll)
+    assert problem and "some/other-model" in problem
+
+
+def test_a_changed_dimension_is_reported():
+    coll = _Collection(metas=[{
+        "embed_model": config.EMBEDDING_MODEL_NAME,
+        "embed_dim": 384,
+        "chunker_version": vector_store.CHUNKER_VERSION,
+        "schema_version": vector_store.SCHEMA_VERSION,
+    }])
+    problem = vector_store.check_index_compatibility(coll)
+    assert problem and "384" in problem
+
+
+def test_a_changed_chunker_is_reported():
+    coll = _Collection(metas=[{
+        "embed_model": config.EMBEDDING_MODEL_NAME,
+        "embed_dim": config.EMBEDDING_DIMENSION,
+        "chunker_version": vector_store.CHUNKER_VERSION + 1,
+        "schema_version": vector_store.SCHEMA_VERSION,
+    }])
+    assert "chunker version" in vector_store.check_index_compatibility(coll)
+
+
+def test_unstamped_legacy_chunks_are_reported_not_assumed_compatible():
+    """Chunks written before stamping existed cannot be compared against
+    anything, so say so rather than silently calling them fine."""
+    coll = _Collection(metas=[{"paper_id": "old"}])
+    problem = vector_store.check_index_compatibility(coll)
+    assert problem and "provenance" in problem
+
+
+def test_fingerprint_reads_back_what_was_stamped():
+    coll = _Collection(metas=[{
+        "embed_model": "BAAI/bge-m3", "embed_dim": 1024,
+        "chunker_version": 1, "schema_version": 1,
+    }])
+    assert vector_store.index_fingerprint(coll) == {
+        "embed_model": "BAAI/bge-m3", "embed_dim": 1024,
+        "chunker_version": 1, "schema_version": 1,
+    }

--- a/tests/test_index_provenance.py
+++ b/tests/test_index_provenance.py
@@ -44,6 +44,7 @@ def test_every_chunk_is_stamped_on_write():
     meta = coll.upserted["metadatas"][0]
     assert meta["embed_model"] == config.EMBEDDING_MODEL_NAME
     assert meta["embed_dim"] == config.EMBEDDING_DIMENSION
+    assert meta["embed_backend"] == vector_store._embed_backend()
     assert meta["chunker_version"] == vector_store.CHUNKER_VERSION
     assert meta["schema_version"] == vector_store.SCHEMA_VERSION
     assert meta["paper_id"] == "p1"  # original fields survive
@@ -174,6 +175,9 @@ def test_a_failed_batch_rolls_back_what_it_already_wrote():
         def delete(self, ids=None, **kw):
             self.deleted.extend(ids or [])
 
+        def get(self, ids=None, include=None, **kw):
+            return {"ids": []}          # nothing pre-exists: all rows are new
+
         def count(self):
             return len(self.written) - len(self.deleted)
 
@@ -187,7 +191,51 @@ def test_a_failed_batch_rolls_back_what_it_already_wrote():
                 texts=["t"] * 6, embeddings=np.zeros((6, 4)),
                 metadatas=[{"paper_id": "p"} for _ in range(6)],
                 ids=ids, collection=coll)
-        # Everything committed before the failure is removed again.
-        assert sorted(coll.deleted) == sorted(coll.written)
+        # Everything committed before the failure is removed again — and so is
+        # the failing batch, whose write may still land after a timeout.
+        assert set(coll.written) <= set(coll.deleted)
+        assert sorted(coll.deleted) == ids
+    finally:
+        config.CHROMA_UPSERT_BATCH = old
+
+
+def test_rollback_keeps_rows_that_already_existed():
+    """An upsert REPLACES an existing row. Deleting it on rollback would lose
+    content the ingest log still records — silent data loss, worse than the
+    orphan the rollback exists to prevent."""
+    import config
+    import pytest
+
+    class _FailsOnSecondBatch:
+        name = "overwrite"
+
+        def __init__(self):
+            self.deleted, self.calls = [], 0
+
+        def get(self, ids=None, include=None, **kw):
+            return {"ids": ["c0", "c1"]}      # first batch is a re-ingest
+
+        def upsert(self, ids=None, **kw):
+            self.calls += 1
+            if self.calls == 2:
+                raise RuntimeError("chroma exploded")
+
+        def delete(self, ids=None, **kw):
+            self.deleted.extend(ids or [])
+
+        def count(self):
+            return 0
+
+    coll = _FailsOnSecondBatch()
+    old = config.CHROMA_UPSERT_BATCH
+    config.CHROMA_UPSERT_BATCH = 2
+    try:
+        ids = [f"c{i}" for i in range(4)]
+        with pytest.raises(RuntimeError, match="exploded"):
+            vector_store.add_documents(
+                texts=["t"] * 4, embeddings=np.zeros((4, 4)),
+                metadatas=[{"paper_id": "p"} for _ in range(4)],
+                ids=ids, collection=coll)
+        assert coll.deleted == ["c2", "c3"]   # only the rows this call created
     finally:
         config.CHROMA_UPSERT_BATCH = old

--- a/tests/test_index_provenance.py
+++ b/tests/test_index_provenance.py
@@ -150,3 +150,44 @@ def test_backend_mismatch_is_not_reported_before_the_model_loads(monkeypatch):
     }])
     monkeypatch.setattr(vector_store, "_embed_backend", lambda: "unloaded")
     assert vector_store.check_index_compatibility(coll) is None
+
+
+def test_a_failed_batch_rolls_back_what_it_already_wrote():
+    """Batched upserts reintroduce partial failure. If batches 1-2 commit and 3
+    raises, the caller never reaches its ingest-log write, so a replay would omit
+    chunks that are still searchable — the exact divergence the log prevents."""
+    import config
+    import pytest
+
+    class _FailsOnThirdBatch:
+        name = "rollback"
+
+        def __init__(self):
+            self.written, self.deleted, self.calls = [], [], 0
+
+        def upsert(self, ids=None, **kw):
+            self.calls += 1
+            if self.calls == 3:
+                raise RuntimeError("chroma exploded")
+            self.written.extend(ids)
+
+        def delete(self, ids=None, **kw):
+            self.deleted.extend(ids or [])
+
+        def count(self):
+            return len(self.written) - len(self.deleted)
+
+    coll = _FailsOnThirdBatch()
+    old = config.CHROMA_UPSERT_BATCH
+    config.CHROMA_UPSERT_BATCH = 2
+    try:
+        ids = [f"c{i}" for i in range(6)]
+        with pytest.raises(RuntimeError, match="exploded"):
+            vector_store.add_documents(
+                texts=["t"] * 6, embeddings=np.zeros((6, 4)),
+                metadatas=[{"paper_id": "p"} for _ in range(6)],
+                ids=ids, collection=coll)
+        # Everything committed before the failure is removed again.
+        assert sorted(coll.deleted) == sorted(coll.written)
+    finally:
+        config.CHROMA_UPSERT_BATCH = old

--- a/tests/test_ingest_log.py
+++ b/tests/test_ingest_log.py
@@ -1,0 +1,131 @@
+"""Tests for the ingest log — the system of record the indexes derive from.
+
+Rebuilding the vector store used to mean re-parsing every PDF and re-calling the
+VLM captioner: hours of work, not reproducible, and impossible once a source
+file had moved. That made an embedding-model or chunking change expensive enough
+that it never happened. The log records the chunks each ingestion produced, so a
+rebuild becomes a replay.
+"""
+
+import uuid
+
+import persistence
+import reindex
+
+TS = "2026-01-01T00:00:00+00:00"
+
+
+def _record(paper_id, chunks, embed_model="BAAI/bge-m3", chunker_version=1):
+    persistence.record_ingest(
+        event_id=paper_id, paper_id=paper_id, content_hash="h" + paper_id,
+        title=f"Title {paper_id}", source_path=f"papers/{paper_id}.pdf",
+        chunks=chunks,
+        metadatas=[{"paper_id": paper_id, "title": f"Title {paper_id}",
+                    "section": "abstract", "chunk_index": i}
+                   for i in range(len(chunks))],
+        ids=[f"{paper_id}_{i}" for i in range(len(chunks))],
+        embed_model=embed_model, chunker_version=chunker_version, created_at=TS,
+    )
+
+
+def test_recorded_chunks_round_trip_exactly():
+    """A replay re-embeds these strings; anything lossy here silently changes
+    the corpus on the next rebuild."""
+    pid = str(uuid.uuid4())
+    chunks = ["first chunk about antennas", "second chunk about qubits"]
+    _record(pid, chunks)
+    try:
+        events = persistence.get_ingest_events(pid)
+        assert len(events) == 1
+        e = events[0]
+        assert e["chunks"] == chunks
+        assert e["ids"] == [f"{pid}_0", f"{pid}_1"]
+        assert e["metadatas"][1]["chunk_index"] == 1
+        assert e["embed_model"] == "BAAI/bge-m3"
+        assert e["source_path"] == f"papers/{pid}.pdf"
+    finally:
+        persistence.delete_ingest_events(pid)
+
+
+def test_reingesting_replaces_rather_than_appends():
+    """The log describes the CURRENT index contents, not history. A second row
+    for the same paper would make a replay reinstate superseded chunks."""
+    pid = str(uuid.uuid4())
+    _record(pid, ["v1 chunk"])
+    _record(pid, ["v2 chunk a", "v2 chunk b"])
+    try:
+        events = persistence.get_ingest_events(pid)
+        assert len(events) == 1
+        assert events[0]["chunks"] == ["v2 chunk a", "v2 chunk b"]
+    finally:
+        persistence.delete_ingest_events(pid)
+
+
+def test_deleting_a_paper_removes_it_from_the_log():
+    """Otherwise a rebuild resurrects a deleted paper — the exact inconsistency
+    a system of record is supposed to prevent."""
+    pid = str(uuid.uuid4())
+    _record(pid, ["chunk"])
+    assert persistence.delete_ingest_events(pid) == 1
+    assert persistence.get_ingest_events(pid) == []
+
+
+def test_events_replay_in_ingest_order():
+    """Chunk ids and citation numbering follow insertion order, so a replay has
+    to reproduce it."""
+    a, b = "aaa-" + str(uuid.uuid4()), "bbb-" + str(uuid.uuid4())
+    persistence.record_ingest(a, a, "h", "A", "", ["x"], [{}], ["a_0"], "m", 1,
+                              "2026-01-01T00:00:00+00:00")
+    persistence.record_ingest(b, b, "h", "B", "", ["y"], [{}], ["b_0"], "m", 1,
+                              "2026-01-02T00:00:00+00:00")
+    try:
+        ordered = [e["paper_id"] for e in persistence.get_ingest_events()]
+        assert ordered.index(a) < ordered.index(b)
+    finally:
+        persistence.delete_ingest_events(a)
+        persistence.delete_ingest_events(b)
+
+
+# --------------------------------------------------------------------------
+# Drift detection
+# --------------------------------------------------------------------------
+def test_no_drift_when_the_log_matches_the_config():
+    import config
+    import vector_store
+    events = [{"embed_model": config.EMBEDDING_MODEL_NAME,
+               "chunker_version": vector_store.CHUNKER_VERSION}]
+    assert reindex._drift_report(events) == []
+
+
+def test_changed_embedding_model_is_reported_as_replayable():
+    import vector_store
+    events = [{"embed_model": "some/old-model",
+               "chunker_version": vector_store.CHUNKER_VERSION}]
+    problems = reindex._drift_report(events)
+    assert any("differs" in p and "re-embed" in p for p in problems)
+
+
+def test_mixed_embedding_models_are_reported():
+    """Two embedding spaces in one collection: cosine distance between them is
+    meaningless, and nothing else in the system would notice."""
+    import config
+    import vector_store
+    events = [
+        {"embed_model": config.EMBEDDING_MODEL_NAME,
+         "chunker_version": vector_store.CHUNKER_VERSION},
+        {"embed_model": "some/other-model",
+         "chunker_version": vector_store.CHUNKER_VERSION},
+    ]
+    assert any("MIXED embedding models" in p for p in reindex._drift_report(events))
+
+
+def test_changed_chunker_is_reported_as_NOT_replayable():
+    """The important half of the honesty: replay reuses recorded chunk
+    boundaries, so it cannot implement a chunker change. Claiming otherwise
+    would leave the user believing they had migrated when they had not."""
+    import config
+    import vector_store
+    events = [{"embed_model": config.EMBEDDING_MODEL_NAME,
+               "chunker_version": vector_store.CHUNKER_VERSION + 1}]
+    problems = reindex._drift_report(events)
+    assert any("CANNOT" in p and "Re-ingest" in p for p in problems)

--- a/tests/test_job_reaper.py
+++ b/tests/test_job_reaper.py
@@ -1,0 +1,155 @@
+"""Tests for durable job leases and the stale-job reaper.
+
+Ingest and report jobs run inside the API process, so a restart, crash or OOM
+mid-job left the row saying `running` forever. Nothing ever moved it, and a
+client polling /ingest/status or /report/status waited on a job that no longer
+existed in any process.
+
+Jobs now carry a lease that every progress update renews, and startup reaps the
+ones whose lease expired — an expired lease being evidence the owner is gone, as
+opposed to merely slow.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import deps
+import persistence
+
+PAST = "2020-01-01T00:00:00+00:00"
+FUTURE = "2099-01-01T00:00:00+00:00"
+
+
+def _now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _save(job_id, status, lease_until, **extra):
+    job = {"job_id": job_id, "status": status, "submitted_at": PAST,
+           "completed_at": None, "error": None, **extra}
+    persistence.save_job(job_id, job, lease_until=lease_until)
+    return job
+
+
+def _row(job_id):
+    return persistence._conn.execute(
+        "SELECT status, lease_until FROM jobs WHERE id = ?", (job_id,)).fetchone()
+
+
+def _cleanup(*ids):
+    for jid in ids:
+        persistence.delete_job(jid)
+
+
+def test_expired_lease_is_reaped_and_reported():
+    jid = str(uuid.uuid4())
+    _save(jid, "running", PAST)
+    try:
+        reaped = persistence.reap_stale_jobs(_now())
+        assert jid in {j["job_id"] for j in reaped}
+        status, lease = _row(jid)
+        assert status == "failed"
+        assert lease is None
+        job = [j for j in reaped if j["job_id"] == jid][0]
+        # The error has to say what happened and what to do — a bare "failed"
+        # tells the user nothing about whether retrying is sensible.
+        assert "Abandoned" in job["error"] and "Resubmit" in job["error"]
+        assert job["completed_at"] is not None
+    finally:
+        _cleanup(jid)
+
+
+def test_a_live_worker_keeps_its_job():
+    """The point of leasing: a job someone is still heartbeating must survive a
+    reap, or one worker starting up would kill another's in-flight work."""
+    jid = str(uuid.uuid4())
+    _save(jid, "running", FUTURE)
+    try:
+        reaped = persistence.reap_stale_jobs(_now())
+        assert jid not in {j["job_id"] for j in reaped}
+        assert _row(jid)[0] == "running"
+    finally:
+        _cleanup(jid)
+
+
+def test_finished_jobs_are_never_reaped():
+    done, failed = str(uuid.uuid4()), str(uuid.uuid4())
+    _save(done, "success", None)
+    _save(failed, "failed", None)
+    try:
+        reaped = {j["job_id"] for j in persistence.reap_stale_jobs(_now())}
+        assert done not in reaped and failed not in reaped
+        assert _row(done)[0] == "success"
+    finally:
+        _cleanup(done, failed)
+
+
+def test_pending_jobs_are_reaped_too():
+    """A job queued but never started is just as abandoned as a running one."""
+    jid = str(uuid.uuid4())
+    _save(jid, "pending", PAST)
+    try:
+        assert jid in {j["job_id"] for j in persistence.reap_stale_jobs(_now())}
+    finally:
+        _cleanup(jid)
+
+
+def test_legacy_jobs_without_a_lease_are_reaped():
+    """Rows written before leasing existed cannot be running — running jobs
+    heartbeat — so a NULL lease is not a reason to leave one in-flight."""
+    jid = str(uuid.uuid4())
+    _save(jid, "running", None)
+    try:
+        assert jid in {j["job_id"] for j in persistence.reap_stale_jobs(_now())}
+    finally:
+        _cleanup(jid)
+
+
+def test_reaping_is_idempotent():
+    jid = str(uuid.uuid4())
+    _save(jid, "running", PAST)
+    try:
+        assert len(persistence.reap_stale_jobs(_now())) >= 1
+        second = {j["job_id"] for j in persistence.reap_stale_jobs(_now())}
+        assert jid not in second  # already failed, nothing left to reap
+    finally:
+        _cleanup(jid)
+
+
+def test_update_job_renews_the_lease_while_running():
+    jid = str(uuid.uuid4())
+    with deps._jobs_lock:
+        deps._jobs[jid] = {"job_id": jid, "status": "pending", "submitted_at": PAST,
+                           "completed_at": None}
+    try:
+        deps._update_job(jid, status="running", progress_message="step 1")
+        status, lease = _row(jid)
+        assert status == "running"
+        assert lease is not None and lease > _now()  # pushed into the future
+    finally:
+        with deps._jobs_lock:
+            deps._jobs.pop(jid, None)
+        _cleanup(jid)
+
+
+def test_finishing_a_job_clears_its_lease():
+    """A finished job holds no claim — leaving a lease on it would assert
+    ongoing work that isn't happening."""
+    jid = str(uuid.uuid4())
+    with deps._jobs_lock:
+        deps._jobs[jid] = {"job_id": jid, "status": "running", "submitted_at": PAST,
+                           "completed_at": None}
+    try:
+        deps._update_job(jid, status="success", completed_at=_now())
+        assert _row(jid) == ("success", None)
+    finally:
+        with deps._jobs_lock:
+            deps._jobs.pop(jid, None)
+        _cleanup(jid)
+
+
+def test_lease_horizon_matches_config():
+    import config
+    lease = datetime.fromisoformat(deps.job_lease())
+    expected = datetime.now(timezone.utc) + timedelta(seconds=config.JOB_LEASE_SECONDS)
+    assert abs((lease - expected).total_seconds()) < 5

--- a/tests/test_openrouter_config.py
+++ b/tests/test_openrouter_config.py
@@ -10,7 +10,7 @@ def test_provider_defaults(monkeypatch):
     assert config.LLM_PROVIDER == "gemini"
     assert config.LLM_FALLBACK_PROVIDER == "openrouter"
     assert config.OPENROUTER_BASE_URL == "https://openrouter.ai/api/v1"
-    assert config.LLM_SELECTABLE_MODELS[0] == "gemini-3.6-flash"
+    assert config.LLM_SELECTABLE_MODELS[0] == "gemini-3.7-flash"
     assert config.MODELS_CACHE_TTL == 3600
 
 

--- a/tests/test_owner_scoping.py
+++ b/tests/test_owner_scoping.py
@@ -1,0 +1,200 @@
+"""Regression tests for the cross-user data exposure fixed in this batch.
+
+Before the fix, any valid API key could read every other user's data:
+  * GET /chat and GET /chat/{id} listed and returned all sessions;
+  * GET /watch took `user_id` as a query parameter, so omitting it returned
+    every user's watches and supplying someone else's returned theirs;
+  * feedback and report listings had no owner column at all.
+
+The rule these tests pin down: `owner` is the API-key fingerprint, it is never
+taken from client input, and a record belonging to another key is indistinguishable
+from one that does not exist (404, not 403 — a 403 confirms the id is real).
+"""
+
+import uuid
+
+import pytest
+
+import deps
+import persistence
+
+OWNER_A = "owner-a-fingerprint"
+OWNER_B = "owner-b-fingerprint"
+
+
+# --------------------------------------------------------------------------
+# Sessions
+# --------------------------------------------------------------------------
+def test_owns_session_matches_only_the_same_fingerprint():
+    sess = {"id": "s1", "owner": OWNER_A}
+    assert deps.owns_session(sess, OWNER_A)
+    assert not deps.owns_session(sess, OWNER_B)
+
+
+def test_owns_session_rejects_missing_session():
+    assert not deps.owns_session(None, OWNER_A)
+
+
+def test_legacy_ownerless_session_is_not_readable_by_a_user_key():
+    """Rows written before ownership existed must fail closed, not default open."""
+    legacy = {"id": "old", "messages": []}
+    assert not deps.owns_session(legacy, OWNER_A)
+
+
+def test_single_tenant_mode_sees_everything():
+    """Auth disabled => current_owner is None => no scoping to apply."""
+    assert deps.owns_session({"id": "s", "owner": None}, None)
+    assert deps.owns_session({"id": "s", "owner": OWNER_A}, None)
+
+
+def test_new_session_records_its_owner():
+    sid, _ = deps._get_or_create_session(None, OWNER_A)
+    try:
+        assert deps._sessions[sid]["owner"] == OWNER_A
+    finally:
+        deps._sessions.pop(sid, None)
+        persistence.delete_session(sid)
+
+
+def test_guessing_another_users_session_id_is_refused():
+    """The core of the bug: continuing a chat by id must not cross keys."""
+    sid, _ = deps._get_or_create_session(None, OWNER_A)
+    try:
+        with pytest.raises(PermissionError):
+            deps._get_or_create_session(sid, OWNER_B)
+    finally:
+        deps._sessions.pop(sid, None)
+        persistence.delete_session(sid)
+
+
+def test_owner_survives_eviction_resurrect_path():
+    """_append_session_messages re-creates an evicted session; if it dropped the
+    owner, the session would vanish from its owner's listing mid-conversation."""
+    sid = str(uuid.uuid4())
+    try:
+        deps._append_session_messages(sid, "q", "a", OWNER_A)
+        assert deps._sessions[sid]["owner"] == OWNER_A
+    finally:
+        deps._sessions.pop(sid, None)
+        persistence.delete_session(sid)
+
+
+# --------------------------------------------------------------------------
+# Watches
+# --------------------------------------------------------------------------
+def _make_watch(owner, user_id="label"):
+    w = {
+        "id": str(uuid.uuid4()), "user_id": user_id, "owner": owner,
+        "topic": "antennas", "language": "en", "cadence": "weekly",
+        "seen_ids": [], "latest_digest": None,
+        "next_run": None, "last_run": None, "created_at": "2026-01-01T00:00:00+00:00",
+    }
+    persistence.save_watch(w)
+    return w
+
+
+def test_list_watches_is_scoped_by_owner_not_by_user_id():
+    a = _make_watch(OWNER_A)
+    b = _make_watch(OWNER_B)
+    try:
+        ids = {w["id"] for w in persistence.list_watches(owner=OWNER_A)}
+        assert a["id"] in ids
+        assert b["id"] not in ids
+    finally:
+        persistence.delete_watch(a["id"])
+        persistence.delete_watch(b["id"])
+
+
+def test_supplying_another_users_user_id_label_reveals_nothing():
+    """user_id is a caller-chosen label; it must not act as an access key."""
+    victim = _make_watch(OWNER_B, user_id="victim-label")
+    try:
+        assert persistence.list_watches("victim-label", owner=OWNER_A) == []
+    finally:
+        persistence.delete_watch(victim["id"])
+
+
+def test_owns_watch_rules():
+    w = {"id": "w", "owner": OWNER_A}
+    assert persistence.owns_watch(w, OWNER_A)
+    assert not persistence.owns_watch(w, OWNER_B)
+    assert not persistence.owns_watch(None, OWNER_A)
+    assert persistence.owns_watch(w, None)                   # single-tenant
+    assert not persistence.owns_watch({"id": "w"}, OWNER_A)  # legacy, fails closed
+
+
+# --------------------------------------------------------------------------
+# Reports
+# --------------------------------------------------------------------------
+def test_report_of_another_owner_reads_as_missing():
+    rid = str(uuid.uuid4())
+    persistence.save_report(rid, "", "topic", "en", "# body", 3,
+                            "2026-01-01T00:00:00+00:00", owner=OWNER_A)
+    try:
+        assert persistence.get_report(rid, owner=OWNER_A) is not None
+        assert persistence.get_report(rid, owner=OWNER_B) is None   # 404, not 403
+        assert persistence.get_report(rid) is not None              # admin/single-tenant
+    finally:
+        persistence._conn.execute("DELETE FROM reports WHERE id = ?", (rid,))
+        persistence._conn.commit()
+
+
+def test_list_reports_filters_by_owner():
+    mine, theirs = str(uuid.uuid4()), str(uuid.uuid4())
+    persistence.save_report(mine, "", "mine", "en", "x", 1,
+                            "2026-01-01T00:00:00+00:00", owner=OWNER_A)
+    persistence.save_report(theirs, "", "theirs", "en", "y", 1,
+                            "2026-01-01T00:00:00+00:00", owner=OWNER_B)
+    try:
+        ids = {r["id"] for r in persistence.list_reports(owner=OWNER_A)}
+        assert mine in ids and theirs not in ids
+    finally:
+        persistence._conn.execute("DELETE FROM reports WHERE id IN (?, ?)", (mine, theirs))
+        persistence._conn.commit()
+
+
+# --------------------------------------------------------------------------
+# Feedback  (the join exposes the original question and answer text)
+# --------------------------------------------------------------------------
+def test_feedback_listing_is_scoped_to_its_submitter():
+    qid_a, qid_b = str(uuid.uuid4()), str(uuid.uuid4())
+    fid_a, fid_b = str(uuid.uuid4()), str(uuid.uuid4())
+    ts = "2026-01-01T00:00:00+00:00"
+    persistence.log_query(qid_a, "secret question A", "answer A", "standard_A",
+                          "m", "en", 0.9, 0.9, ts, owner=OWNER_A)
+    persistence.log_query(qid_b, "secret question B", "answer B", "standard_A",
+                          "m", "en", 0.9, 0.9, ts, owner=OWNER_B)
+    persistence.save_feedback(fid_a, qid_a, "up", "", ts, owner=OWNER_A)
+    persistence.save_feedback(fid_b, qid_b, "down", "", ts, owner=OWNER_B)
+    try:
+        rows = persistence.get_feedback_with_context(owner=OWNER_A)
+        questions = {r["question"] for r in rows}
+        assert "secret question A" in questions
+        assert "secret question B" not in questions
+    finally:
+        persistence._conn.execute("DELETE FROM feedback WHERE id IN (?, ?)", (fid_a, fid_b))
+        persistence._conn.execute("DELETE FROM query_log WHERE query_id IN (?, ?)", (qid_a, qid_b))
+        persistence._conn.commit()
+
+
+def test_feedback_stats_are_scoped_too():
+    qid, fid = str(uuid.uuid4()), str(uuid.uuid4())
+    ts = "2026-01-01T00:00:00+00:00"
+    persistence.save_feedback(fid, qid, "up", "", ts, owner=OWNER_A)
+    try:
+        assert persistence.feedback_stats(owner=OWNER_A)["total"] >= 1
+        assert persistence.feedback_stats(owner=OWNER_B)["total"] == 0
+    finally:
+        persistence._conn.execute("DELETE FROM feedback WHERE id = ?", (fid,))
+        persistence._conn.commit()
+
+
+# --------------------------------------------------------------------------
+# Migration
+# --------------------------------------------------------------------------
+def test_owner_columns_exist_and_ensure_column_is_idempotent():
+    for table in ("feedback", "reports", "query_log"):
+        cols = {r[1] for r in persistence._conn.execute(f"PRAGMA table_info({table})")}
+        assert "owner" in cols, f"{table} missing owner column"
+    # Running it again must not raise "duplicate column name".
+    persistence._ensure_column("feedback", "owner", "TEXT")

--- a/tests/test_providers_gemini.py
+++ b/tests/test_providers_gemini.py
@@ -163,3 +163,91 @@ def test_supports_thinking_gates_gemma():
     b = GeminiBackend()
     assert b.supports_thinking("gemini-3.5-flash")
     assert not b.supports_thinking("gemma-4-26b-a4b-it")
+
+
+# ---------------------------------------------------------------------------
+# Thinking LEVEL rejection (gemini-3.7-flash refuses MINIMAL)
+# ---------------------------------------------------------------------------
+def _level_config(name="MINIMAL"):
+    from google.genai import types
+    return types.GenerateContentConfig(
+        max_output_tokens=32,
+        thinking_config=types.ThinkingConfig(
+            thinking_level=getattr(types.ThinkingLevel, name)),
+    )
+
+
+class _RejectsLevel:
+    """Refuses one named level the way gemini-3.7-flash refuses MINIMAL."""
+
+    def __init__(self, bad="MINIMAL"):
+        self.bad = bad
+        self.levels_seen = []
+        self.models = self
+
+    def generate_content(self, model=None, contents=None, config=None):
+        from providers.gemini import GeminiBackend
+        lvl = GeminiBackend._current_level_name(config)
+        self.levels_seen.append(lvl)
+        if lvl == self.bad:
+            raise RuntimeError(
+                "400 INVALID_ARGUMENT. Thinking level MINIMAL is not supported "
+                "for this model. Please retry with other thinking level.")
+        return types_ns(text="ok")
+
+
+def types_ns(**kw):
+    return type("R", (), kw)()
+
+
+def _fresh_backend():
+    from providers.gemini import GeminiBackend
+    GeminiBackend._level_rejected.clear()
+    return GeminiBackend()
+
+
+def test_unsupported_thinking_level_escalates_and_succeeds():
+    b = _fresh_backend()
+    client = _RejectsLevel()
+    out = b.generate("gemini-3.7-flash", "q", _level_config(), client=client)
+    assert out.text == "ok"
+    # Retried one level UP, not down: a refused level means the model will not
+    # think that little, so less thinking cannot succeed.
+    assert client.levels_seen == ["MINIMAL", "LOW"]
+
+
+def test_the_rejection_is_remembered_so_only_one_call_pays_for_it():
+    from providers.gemini import GeminiBackend
+    b = _fresh_backend()
+    client = _RejectsLevel()
+    b.generate("gemini-3.7-flash", "q", _level_config(), client=client)
+    b.generate("gemini-3.7-flash", "q2", _level_config(), client=client)
+    # Second call skips MINIMAL entirely — three attempts total, not four.
+    assert client.levels_seen == ["MINIMAL", "LOW", "LOW"]
+    assert ("gemini-3.7-flash", "MINIMAL") in GeminiBackend._level_rejected
+
+
+def test_rejection_is_learned_per_model_not_globally():
+    """3.6-flash accepts MINIMAL; 3.7 refusing it must not change 3.6's behavior."""
+    b = _fresh_backend()
+    b.generate("gemini-3.7-flash", "q", _level_config(), client=_RejectsLevel())
+    ok = _RejectsLevel(bad="NOTHING")
+    b.generate("gemini-3.6-flash", "q", _level_config(), client=ok)
+    assert ok.levels_seen == ["MINIMAL"]
+
+
+def test_an_unrelated_400_still_propagates():
+    """Narrowness matters: only a thinking-level refusal may be retried, or a
+    genuinely bad request gets silently re-sent with different thinking."""
+    import pytest
+    b = _fresh_backend()
+
+    class _OtherError:
+        models = None
+
+        def generate_content(self, **kw):
+            raise RuntimeError("400 INVALID_ARGUMENT. Unsupported MIME type.")
+
+    c = _OtherError(); c.models = c
+    with pytest.raises(RuntimeError, match="MIME"):
+        b.generate("gemini-3.7-flash", "q", _level_config(), client=c)

--- a/tests/test_providers_gemini.py
+++ b/tests/test_providers_gemini.py
@@ -227,6 +227,31 @@ def test_the_rejection_is_remembered_so_only_one_call_pays_for_it():
     assert ("gemini-3.7-flash", "MINIMAL") in GeminiBackend._level_rejected
 
 
+def test_a_budget_rejection_followed_by_a_level_rejection_keeps_climbing():
+    """The two refusals chain: the budget translates to MINIMAL, and a model that
+    also refuses MINIMAL must advance up the ladder rather than fail the call."""
+    from google.genai import types
+    from providers.gemini import GeminiBackend
+
+    class _RejectsBoth(_RejectsLevel):
+        def generate_content(self, model=None, contents=None, config=None):
+            tc = getattr(config, "thinking_config", None)
+            if getattr(tc, "thinking_budget", None) is not None:
+                self.levels_seen.append("BUDGET")
+                raise RuntimeError("400 INVALID_ARGUMENT. Request contains an invalid argument.")
+            return super().generate_content(model=model, contents=contents, config=config)
+
+    GeminiBackend._level_rejected.clear()
+    b = GeminiBackend()
+    b._zero_budget_rejected = set()
+    client = _RejectsBoth()
+    cfg = types.GenerateContentConfig(
+        max_output_tokens=16, thinking_config=types.ThinkingConfig(thinking_budget=0))
+    out = b.generate("gemini-3.7-flash", "q", cfg, client=client)
+    assert out.text == "ok"
+    assert client.levels_seen == ["BUDGET", "MINIMAL", "LOW"]
+
+
 def test_rejection_is_learned_per_model_not_globally():
     """3.6-flash accepts MINIMAL; 3.7 refusing it must not change 3.6's behavior."""
     b = _fresh_backend()

--- a/tests/test_providers_gemini.py
+++ b/tests/test_providers_gemini.py
@@ -248,6 +248,7 @@ def test_an_unrelated_400_still_propagates():
         def generate_content(self, **kw):
             raise RuntimeError("400 INVALID_ARGUMENT. Unsupported MIME type.")
 
-    c = _OtherError(); c.models = c
+    c = _OtherError()
+    c.models = c
     with pytest.raises(RuntimeError, match="MIME"):
         b.generate("gemini-3.7-flash", "q", _level_config(), client=c)

--- a/tests/test_watch_run.py
+++ b/tests/test_watch_run.py
@@ -254,6 +254,9 @@ def test_run_due_watches_runs_each_due_and_survives_failures(monkeypatch):
     ran = []
     monkeypatch.setattr(watch_runner.persistence, "due_watches",
                         lambda now: [{"id": "a"}, {"id": "b"}, {"id": "c"}])
+    # Claiming is now part of the sweep; this caller wins every claim.
+    monkeypatch.setattr(watch_runner.persistence, "claim_watch",
+                        lambda wid, expected, lease: True)
 
     def _fake_run(wid):
         if wid == "b":
@@ -266,3 +269,66 @@ def test_run_due_watches_runs_each_due_and_survives_failures(monkeypatch):
 
     assert count == 3            # all due watches attempted
     assert ran == ["a", "c"]     # b failed but a and c still ran
+
+
+def test_run_due_watches_skips_watches_claimed_by_another_worker(monkeypatch):
+    """The schedule loop runs in-process, so every worker sees the same watch as
+    due. Only the one that wins the claim may run it — otherwise each replica
+    re-fetches arXiv, re-ingests, and pays for its own digest."""
+    ran = []
+    monkeypatch.setattr(watch_runner.persistence, "due_watches",
+                        lambda now: [{"id": "a"}, {"id": "b"}])
+    # 'a' was taken by another worker between our read and our claim.
+    monkeypatch.setattr(watch_runner.persistence, "claim_watch",
+                        lambda wid, expected, lease: wid != "a")
+    monkeypatch.setattr(watch_runner, "run_watch", lambda wid: ran.append(wid))
+
+    count = asyncio.run(watch_runner.run_due_watches())
+
+    assert ran == ["b"]
+    assert count == 1  # counts what was claimed and run, not what looked due
+
+
+def _seed_watch(persistence, wid, due_at):
+    persistence.save_watch({
+        "id": wid, "user_id": "u", "owner": None, "topic": "t", "language": "en",
+        "cadence": "weekly", "seen_ids": [], "latest_digest": None,
+        "next_run": due_at, "last_run": None, "created_at": due_at,
+    })
+
+
+def test_claim_watch_is_won_by_exactly_one_caller():
+    """The compare-and-set itself: two workers racing on one row, one winner."""
+    import uuid
+    import persistence
+
+    wid = str(uuid.uuid4())
+    due_at = "2026-01-01T00:00:00+00:00"
+    _seed_watch(persistence, wid, due_at)
+    try:
+        lease = "2026-01-01T01:00:00+00:00"
+        first = persistence.claim_watch(wid, due_at, lease)
+        second = persistence.claim_watch(wid, due_at, lease)
+        assert first is True
+        assert second is False   # next_run already moved; the loser matches no row
+    finally:
+        persistence.delete_watch(wid)
+
+
+def test_claim_parks_next_run_so_a_dead_claimer_cannot_wedge_the_watch():
+    import uuid
+    import persistence
+
+    wid = str(uuid.uuid4())
+    due_at = "2026-01-01T00:00:00+00:00"
+    lease = "2026-01-01T01:00:00+00:00"
+    _seed_watch(persistence, wid, due_at)
+    try:
+        assert persistence.claim_watch(wid, due_at, lease) is True
+        # Not due while the lease holds...
+        assert wid not in {w["id"] for w in persistence.due_watches(due_at)}
+        # ...but due again once it expires, so a crashed claimer costs one delayed
+        # run rather than a permanently stuck watch.
+        assert wid in {w["id"] for w in persistence.due_watches("2026-01-01T02:00:00+00:00")}
+    finally:
+        persistence.delete_watch(wid)

--- a/tests/test_watch_run.py
+++ b/tests/test_watch_run.py
@@ -332,3 +332,26 @@ def test_claim_parks_next_run_so_a_dead_claimer_cannot_wedge_the_watch():
         assert wid in {w["id"] for w in persistence.due_watches("2026-01-01T02:00:00+00:00")}
     finally:
         persistence.delete_watch(wid)
+
+
+def test_a_failed_run_can_be_reclaimed_after_the_lease_expires():
+    """The retry path: nothing rewrites next_run after a failed run, so the row
+    the poller reads must already carry the lease — otherwise the second claim
+    compares a stale next_run and the watch is wedged for good."""
+    import uuid
+    import persistence
+
+    wid = str(uuid.uuid4())
+    due_at = "2026-01-01T00:00:00+00:00"
+    lease = "2026-01-01T01:00:00+00:00"
+    _seed_watch(persistence, wid, due_at)
+    try:
+        assert persistence.claim_watch(wid, due_at, lease) is True
+        # run fails: next_run is never rewritten, the lease just expires
+        again = [w for w in persistence.due_watches("2026-01-01T02:00:00+00:00")
+                 if w["id"] == wid]
+        assert again and again[0]["next_run"] == lease
+        assert persistence.claim_watch(
+            wid, again[0]["next_run"], "2026-01-01T03:00:00+00:00") is True
+    finally:
+        persistence.delete_watch(wid)

--- a/vector_store.py
+++ b/vector_store.py
@@ -305,14 +305,30 @@ def add_documents(
         duplicates = {k: v for k, v in Counter(ids).items() if v > 1}
         logger.error(f"Duplicate IDs detected before upsert: {duplicates}")
     
-    # Add to collection (upsert replaces existing, inserts new)
-    _chroma_call(collection.upsert,
-        documents=texts,
-        embeddings=embeddings_list,
-        metadatas=metadatas,
-        ids=ids
-    )
-    
+    # Add to collection (upsert replaces existing, inserts new).
+    #
+    # Batched, with a write-sized timeout. _chroma_call defaults to 5s, which is
+    # right for a query and badly wrong for a bulk write: a whole corpus in one
+    # upsert (1359 chunks x 1024 dims) blew past it and raised — AFTER ~27
+    # minutes of embedding. The write itself had actually succeeded, because a
+    # timed-out call keeps running and merely stops being waited on, so the data
+    # landed while the caller saw a failure and skipped the ingest-log write.
+    #
+    # Batching bounds each individual wait, rather than scaling one timeout to
+    # the largest corpus anyone might ever ingest, and keeps peak memory flat.
+    batch = max(1, config.CHROMA_UPSERT_BATCH)
+    for start in range(0, len(ids), batch):
+        sl = slice(start, start + batch)
+        _chroma_call(collection.upsert,
+            documents=texts[sl],
+            embeddings=embeddings_list[sl],
+            metadatas=metadatas[sl],
+            ids=ids[sl],
+            timeout=config.CHROMA_WRITE_TIMEOUT_S,
+        )
+        if len(ids) > batch:
+            logger.info("  upserted %d/%d chunks", min(start + batch, len(ids)), len(ids))
+
     logger.info(f"Added {len(texts)} documents. Total in collection: {collection.count()}")
 
 

--- a/vector_store.py
+++ b/vector_store.py
@@ -51,8 +51,9 @@ def _chroma_record_failure() -> None:
         _circuit_failures += 1
         if _circuit_failures >= _CIRCUIT_TRIP_AFTER:
             _circuit_until = time.monotonic() + _CIRCUIT_COOLDOWN
+            failures, _circuit_failures = _circuit_failures, 0  # fresh streak after the cooldown
             logger.error("ChromaDB circuit OPEN for %.0fs after %d consecutive timeouts",
-                         _CIRCUIT_COOLDOWN, _circuit_failures)
+                         _CIRCUIT_COOLDOWN, failures)
             try:
                 import metrics
                 metrics.record_circuit_trip("chromadb")
@@ -294,7 +295,8 @@ def add_documents(
     # sizes — silently mixed incompatible vectors into one collection. Cosine
     # distance between two different embedding spaces is meaningless but never
     # errors, so retrieval quality just quietly degrades. See check_index_compatibility.
-    metadatas = [{**m, **_provenance_stamp()} for m in metadatas]
+    stamp = _provenance_stamp()
+    metadatas = [{**m, **stamp} for m in metadatas]
 
     # Convert embeddings to list of lists
     embeddings_list = embeddings.tolist()
@@ -322,10 +324,28 @@ def add_documents(
     # still searchable in ChromaDB — exactly the divergence the log exists to
     # prevent. So a failed write is rolled back, restoring all-or-nothing.
     batch = max(1, config.CHROMA_UPSERT_BATCH)
+    # Which of these ids the collection ALREADY holds. An upsert replaces those
+    # rows, so deleting them during a rollback would destroy content the ingest
+    # log still records — divergence in the more damaging direction, since
+    # retrieval silently loses chunks nothing flags as missing. Rollback removes
+    # only rows this call created.
+    try:
+        preexisting = set(_chroma_call(collection.get, ids=list(ids), include=[],
+                                       timeout=config.CHROMA_WRITE_TIMEOUT_S).get("ids", []))
+    except Exception:
+        preexisting = set()
+        logger.warning("Could not check which ids already exist; a rollback would "
+                       "delete overwritten rows too", exc_info=True)
+
     written: List[str] = []
+    attempted: List[str] = []
     try:
         for start in range(0, len(ids), batch):
             sl = slice(start, start + batch)
+            # Counted as attempted BEFORE the call: a timed-out _chroma_call is
+            # not cancelled, it just stops being waited on, so its batch can
+            # still land afterwards and must be rolled back as well.
+            attempted.extend(ids[sl])
             _chroma_call(collection.upsert,
                 documents=texts[sl],
                 embeddings=embeddings_list[sl],
@@ -337,12 +357,20 @@ def add_documents(
             if len(ids) > batch:
                 logger.info("  upserted %d/%d chunks", len(written), len(ids))
     except Exception:
-        if written:
-            logger.error("Upsert failed after %d/%d chunks; rolling back so the "
-                         "store cannot hold chunks the ingest log will not record",
-                         len(written), len(ids))
+        orphans = [i for i in attempted if i not in preexisting]
+        overwritten = [i for i in attempted if i in preexisting]
+        if overwritten:
+            logger.error("Upsert failed with %d chunks already overwritten in place. "
+                         "They are kept (deleting them would lose content the ingest "
+                         "log still records) but now hold text this run never logged. "
+                         "Re-ingest this paper. First ids: %s",
+                         len(overwritten), overwritten[:5])
+        if orphans:
+            logger.error("Upsert failed after %d/%d chunks; rolling back %d newly "
+                         "created chunks so the store cannot hold chunks the ingest "
+                         "log will not record", len(written), len(ids), len(orphans))
             try:
-                _chroma_call(collection.delete, ids=written,
+                _chroma_call(collection.delete, ids=orphans,
                              timeout=config.CHROMA_WRITE_TIMEOUT_S)
             except Exception:
                 # Rollback itself failed: say so loudly and name the ids, because
@@ -351,7 +379,7 @@ def add_documents(
                 logger.error("ROLLBACK FAILED — %d orphaned chunks remain in the "
                              "collection and are absent from the ingest log. Run "
                              "reindex.py --backfill-log, or re-ingest this paper. "
-                             "First ids: %s", len(written), written[:5], exc_info=True)
+                             "First ids: %s", len(orphans), orphans[:5], exc_info=True)
         raise
 
     logger.info(f"Added {len(texts)} documents. Total in collection: {collection.count()}")

--- a/vector_store.py
+++ b/vector_store.py
@@ -53,6 +53,11 @@ def _chroma_record_failure() -> None:
             _circuit_until = time.monotonic() + _CIRCUIT_COOLDOWN
             logger.error("ChromaDB circuit OPEN for %.0fs after %d consecutive timeouts",
                          _CIRCUIT_COOLDOWN, _circuit_failures)
+            try:
+                import metrics
+                metrics.record_circuit_trip("chromadb")
+            except Exception:
+                pass  # a metrics failure must never worsen an outage
 
 
 def _chroma_record_success() -> None:
@@ -161,6 +166,78 @@ def get_or_create_collection(
     return collection
 
 
+# Bump CHUNKER_VERSION whenever chunk boundaries change (section sizes, splitter
+# rules): the vectors stay valid but stop being comparable to older chunks of the
+# same document. SCHEMA_VERSION covers the metadata shape itself.
+CHUNKER_VERSION = 1
+SCHEMA_VERSION = 1
+
+
+def _provenance_stamp() -> Dict[str, Any]:
+    return {
+        "embed_model": config.EMBEDDING_MODEL_NAME,
+        "embed_dim": config.EMBEDDING_DIMENSION,
+        "chunker_version": CHUNKER_VERSION,
+        "schema_version": SCHEMA_VERSION,
+    }
+
+
+def index_fingerprint(collection: chromadb.Collection = None) -> Optional[Dict[str, Any]]:
+    """Provenance of the chunks already in the collection, or None if empty.
+
+    Samples one chunk: a mixed collection is the failure this is meant to catch,
+    and one disagreeing sample is enough to know something is wrong. Chunks
+    written before stamping existed report embed_model=None (unknown), which is
+    reported rather than assumed compatible.
+    """
+    if collection is None:
+        collection = get_or_create_collection()
+    try:
+        sample = _chroma_call(collection.peek, limit=1)
+    except Exception:
+        return None
+    metas = sample.get("metadatas") or []
+    if not metas:
+        return None
+    m = metas[0] or {}
+    return {
+        "embed_model": m.get("embed_model"),
+        "embed_dim": m.get("embed_dim"),
+        "chunker_version": m.get("chunker_version"),
+        "schema_version": m.get("schema_version"),
+    }
+
+
+def check_index_compatibility(collection: chromadb.Collection = None) -> Optional[str]:
+    """Return a human-readable problem description, or None when consistent.
+
+    Called at startup so a model or chunker change is loud instead of silent.
+    Unstamped legacy chunks are reported (they may predate any change) but are
+    not treated as a hard mismatch — there is nothing to compare them against.
+    """
+    fp = index_fingerprint(collection)
+    if fp is None:
+        return None  # empty collection: nothing to be incompatible with
+    if fp["embed_model"] is None:
+        return ("indexed chunks carry no embedding provenance (written before "
+                "version stamping); re-ingest to make future model changes detectable")
+    problems = []
+    if fp["embed_model"] != config.EMBEDDING_MODEL_NAME:
+        problems.append(f"embedding model {fp['embed_model']!r} indexed vs "
+                        f"{config.EMBEDDING_MODEL_NAME!r} configured")
+    if fp["embed_dim"] != config.EMBEDDING_DIMENSION:
+        problems.append(f"embedding dimension {fp['embed_dim']} indexed vs "
+                        f"{config.EMBEDDING_DIMENSION} configured")
+    if fp["chunker_version"] != CHUNKER_VERSION:
+        problems.append(f"chunker version {fp['chunker_version']} indexed vs "
+                        f"{CHUNKER_VERSION} configured")
+    if not problems:
+        return None
+    return ("; ".join(problems) +
+            " — queries will compare vectors from different embedding spaces, "
+            "which silently degrades retrieval. Re-ingest the corpus.")
+
+
 def add_documents(
     texts: List[str],
     embeddings: np.ndarray,
@@ -180,7 +257,14 @@ def add_documents(
     """
     if collection is None:
         collection = get_or_create_collection()
-    
+
+    # Stamp provenance on every chunk. Nothing recorded WHICH model produced a
+    # vector, so swapping the embedding model — or changing the per-section chunk
+    # sizes — silently mixed incompatible vectors into one collection. Cosine
+    # distance between two different embedding spaces is meaningless but never
+    # errors, so retrieval quality just quietly degrades. See check_index_compatibility.
+    metadatas = [{**m, **_provenance_stamp()} for m in metadatas]
+
     # Convert embeddings to list of lists
     embeddings_list = embeddings.tolist()
     

--- a/vector_store.py
+++ b/vector_store.py
@@ -173,10 +173,30 @@ CHUNKER_VERSION = 1
 SCHEMA_VERSION = 1
 
 
+def _embed_backend() -> str:
+    """Which weights produced the vectors: 'fp32', 'onnx-int8' or 'fp16'.
+
+    The model id alone is not enough. int8-quantized BGE-M3 and fp32 BGE-M3 share
+    a model name but do NOT produce interchangeable vectors, so a stamp recording
+    only `embed_model` would call a mixed collection consistent — exactly the
+    silent failure the stamp exists to prevent.
+
+    Read from the loader rather than sniffed off the model object: the loader
+    knows which branch it took, and inspecting sentence-transformers internals
+    would quietly start returning the wrong answer on a library upgrade.
+    """
+    try:
+        import embeddings
+        return embeddings.EMBED_BACKEND
+    except Exception:
+        return "unknown"
+
+
 def _provenance_stamp() -> Dict[str, Any]:
     return {
         "embed_model": config.EMBEDDING_MODEL_NAME,
         "embed_dim": config.EMBEDDING_DIMENSION,
+        "embed_backend": _embed_backend(),
         "chunker_version": CHUNKER_VERSION,
         "schema_version": SCHEMA_VERSION,
     }
@@ -203,6 +223,7 @@ def index_fingerprint(collection: chromadb.Collection = None) -> Optional[Dict[s
     return {
         "embed_model": m.get("embed_model"),
         "embed_dim": m.get("embed_dim"),
+        "embed_backend": m.get("embed_backend"),
         "chunker_version": m.get("chunker_version"),
         "schema_version": m.get("schema_version"),
     }
@@ -231,6 +252,16 @@ def check_index_compatibility(collection: chromadb.Collection = None) -> Optiona
     if fp["chunker_version"] != CHUNKER_VERSION:
         problems.append(f"chunker version {fp['chunker_version']} indexed vs "
                         f"{CHUNKER_VERSION} configured")
+    # Same model id, different weights. int8 and fp32 vectors are not comparable,
+    # and without this the model-name check above would call the pair consistent.
+    # Only meaningful once the model is loaded — 'unloaded' means we cannot tell
+    # yet, and guessing would produce a spurious warning at import time.
+    current_backend = _embed_backend()
+    if (fp["embed_backend"] and current_backend not in ("unloaded", "unknown")
+            and fp["embed_backend"] != current_backend):
+        problems.append(f"embedding backend {fp['embed_backend']!r} indexed vs "
+                        f"{current_backend!r} configured (same model, different "
+                        "weights — the vectors are not comparable)")
     if not problems:
         return None
     return ("; ".join(problems) +

--- a/vector_store.py
+++ b/vector_store.py
@@ -316,18 +316,43 @@ def add_documents(
     #
     # Batching bounds each individual wait, rather than scaling one timeout to
     # the largest corpus anyone might ever ingest, and keeps peak memory flat.
+    # Batching reintroduces a failure mode a single upsert did not have: an
+    # exception on batch 3 leaves batches 1-2 committed, the caller never reaches
+    # its ingest-log write, and a later replay silently omits chunks that are
+    # still searchable in ChromaDB — exactly the divergence the log exists to
+    # prevent. So a failed write is rolled back, restoring all-or-nothing.
     batch = max(1, config.CHROMA_UPSERT_BATCH)
-    for start in range(0, len(ids), batch):
-        sl = slice(start, start + batch)
-        _chroma_call(collection.upsert,
-            documents=texts[sl],
-            embeddings=embeddings_list[sl],
-            metadatas=metadatas[sl],
-            ids=ids[sl],
-            timeout=config.CHROMA_WRITE_TIMEOUT_S,
-        )
-        if len(ids) > batch:
-            logger.info("  upserted %d/%d chunks", min(start + batch, len(ids)), len(ids))
+    written: List[str] = []
+    try:
+        for start in range(0, len(ids), batch):
+            sl = slice(start, start + batch)
+            _chroma_call(collection.upsert,
+                documents=texts[sl],
+                embeddings=embeddings_list[sl],
+                metadatas=metadatas[sl],
+                ids=ids[sl],
+                timeout=config.CHROMA_WRITE_TIMEOUT_S,
+            )
+            written.extend(ids[sl])
+            if len(ids) > batch:
+                logger.info("  upserted %d/%d chunks", len(written), len(ids))
+    except Exception:
+        if written:
+            logger.error("Upsert failed after %d/%d chunks; rolling back so the "
+                         "store cannot hold chunks the ingest log will not record",
+                         len(written), len(ids))
+            try:
+                _chroma_call(collection.delete, ids=written,
+                             timeout=config.CHROMA_WRITE_TIMEOUT_S)
+            except Exception:
+                # Rollback itself failed: say so loudly and name the ids, because
+                # the store now genuinely diverges from the log and only a
+                # reindex can reconcile it.
+                logger.error("ROLLBACK FAILED — %d orphaned chunks remain in the "
+                             "collection and are absent from the ingest log. Run "
+                             "reindex.py --backfill-log, or re-ingest this paper. "
+                             "First ids: %s", len(written), written[:5], exc_info=True)
+        raise
 
     logger.info(f"Added {len(texts)} documents. Total in collection: {collection.count()}")
 

--- a/vector_store.py
+++ b/vector_store.py
@@ -415,6 +415,15 @@ def delete_by_paper_id(paper_id: str, collection: chromadb.Collection = None) ->
             # A stale lexical index is a quality bug, not a correctness one for the
             # delete itself — never fail the deletion over it.
             logger.warning("BM25 index not updated after deleting %s", paper_id, exc_info=True)
+        try:
+            # The ingest log is the system of record a reindex replays from. Leaving
+            # the row behind would make a rebuild resurrect the paper we just
+            # deleted — exactly the inconsistency a system of record must prevent.
+            import persistence
+            persistence.delete_ingest_events(paper_id)
+        except Exception:
+            logger.warning("Ingest log not updated after deleting %s — a reindex would "
+                           "resurrect it", paper_id, exc_info=True)
     return len(ids)
 
 

--- a/vector_store.py
+++ b/vector_store.py
@@ -8,6 +8,7 @@ from typing import List, Dict, Optional, Any
 import numpy as np
 import logging
 import threading
+import time
 import concurrent.futures
 import config
 
@@ -22,19 +23,64 @@ logger = logging.getLogger(__name__)
 _chroma_executor = concurrent.futures.ThreadPoolExecutor(max_workers=32, thread_name_prefix="chroma-timeout")
 
 
+# Circuit breaker, same shape as the per-(provider, model) one in llm_client.py.
+# Without it an unhealthy ChromaDB (disk full, corrupt segment, hung compaction)
+# makes every request pay the full timeout before failing, and each one parks a
+# worker in the pool above that cannot be cancelled — the pool drains in seconds
+# and the failure spreads to requests that would never have touched Chroma.
+_CIRCUIT_COOLDOWN = 60.0
+_CIRCUIT_TRIP_AFTER = 3  # consecutive timeouts before the circuit opens
+_circuit_until = 0.0
+_circuit_failures = 0
+_circuit_lock = threading.Lock()
+
+
+class ChromaUnavailable(RuntimeError):
+    """Raised instead of waiting on a ChromaDB already known to be timing out."""
+
+
+def chroma_circuit_open() -> bool:
+    """True while the breaker is open — callers can degrade without trying."""
+    with _circuit_lock:
+        return time.monotonic() < _circuit_until
+
+
+def _chroma_record_failure() -> None:
+    global _circuit_until, _circuit_failures
+    with _circuit_lock:
+        _circuit_failures += 1
+        if _circuit_failures >= _CIRCUIT_TRIP_AFTER:
+            _circuit_until = time.monotonic() + _CIRCUIT_COOLDOWN
+            logger.error("ChromaDB circuit OPEN for %.0fs after %d consecutive timeouts",
+                         _CIRCUIT_COOLDOWN, _circuit_failures)
+
+
+def _chroma_record_success() -> None:
+    global _circuit_failures
+    if _circuit_failures:
+        with _circuit_lock:
+            _circuit_failures = 0
+
+
 def _chroma_call(fn, *args, timeout: float = 5.0, **kwargs) -> Any:
     """Run a ChromaDB call with a timeout. Raises TimeoutError if it hangs.
 
     Note: cancel() cannot stop an already-running call; on timeout the worker
     thread keeps running until the underlying call returns. The large pool above
-    bounds the damage of that leak.
+    bounds the damage of that leak, and the breaker bounds how often we are
+    willing to create one.
     """
+    if chroma_circuit_open():
+        raise ChromaUnavailable("ChromaDB circuit is open; skipping call")
     fut = _chroma_executor.submit(fn, *args, **kwargs)
     try:
-        return fut.result(timeout=timeout)
+        result = fut.result(timeout=timeout)
     except concurrent.futures.TimeoutError as err:
         fut.cancel()
+        _chroma_record_failure()
         raise TimeoutError(f"ChromaDB operation timed out after {timeout}s") from err
+    _chroma_record_success()
+    return result
 
 
 # Global client cache
@@ -267,11 +313,24 @@ def get_paper_chunk_counts(collection: chromadb.Collection = None) -> Dict[str, 
 def delete_by_paper_id(paper_id: str, collection: chromadb.Collection = None) -> int:
     """
     Delete all chunks for a specific paper.
+
+    The BM25 index is updated here rather than in the route, because every
+    deletion path routes through this function — doing it per caller meant the
+    lexical index kept serving chunks of deleted papers until something happened
+    to trigger a full rebuild, so deleted papers went on being cited.
     """
     if collection is None:
         collection = get_or_create_collection()
     ids = _chroma_call(collection.get, where={'paper_id': paper_id}, include=[])['ids']
     _chroma_call(collection.delete, where={'paper_id': paper_id})
+    if ids:
+        try:
+            import bm25_search
+            bm25_search.remove_from_index(ids, getattr(collection, "name", None))
+        except Exception:
+            # A stale lexical index is a quality bug, not a correctness one for the
+            # delete itself — never fail the deletion over it.
+            logger.warning("BM25 index not updated after deleting %s", paper_id, exc_info=True)
     return len(ids)
 
 

--- a/watch_runner.py
+++ b/watch_runner.py
@@ -152,19 +152,35 @@ def run_watch(watch_id: str) -> dict:
 
 
 async def run_due_watches() -> int:
-    """Run every watch whose next_run has arrived. Returns how many were run.
+    """Run every watch whose next_run has arrived. Returns how many were claimed
+    and run — not how many looked due, since another worker may take some.
 
     run_watch blocks (network + ingest), so each runs in a worker thread to keep
     the event loop free. One watch failing does not abort the sweep.
+
+    Each watch is claimed first (compare-and-set on next_run). The schedule loop
+    runs inside the API process, so with more than one worker or replica every
+    watch would otherwise be picked up by all of them at once — duplicate arXiv
+    fetches, duplicate ingests, and duplicate LLM spend on the digest. Only the
+    claimer proceeds; the rest skip it.
     """
-    now = datetime.now(timezone.utc).isoformat()
+    now_dt = datetime.now(timezone.utc)
+    now = now_dt.isoformat()
+    lease_until = (now_dt + timedelta(seconds=config.WATCH_LEASE_SECONDS)).isoformat()
     due = persistence.due_watches(now)
+    ran = 0
     for w in due:
+        if not persistence.claim_watch(w["id"], w.get("next_run"), lease_until):
+            logger.debug("[Watch] %s claimed by another worker, skipping", w["id"])
+            continue
+        ran += 1
         try:
             await asyncio.to_thread(run_watch, w["id"])
         except Exception as e:
+            # next_run stays parked at the lease, so a failed run retries once the
+            # lease expires rather than being retried on every poll interval.
             logger.error(f"[Watch] scheduled run failed for {w['id']}: {e}")
-    return len(due)
+    return ran
 
 
 async def watch_loop() -> None:

--- a/watch_runner.py
+++ b/watch_runner.py
@@ -133,6 +133,7 @@ def run_watch(watch_id: str) -> dict:
                     markdown=new_report["markdown"],
                     citation_count=new_report["citation_count"],
                     created_at=datetime.now(timezone.utc).isoformat(),
+                    owner=w.get("owner"),
                 )
             except Exception as e:
                 logger.error(f"[Watch] living-review regeneration failed for {watch_id}: {e}")


### PR DESCRIPTION
Closes the findings from `docs/ARCHITECTURE_REVIEW_v2.4.md`, which is included here so the reasoning is reviewable alongside the code.

25 commits, 45 files, +5203/-432. **380 unit tests + 13 integration tests green.** Every number below was measured, not estimated.

---

## Security

**Cross-user data exposure (the reason this branch exists).** Any valid API key could read every other user's data. `GET /chat` and `GET /chat/{id}` listed and returned all conversations and `DELETE` removed any of them; `GET /watch` took `user_id` as a *query parameter*, so omitting it returned every user's watches and supplying someone else's returned theirs; feedback and report listings had no owner column at all — and the feedback join exposes the original question and answer text.

Ownership is now the API-key fingerprint, never client input. A record owned by another key reads as `404`, not `403` — a 403 confirms the id exists. Rows written before scoping carry no owner and stay invisible to ordinary keys rather than defaulting open.

**SSRF via DNS rebinding.** The private-IP guard and `urlopen`'s own lookup were two separate DNS queries, so a rebinding resolver could answer public for the check and `169.254.169.254` for the fetch. Resolution now happens once and the connection is pinned to that address. TLS still validates against the hostname, not the pinned IP — verified, because a "pinning" change that quietly becomes an unverified-TLS change is the obvious way to get this wrong.

**Unbounded LLM spend.** `POST /report` and `POST /watch/{id}/run` each start a full LLM workload with no rate limit.

## Correctness

- **Lost updates on concurrent turns** — two requests on one session both read history at length N and both appended, so each answer was blind to the other. A per-session lock now spans read → generate → append.
- **Abandoned jobs** — a crash left the row saying `running` forever while clients polled a job that existed in no process. Jobs now heartbeat a lease and startup reaps the expired ones. Reaping on lease expiry rather than "not started by me" is what keeps it safe with multiple workers.
- **Duplicate watch runs** — the scheduler runs in-process, so every replica ran every due watch. A compare-and-set claim means one winner, no new infrastructure.
- **Bulk ingest reported failure after succeeding** — a 1359-chunk upsert blew past the 5s timeout meant for *queries* and raised, after 27 minutes of embedding. The write had already landed; the caller had simply stopped waiting. Upserts are now batched with a write-sized timeout.
- **History lost its sources** — citations were never stored with the turn, so reopening a conversation left the evidence panel blank.

## Performance (measured)

| | before | after |
|---|---|---|
| BM25 search, 20k chunks | 25.90 ms | **2.87 ms** |
| BM25 after ingest | full rebuild, 2.93 s | **3.8 ms** incremental |
| BM25 cold start | 14.32 s | **1.75 s** from disk |
| Agent: first feedback | one line, then 85s silence | **33.9 s**, then steps |
| Agent: sources visible | 152 s | **77.2 s** |

## Observability and evolvability

- Per-stage Prometheus metrics — retrieval, rerank, NLI, cache hits, tokens, breaker trips, failover hops. Route latency answers "is /query slow"; these answer "why".
- Every chunk records the embedding model, dimension, backend and chunker version. Cosine distance between two embedding spaces is meaningless but never raises, so a model swap previously showed up only as quality quietly degrading.
- An ingest log makes the indexes derived views; `reindex.py` replays it without re-parsing PDFs. `--check` is explicit that replay implements an *embedding* change and **not** a chunker change.
- Circuit breaker on ChromaDB plus a sparse-only degraded mode, surfaced to the client as a `degraded` field so a reduced answer is never presented as a normal one.

## Testing

Every prior test mocked the LLM, vector store and embeddings, so the seams *between* stages were never exercised — and all three v2.4 patch bugs lived in exactly those seams. The new integration suite runs a real ChromaDB through ingest, retrieval, citation compaction, caching and delete consistency. Models are stubbed at their true external boundary; everything on our side of it is real.

---

## Breaking change

`POST /watch` no longer treats `user_id` as an identity. It is a display label; authorization comes from the API key. Clients that read another user's watches by passing their `user_id` now receive `[]` — that is the fix, not a regression.

## Known limits (deliberate)

- **Existing corpora and conversations are not retrofitted.** Chunks indexed before provenance stamping report "no provenance"; conversations saved before this branch reopen with an empty source panel. Neither can be recovered from data that was never written. `reindex.py --backfill-log` recovers the ingest log from chunks already in the collection.
- **The CI eval gate still cannot fail.** `evaluate.py` scores a committed snapshot. `run_live.py` (added here) wires it to the live pipeline, but turning the gate on is blocked on a data mismatch: `relevance_judgments.json` names papers by alias (`tandem_nn`) while ingest assigns filename-derived ids, and the judged papers are not in the current corpus. A preflight reports that by name instead of letting it surface as a uniform 0.000.
- **int8 embeddings ship off.** They work and measured 3.1× on a real ingest, but every vector moves (cosine ~0.987 vs fp32) and there is no working eval gate to confirm retrieval held. Enabling it should follow a measurement, not precede one.
- **Still open:** externalising state (Redis/Qdrant) is deferred until the new metrics say where the ceiling actually is; the durable job queue is half-done (restart safety, not a separate worker process); inline `[N]` citation markers still render as plain text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgraded the default Gemini model and added another selectable model.
  * Added faster hybrid search with persistent incremental indexing and sparse-only fallback when dense retrieval is unavailable.
  * Added live agent progress, source previews, citation restoration, and retrieval-degradation indicators.
  * Added reindexing and evaluation tools.
* **Bug Fixes**
  * Strengthened data isolation, session access, download security, and concurrent processing safeguards.
  * Improved recovery for stalled jobs and scheduled watches.
* **Documentation**
  * Updated v2.5 documentation, configuration guidance, API references, and architecture review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->